### PR TITLE
fix: refine TMDB detail playback modes

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -1223,7 +1223,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
     }
 
     private void onEpisodeLongClick(Episode item) {
-        com.fongmi.android.tv.ui.dialog.EpisodeDetailDialog.show(this, item);
+        com.fongmi.android.tv.ui.dialog.EpisodeDetailDialog.show(this, item, getSite());
     }
 
     private void selectEpisode(Episode item, boolean scrollToEpisode) {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
@@ -12,11 +12,14 @@ import androidx.fragment.app.FragmentActivity;
 import com.bumptech.glide.Glide;
 import com.fongmi.android.tv.R;
 import com.fongmi.android.tv.bean.Episode;
+import com.fongmi.android.tv.bean.Site;
 import com.fongmi.android.tv.bean.TmdbConfig;
 import com.fongmi.android.tv.bean.TmdbEpisode;
+import com.fongmi.android.tv.bean.TmdbPerson;
 import com.fongmi.android.tv.service.TmdbService;
 import com.fongmi.android.tv.setting.Setting;
 import com.fongmi.android.tv.ui.adapter.EpisodePhotoAdapter;
+import com.fongmi.android.tv.ui.adapter.TmdbPersonAdapter;
 import com.fongmi.android.tv.utils.ResUtil;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.gson.JsonObject;
@@ -29,6 +32,10 @@ import java.util.List;
 public class EpisodeDetailDialog {
 
     public static void show(FragmentActivity activity, Episode episode) {
+        show(activity, episode, null);
+    }
+
+    public static void show(FragmentActivity activity, Episode episode, Site site) {
         TmdbEpisode tmdbEpisode = episode.getTmdbEpisode();
         if (tmdbEpisode == null) {
             // 没有TMDB数据，显示简单信息
@@ -46,6 +53,8 @@ public class EpisodeDetailDialog {
         TextView overview = view.findViewById(R.id.overview);
         TextView photosLabel = view.findViewById(R.id.photosLabel);
         androidx.leanback.widget.HorizontalGridView photosGrid = view.findViewById(R.id.photosGrid);
+        TextView guestsLabel = view.findViewById(R.id.guestsLabel);
+        androidx.leanback.widget.HorizontalGridView guestsGrid = view.findViewById(R.id.guestsGrid);
 
         // 加载剧照 - 使用原图
         if (!tmdbEpisode.getStillUrl().isEmpty()) {
@@ -98,9 +107,11 @@ public class EpisodeDetailDialog {
         // 初始隐藏本集图片，异步加载
         photosLabel.setVisibility(View.GONE);
         photosGrid.setVisibility(View.GONE);
+        guestsLabel.setVisibility(View.GONE);
+        guestsGrid.setVisibility(View.GONE);
 
-        // 异步加载本集图片
-        loadEpisodePhotos(activity, tmdbEpisode, photosLabel, photosGrid);
+        // 异步加载本集图片与客串演员
+        loadEpisodeMedia(activity, tmdbEpisode, site, photosLabel, photosGrid, guestsLabel, guestsGrid);
 
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(activity)
                 .setView(view);
@@ -127,8 +138,9 @@ public class EpisodeDetailDialog {
                 .show();
     }
 
-    private static void loadEpisodePhotos(FragmentActivity activity, TmdbEpisode tmdbEpisode,
-                                         TextView photosLabel, androidx.leanback.widget.HorizontalGridView photosGrid) {
+    private static void loadEpisodeMedia(FragmentActivity activity, TmdbEpisode tmdbEpisode, Site site,
+                                         TextView photosLabel, androidx.leanback.widget.HorizontalGridView photosGrid,
+                                         TextView guestsLabel, androidx.leanback.widget.HorizontalGridView guestsGrid) {
         // 只有有tmdbId才能加载图片
         if (tmdbEpisode.getTmdbId() == 0) {
             android.util.Log.d("EpisodeDetail", "跳过图片加载: tmdbId为0");
@@ -156,19 +168,34 @@ public class EpisodeDetailDialog {
                 android.util.Log.d("EpisodeDetail", "TMDB API返回成功");
 
                 List<String> photos = service.episodePhotos(episodeJson, config);
+                List<TmdbPerson> guests = service.episodeGuests(episodeJson, config);
 
                 android.util.Log.d("EpisodeDetail", "图片数量: " + (photos != null ? photos.size() : 0));
+                android.util.Log.d("EpisodeDetail", "客串演员数量: " + (guests != null ? guests.size() : 0));
 
-                if (photos != null && !photos.isEmpty()) {
+                if ((photos != null && !photos.isEmpty()) || (guests != null && !guests.isEmpty())) {
                     activity.runOnUiThread(() -> {
-                        photosLabel.setVisibility(View.VISIBLE);
-                        photosGrid.setVisibility(View.VISIBLE);
-                        photosGrid.setHorizontalSpacing(ResUtil.dp2px(12));
-                        photosGrid.setRowHeight(ResUtil.dp2px(124));
+                        if (photos != null && !photos.isEmpty()) {
+                            photosLabel.setVisibility(View.VISIBLE);
+                            photosGrid.setVisibility(View.VISIBLE);
+                            photosGrid.setHorizontalSpacing(ResUtil.dp2px(12));
+                            photosGrid.setRowHeight(ResUtil.dp2px(124));
 
-                        EpisodePhotoAdapter photoAdapter = new EpisodePhotoAdapter(photos,
-                                (url, position) -> PhotoViewerDialog.show(activity, photos, position, null));
-                        photosGrid.setAdapter(photoAdapter);
+                            EpisodePhotoAdapter photoAdapter = new EpisodePhotoAdapter(photos,
+                                    (url, position) -> PhotoViewerDialog.show(activity, photos, position, null));
+                            photosGrid.setAdapter(photoAdapter);
+                        }
+
+                        if (guests != null && !guests.isEmpty()) {
+                            guestsLabel.setVisibility(View.VISIBLE);
+                            guestsGrid.setVisibility(View.VISIBLE);
+                            guestsGrid.setHorizontalSpacing(ResUtil.dp2px(12));
+                            guestsGrid.setRowHeight(ResUtil.dp2px(154));
+
+                            TmdbPersonAdapter guestAdapter = new TmdbPersonAdapter(person -> TmdbPersonDialog.show(activity, person, site));
+                            guestAdapter.setItems(guests);
+                            guestsGrid.setAdapter(guestAdapter);
+                        }
 
                         android.util.Log.d("EpisodeDetail", "图片显示成功");
                     });

--- a/app/src/leanback/res/layout/dialog_episode_detail.xml
+++ b/app/src/leanback/res/layout/dialog_episode_detail.xml
@@ -129,6 +129,26 @@
                 android:clipToPadding="false"
                 android:visibility="gone" />
 
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/guestsLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/detail_episode_guests"
+                android:textColor="@color/white"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:visibility="gone" />
+
+            <androidx.leanback.widget.HorizontalGridView
+                android:id="@+id/guestsGrid"
+                android:layout_width="match_parent"
+                android:layout_height="154dp"
+                android:layout_marginTop="12dp"
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                android:visibility="gone" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/app/src/main/java/com/fongmi/android/tv/service/TmdbService.java
+++ b/app/src/main/java/com/fongmi/android/tv/service/TmdbService.java
@@ -9,6 +9,7 @@ import com.fongmi.android.tv.bean.TmdbConfig;
 import com.fongmi.android.tv.bean.TmdbEpisode;
 import com.fongmi.android.tv.bean.TmdbItem;
 import com.fongmi.android.tv.bean.TmdbPerson;
+import com.fongmi.android.tv.utils.TmdbImageSelector;
 import com.github.catvod.crawler.SpiderDebug;
 import com.github.catvod.utils.Path;
 import com.google.gson.JsonArray;
@@ -298,15 +299,11 @@ public class TmdbService {
     }
 
     public List<String> photos(JsonObject detail, @NonNull TmdbConfig config) {
-        List<String> items = new ArrayList<>();
-        for (JsonElement element : array(detail, "images", "backdrops")) {
-            if (!element.isJsonObject()) continue;
-            String url = image(config.getBackdropBase(), string(element.getAsJsonObject(), "file_path"));
-            if (TextUtils.isEmpty(url) || items.contains(url)) continue;
-            items.add(url);
-            if (items.size() >= 24) break;
-        }
-        return items;
+        return photos(detail, config, true);
+    }
+
+    public List<String> photos(JsonObject detail, @NonNull TmdbConfig config, boolean preferLandscape) {
+        return TmdbImageSelector.backgrounds(detail, config.getImageBase(), config.getBackdropBase(), preferLandscape, 24);
     }
 
     public List<String> seasonPhotos(JsonObject season, @NonNull TmdbConfig config) {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -67,8 +67,10 @@ import com.fongmi.android.tv.databinding.ActivityTmdbDetailBinding;
 import com.fongmi.android.tv.databinding.DialogTmdbEpisodeBinding;
 import com.fongmi.android.tv.db.AppDatabase;
 import com.fongmi.android.tv.event.RefreshEvent;
+import com.fongmi.android.tv.player.IntroSkipPlayback;
 import com.fongmi.android.tv.player.PlayerHelper;
 import com.fongmi.android.tv.service.PersonalRecommendationService;
+import com.fongmi.android.tv.service.IntroSkipService;
 import com.fongmi.android.tv.service.PlaybackService;
 import com.fongmi.android.tv.service.TmdbService;
 import com.fongmi.android.tv.setting.DanmakuSetting;
@@ -90,6 +92,7 @@ import com.fongmi.android.tv.ui.dialog.SubtitleDialog;
 import com.fongmi.android.tv.ui.dialog.TitleDialog;
 import com.fongmi.android.tv.ui.dialog.TmdbSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TrackDialog;
+import com.fongmi.android.tv.ui.helper.DetailThemeVisibility;
 import com.fongmi.android.tv.ui.helper.TmdbRecommendationRows;
 import com.fongmi.android.tv.utils.BatteryUtil;
 import com.fongmi.android.tv.utils.Formatters;
@@ -101,6 +104,7 @@ import com.fongmi.android.tv.utils.PiP;
 import com.fongmi.android.tv.utils.ResUtil;
 import com.fongmi.android.tv.utils.Task;
 import com.fongmi.android.tv.utils.TmdbEpisodeSorter;
+import com.fongmi.android.tv.utils.TmdbImageSelector;
 import com.fongmi.android.tv.utils.TmdbImageSaver;
 import com.fongmi.android.tv.utils.Traffic;
 import com.fongmi.android.tv.utils.Util;
@@ -120,6 +124,7 @@ import com.github.catvod.crawler.SpiderDebug;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -161,6 +166,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private static final Pattern SOURCE_SEASON = Pattern.compile("(?i)(?:第\\s*([零〇一二三四五六七八九十两0-9]+)\\s*[季部]|season\\s*([0-9]{1,2})|s([0-9]{1,2})(?:[-._\\s]*e[0-9]{1,3})?)");
 
     private final TmdbService tmdbService = new TmdbService();
+    private final IntroSkipPlayback introSkipPlayback = new IntroSkipPlayback();
     private final List<TmdbPerson> detailCastItems = new ArrayList<>();
     private final List<TmdbPerson> castItems = new ArrayList<>();
     private final List<TmdbPerson> creatorItems = new ArrayList<>();
@@ -256,6 +262,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private int backdropSlideGeneration;
     private int backdropSlideIndex;
     private boolean episodeGridMode;
+    private boolean inlineEpisodeGridMode = true;
     private boolean episodeReverse;
     private boolean scrollEpisodeStartOnce;
     private boolean tmdbMediaLoading;
@@ -476,9 +483,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.keepTop.setVisibility(View.GONE);
         binding.rematchTop.setVisibility(View.GONE);
         binding.headerBar.setVisibility(Util.isMobile() ? View.VISIBLE : View.GONE);
-        binding.themeModeTop.setVisibility(Util.isMobile() ? View.VISIBLE : View.GONE);
-        binding.themeMode.setVisibility(Util.isMobile() ? View.GONE : View.VISIBLE);
-        binding.themeModeDetail.setVisibility(Util.isMobile() ? View.GONE : View.VISIBLE);
+        updateDetailThemeButtonVisibility();
         binding.fusionActions.setVisibility(isFusionMode() ? View.VISIBLE : View.GONE);
         binding.detailActions.setVisibility(isFusionMode() ? View.GONE : View.VISIBLE);
         applyDetailTemplate();
@@ -765,6 +770,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     private boolean onInlineTouch(View view, MotionEvent event) {
+        if (!inlineStarted || !isInlinePlayerMode() || service() == null || player() == null || player().isEmpty()) return false;
         if (inlineGestureDetector != null) inlineGestureDetector.onTouchEvent(event);
         return true;
     }
@@ -937,8 +943,11 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         lightTheme = resolveLightTheme();
         ThemeColors colors = lightTheme ? ThemeColors.light() : ThemeColors.dark();
         if (isCinemaMode()) colors = ThemeColors.cinema();
-        binding.root.setBackgroundColor(colors.background);
-        binding.hero.setBackgroundColor(colors.background);
+        int backdropBackground = backdropFallbackBackground(colors);
+        binding.root.setBackgroundColor(backdropBackground);
+        binding.hero.setBackgroundColor(backdropBackground);
+        binding.backdropFill.setBackgroundColor(backdropBackground);
+        binding.backdrop.setBackgroundColor(backdropBackground);
         binding.backdropFill.setAlpha(backdropSlideAlpha());
         binding.backdrop.setAlpha(backdropSlideAlpha());
         binding.backdropShade.setBackground(isCinemaMode() ? cinemaBackdropShade() : colorDrawable(colors.backdropShade));
@@ -972,6 +981,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.themeModeTop.setText(themeModeLabel());
         binding.themeMode.setText(themeModeLabel());
         binding.themeModeDetail.setText(themeModeLabel());
+        updateDetailThemeButtonVisibility();
         tintInlineGestureOverlay();
         if (isInlinePlayerMode()) {
             binding.playerError.setTextColor(0xFFFFFFFF);
@@ -984,6 +994,17 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             episodeAdapter.setActiveStrokeColor(colors.accent);
         }
         if (episodePhotoAdapter != null) episodePhotoAdapter.setLight(lightTheme);
+    }
+
+    private void updateDetailThemeButtonVisibility() {
+        if (binding == null) return;
+        boolean mobile = Util.isMobile();
+        boolean pictureInPicture = isInPictureInPictureMode();
+        boolean showMobileButton = DetailThemeVisibility.showMobileThemeButton(mobile, inlineFullscreen, inlinePiPLayout, pictureInPicture);
+        boolean showLargeScreenButton = DetailThemeVisibility.showLargeScreenThemeButton(mobile, inlineFullscreen, inlinePiPLayout, pictureInPicture);
+        binding.themeModeTop.setVisibility(showMobileButton ? View.VISIBLE : View.GONE);
+        binding.themeMode.setVisibility(showLargeScreenButton ? View.VISIBLE : View.GONE);
+        binding.themeModeDetail.setVisibility(showLargeScreenButton ? View.VISIBLE : View.GONE);
     }
 
     private void applyTemplateCardChrome(ThemeColors colors) {
@@ -1228,6 +1249,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void setButton(MaterialButton button, int background, int stroke, int text) {
         button.setBackgroundTintList(ColorStateList.valueOf(background));
         button.setTextColor(text);
+        button.setIconTint(ColorStateList.valueOf(text));
         button.setOnFocusChangeListener(null);
         applyButtonFocus(button, stroke, button.hasFocus());
         button.setOnFocusChangeListener((view, focused) -> applyButtonFocus(button, stroke, focused));
@@ -1456,7 +1478,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             } catch (Throwable ignored) {
             }
             try {
-                photos = tmdbService.photos(bundle.detail(), tmdbConfig);
+                photos = tmdbService.photos(bundle.detail(), tmdbConfig, preferLandscapeBackground());
             } catch (Throwable ignored) {
             }
             try {
@@ -1693,11 +1715,20 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         bindBackdrop();
         bindHeader();
         bindMeta();
+        bindRatings();
         bindOverview();
         bindSource();
         bindFlags();
         bindTmdbSection();
         updateKeepState();
+        requestDetailPlayFocus();
+    }
+
+    private void requestDetailPlayFocus() {
+        if (Util.isMobile() || isInlinePlayerMode() || binding.play.getVisibility() != View.VISIBLE) return;
+        binding.play.post(() -> {
+            if (!isFinishing() && binding != null && binding.play.getVisibility() == View.VISIBLE && !isInlinePlayerMode()) binding.play.requestFocus();
+        });
     }
 
     private void bindInitialArtwork() {
@@ -1732,9 +1763,20 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         backdropSlideVisibleView = binding.backdropFill;
         binding.backdropFill.setVisibility(View.VISIBLE);
         binding.backdropFill.setAlpha(backdropSlideAlpha());
+        binding.backdropFill.setScaleType(backdropScaleType());
         binding.backdrop.setVisibility(View.INVISIBLE);
         ImgUtil.clear(binding.backdrop);
-        ImgUtil.load(title, image, binding.backdropFill);
+        loadBackdropImage(title, image, binding.backdropFill);
+    }
+
+    private void loadBackdropImage(String title, String image, ImageView target) {
+        try {
+            com.bumptech.glide.RequestBuilder<Drawable> request = Glide.with(target).load(ImgUtil.getUrl(image));
+            request = shouldCropBackdrop() ? request.centerCrop() : request.fitCenter();
+            request.into(target);
+        } catch (Throwable e) {
+            ImgUtil.load(title, image, target);
+        }
     }
 
     private void bindBackdropSlideSource(String title, String image) {
@@ -1796,10 +1838,9 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         backdropSlideLoading = true;
         backdropSlideLoadingView = targetView;
         try {
-            Glide.with(this)
-                    .load(model)
-                    .centerCrop()
-                    .listener(new RequestListener<Drawable>() {
+            com.bumptech.glide.RequestBuilder<Drawable> request = Glide.with(this).load(model);
+            request = shouldCropBackdrop() ? request.centerCrop() : request.fitCenter();
+            request.listener(new RequestListener<Drawable>() {
                         @Override
                         public boolean onLoadFailed(@Nullable GlideException e, Object model, @NonNull Target<Drawable> target, boolean isFirstResource) {
                             targetView.post(() -> onBackdropSlideFailed(generation, next, url));
@@ -1821,8 +1862,12 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void prepareBackdropSlideTarget(ImageView targetView) {
         targetView.setVisibility(View.INVISIBLE);
         targetView.setAlpha(backdropSlideAlpha());
-        targetView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+        targetView.setScaleType(backdropScaleType());
         ImgUtil.clear(targetView);
+    }
+
+    private ImageView.ScaleType backdropScaleType() {
+        return shouldCropBackdrop() ? ImageView.ScaleType.CENTER_CROP : ImageView.ScaleType.FIT_CENTER;
     }
 
     private void onBackdropSlideReady(int generation, int index, String url, ImageView targetView) {
@@ -1896,11 +1941,27 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     private String tmdbBackdropUrl() {
+        if (matchedTmdbDetail != null) {
+            List<String> backgrounds = TmdbImageSelector.backgrounds(matchedTmdbDetail, tmdbConfig.getImageBase(), tmdbConfig.getBackdropBase(), preferLandscapeBackground(), 1);
+            if (!backgrounds.isEmpty()) return backgrounds.get(0);
+        }
         String backdrop = matchedTmdbItem != null ? matchedTmdbItem.getBackdropUrl() : "";
         if (TextUtils.isEmpty(backdrop) && matchedTmdbDetail != null) {
             backdrop = tmdbService.image(tmdbConfig.getBackdropBase(), string(matchedTmdbDetail, "backdrop_path"));
         }
-        return backdrop;
+        return TmdbImageSelector.originalUrl(backdrop);
+    }
+
+    private boolean preferLandscapeBackground() {
+        return !Util.isMobile() || ResUtil.isPad() || ResUtil.getScreenWidth(this) >= ResUtil.getScreenHeight(this);
+    }
+
+    private boolean shouldCropBackdrop() {
+        return true;
+    }
+
+    private int backdropFallbackBackground(ThemeColors colors) {
+        return isPlayerMode() ? 0xFF0F141A : colors.background;
     }
 
     private String episodeFallbackStillUrl() {
@@ -1930,6 +1991,135 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         String rating = ratingLabel();
         if (!TextUtils.isEmpty(rating)) addMetaChip(rating);
         addMetaChip(externalIdLabel());
+    }
+
+    private void bindRatings() {
+        String key = ratingDisplayKey();
+        binding.ratingsContainer.setTag(key);
+        binding.ratingsContainer.removeAllViews();
+        binding.ratingsContainer.setVisibility(View.GONE);
+        String tmdb = tmdbRatingValue();
+        if (!TextUtils.isEmpty(tmdb)) addRatingChip(key, "TMDB", tmdb + "/10", 0xFF21D07A);
+        fetchDoubanRating(key);
+        fetchOmdbRating(key);
+    }
+
+    private void addRatingChip(String key, String platform, String value, int color) {
+        if (TextUtils.isEmpty(platform) || TextUtils.isEmpty(value)) return;
+        if (!(binding.ratingsContainer.getTag() instanceof String) || !key.equals(binding.ratingsContainer.getTag())) return;
+        TextView existing = findRatingChip(platform);
+        if (existing != null) {
+            existing.setText(platform + "  " + value);
+            existing.setTextColor(color);
+            return;
+        }
+        TextView chip = new TextView(this);
+        chip.setTag(platform);
+        chip.setText(platform + "  " + value);
+        chip.setTextColor(color);
+        chip.setTextSize(12f);
+        chip.setTypeface(null, android.graphics.Typeface.BOLD);
+        chip.setIncludeFontPadding(false);
+        chip.setSingleLine(true);
+        chip.setGravity(Gravity.CENTER);
+        chip.setPadding(ResUtil.dp2px(10), ResUtil.dp2px(7), ResUtil.dp2px(10), ResUtil.dp2px(7));
+        ThemeColors colors = lightTheme ? ThemeColors.light() : ThemeColors.dark();
+        GradientDrawable background = new GradientDrawable();
+        background.setColor(isCinemaMode() ? 0x40000000 : colors.chip);
+        background.setCornerRadius(ResUtil.dp2px(8));
+        background.setStroke(ResUtil.dp2px(1), colors.line);
+        chip.setBackground(background);
+        FlexboxLayout.LayoutParams params = new FlexboxLayout.LayoutParams(FlexboxLayout.LayoutParams.WRAP_CONTENT, FlexboxLayout.LayoutParams.WRAP_CONTENT);
+        params.setMargins(0, 0, ResUtil.dp2px(8), ResUtil.dp2px(8));
+        chip.setLayoutParams(params);
+        binding.ratingsContainer.addView(chip);
+        binding.ratingsContainer.setVisibility(View.VISIBLE);
+    }
+
+    private TextView findRatingChip(String platform) {
+        for (int i = 0; i < binding.ratingsContainer.getChildCount(); i++) {
+            View child = binding.ratingsContainer.getChildAt(i);
+            if (child instanceof TextView text && platform.equals(child.getTag())) return text;
+        }
+        return null;
+    }
+
+    private void fetchDoubanRating(String key) {
+        String title = ratingTitle();
+        if (TextUtils.isEmpty(title)) return;
+        String mediaType = matchedTmdbItem == null ? "" : matchedTmdbItem.getMediaType();
+        int year = ratingYear();
+        Task.execute(() -> {
+            try {
+                PersonalRecommendationService.DoubanRating rating = new PersonalRecommendationService().loadDoubanRating(title, mediaType, year);
+                if (rating == null || rating.isEmpty()) return;
+                String value = String.format(Locale.US, "%.1f/10", rating.getRating());
+                runOnAliveUi(() -> addRatingChip(key, "豆瓣", value, 0xFF00B51D));
+            } catch (Throwable ignored) {
+            }
+        });
+    }
+
+    private void fetchOmdbRating(String key) {
+        String imdb = string(object(matchedTmdbDetail, "external_ids"), "imdb_id");
+        String omdbApiKey = tmdbConfig == null ? "" : tmdbConfig.getOmdbApiKey();
+        if (TextUtils.isEmpty(imdb) || TextUtils.isEmpty(omdbApiKey)) return;
+        Task.execute(() -> {
+            try {
+                String url = "https://www.omdbapi.com/?i=" + imdb + "&apikey=" + omdbApiKey;
+                okhttp3.OkHttpClient client = new okhttp3.OkHttpClient.Builder()
+                        .connectTimeout(8, TimeUnit.SECONDS)
+                        .readTimeout(8, TimeUnit.SECONDS)
+                        .build();
+                okhttp3.Request request = new okhttp3.Request.Builder().url(url).build();
+                try (okhttp3.Response response = client.newCall(request).execute()) {
+                    if (!response.isSuccessful() || response.body() == null) return;
+                    JsonObject body = JsonParser.parseString(response.body().string()).getAsJsonObject();
+                    if ("False".equalsIgnoreCase(string(body, "Response"))) return;
+                    runOnAliveUi(() -> addOmdbRatingChips(key, body));
+                }
+            } catch (Throwable ignored) {
+            }
+        });
+    }
+
+    private void addOmdbRatingChips(String key, JsonObject body) {
+        String imdbRating = string(body, "imdbRating");
+        if (!TextUtils.isEmpty(imdbRating) && !"N/A".equalsIgnoreCase(imdbRating)) addRatingChip(key, "IMDB", imdbRating + "/10", 0xFFF5C518);
+        for (JsonElement element : array(body, "Ratings")) {
+            if (!element.isJsonObject()) continue;
+            JsonObject rating = element.getAsJsonObject();
+            String source = string(rating, "Source");
+            String value = string(rating, "Value");
+            if (TextUtils.isEmpty(value) || "N/A".equalsIgnoreCase(value)) continue;
+            if ("Rotten Tomatoes".equals(source)) addRatingChip(key, "烂番茄", value, 0xFFFA320A);
+            else if ("Metacritic".equals(source)) addRatingChip(key, "Metacritic", value, 0xFFFFCC33);
+        }
+    }
+
+    private String ratingDisplayKey() {
+        int tmdbId = matchedTmdbItem == null ? 0 : matchedTmdbItem.getTmdbId();
+        return tmdbId + "|" + ratingTitle() + "|" + ratingYear();
+    }
+
+    private String tmdbRatingValue() {
+        if (matchedTmdbDetail == null || !matchedTmdbDetail.has("vote_average") || matchedTmdbDetail.get("vote_average").isJsonNull()) return "";
+        double value = matchedTmdbDetail.get("vote_average").getAsDouble();
+        return value <= 0 ? "" : String.format(Locale.US, "%.1f", value);
+    }
+
+    private String ratingTitle() {
+        return coalesce(matchedTmdbItem == null ? "" : matchedTmdbItem.getTitle(), vod == null ? "" : vod.getName(), getNameText());
+    }
+
+    private int ratingYear() {
+        String year = yearLabel();
+        if (TextUtils.isEmpty(year) || year.length() < 4) return 0;
+        try {
+            return Integer.parseInt(year.substring(0, 4));
+        } catch (Throwable e) {
+            return 0;
+        }
     }
 
     private void bindOverview() {
@@ -2079,7 +2269,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         List<Episode> displayEpisodes = new ArrayList<>(visibleEpisodes);
         if (episodeReverse) Collections.reverse(displayEpisodes);
         binding.episodeReverse.setText(episodeReverse ? R.string.detail_episode_forward : R.string.detail_episode_reverse);
-        binding.episodeViewMode.setText(episodeGridMode ? R.string.detail_episode_view_list : R.string.detail_episode_view_grid);
+        updateEpisodeViewModeButton();
         episodeAdapter.setMode(episodeGridMode ? TmdbEpisodeAdapter.Mode.GRID : TmdbEpisodeAdapter.Mode.LIST);
         updateEpisodeLayoutManager();
         episodeAdapter.setItems(displayEpisodes, tmdbEpisodes, episodeNumbers, selectedEpisode);
@@ -2124,6 +2314,13 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void toggleEpisodeViewMode() {
         episodeGridMode = !episodeGridMode;
         renderEpisodes();
+    }
+
+    private void updateEpisodeViewModeButton() {
+        boolean switchToList = episodeGridMode;
+        binding.episodeViewMode.setText(switchToList ? R.string.detail_episode_view_list : R.string.detail_episode_view_grid);
+        binding.episodeViewMode.setIconResource(switchToList ? R.drawable.ic_site_list : R.drawable.ic_site_grid);
+        binding.episodeViewMode.setContentDescription(getString(switchToList ? R.string.detail_episode_view_list_action : R.string.detail_episode_view_grid_action));
     }
 
     private void updateEpisodeLayoutManager() {
@@ -3116,6 +3313,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         inlineStartPositionApplied = false;
         pendingInlineResult = null;
         currentInlineResult = null;
+        introSkipPlayback.reset();
         if (service() == null || player() == null || player().isEmpty()) {
             updateInlineButtons(false);
             return;
@@ -3984,13 +4182,28 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             showTvInlineEpisodes();
             return;
         }
-        FrameLayout content = new FrameLayout(this);
+        LinearLayout content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
         content.setPadding(ResUtil.dp2px(12), ResUtil.dp2px(8), ResUtil.dp2px(12), ResUtil.dp2px(8));
+        LinearLayout header = new LinearLayout(this);
+        header.setGravity(Gravity.CENTER_VERTICAL);
+        header.setOrientation(LinearLayout.HORIZONTAL);
+        TextView title = new TextView(this);
+        title.setText(R.string.detail_episode);
+        title.setTextColor(0xFFEAF2F8);
+        title.setTextSize(18f);
+        title.setTypeface(null, android.graphics.Typeface.BOLD);
+        header.addView(title, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+        MaterialButton mode = createInlineEpisodeModeButton();
+        header.addView(mode, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ResUtil.dp2px(36)));
+        content.addView(header, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         RecyclerView recycler = new RecyclerView(this);
         recycler.setClipToPadding(false);
-        recycler.setLayoutManager(new GridLayoutManager(this, inlineEpisodeSpanCount()));
+        updateInlineEpisodeLayoutManager(recycler);
         int height = Math.min(ResUtil.dp2px(520), (int) (ResUtil.getScreenHeight(this) * 0.68f));
-        content.addView(recycler, new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height));
+        LinearLayout.LayoutParams recyclerParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height);
+        recyclerParams.topMargin = ResUtil.dp2px(8);
+        content.addView(recycler, recyclerParams);
 
         AlertDialog[] holder = new AlertDialog[1];
         InlineEpisodeAdapter adapter = new InlineEpisodeAdapter(new InlineEpisodeAdapter.Listener() {
@@ -4008,9 +4221,14 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         });
         recycler.setAdapter(adapter);
         adapter.setItems(selectedFlag.getEpisodes(), selectedEpisode, inlineEpisodeTitles(selectedFlag.getEpisodes()));
+        mode.setOnClickListener(view -> {
+            inlineEpisodeGridMode = !inlineEpisodeGridMode;
+            updateInlineEpisodeLayoutManager(recycler);
+            updateInlineEpisodeModeButton(mode);
+            scrollInlineEpisodeToSelected(recycler, selectedFlag.getEpisodes());
+        });
 
         AlertDialog dialog = new MaterialAlertDialogBuilder(this)
-                .setTitle(R.string.detail_episode)
                 .setView(content)
                 .create();
         holder[0] = dialog;
@@ -4060,6 +4278,18 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         applyEpisodeDialogIconState(reverse, false);
         reverse.setOnFocusChangeListener((view, focused) -> applyEpisodeDialogIconState(reverse, focused));
         header.addView(reverse, new LinearLayout.LayoutParams(ResUtil.dp2px(34), ResUtil.dp2px(34)));
+        ImageView mode = new ImageView(this);
+        updateInlineEpisodeModeIcon(mode);
+        mode.setColorFilter(0xFFEAF2F8);
+        mode.setPadding(ResUtil.dp2px(8), ResUtil.dp2px(8), ResUtil.dp2px(8), ResUtil.dp2px(8));
+        mode.setFocusable(true);
+        mode.setFocusableInTouchMode(true);
+        mode.setClickable(true);
+        applyEpisodeDialogIconState(mode, false);
+        mode.setOnFocusChangeListener((view, focused) -> applyEpisodeDialogIconState(mode, focused));
+        LinearLayout.LayoutParams modeParams = new LinearLayout.LayoutParams(ResUtil.dp2px(34), ResUtil.dp2px(34));
+        modeParams.setMarginStart(ResUtil.dp2px(8));
+        header.addView(mode, modeParams);
         panel.addView(header, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
 
         HorizontalScrollView pageScroll = new HorizontalScrollView(this);
@@ -4073,7 +4303,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
         RecyclerView recycler = new RecyclerView(this);
         recycler.setClipToPadding(false);
-        recycler.setLayoutManager(new GridLayoutManager(this, 3));
+        updateTvInlineEpisodeLayoutManager(recycler);
         InlineEpisodeAdapter adapter = new InlineEpisodeAdapter(new InlineEpisodeAdapter.Listener() {
             @Override
             public void onItemClick(Episode episode) {
@@ -4093,13 +4323,13 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         recyclerParams.topMargin = ResUtil.dp2px(6);
         panel.addView(recycler, recyclerParams);
 
-        final int pageSize = 12;
         final int[] pageIndex = {0};
         final List<TextView> pageButtons = new ArrayList<>();
         final Runnable[] render = new Runnable[1];
         final java.util.function.BiConsumer<Integer, Boolean> showPage = (index, focusEpisode) -> {
             List<Episode> ordered = orderedInlineEpisodes();
             if (ordered.isEmpty()) return;
+            int pageSize = inlineEpisodeDialogPageSize();
             int pageCount = (int) Math.ceil(ordered.size() / (float) pageSize);
             pageIndex[0] = Math.max(0, Math.min(index, pageCount - 1));
             int start = pageIndex[0] * pageSize;
@@ -4124,6 +4354,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             pageRow.removeAllViews();
             pageButtons.clear();
             if (ordered.isEmpty()) return;
+            int pageSize = inlineEpisodeDialogPageSize();
             int pageCount = (int) Math.ceil(ordered.size() / (float) pageSize);
             int selected = ordered.indexOf(selectedEpisode);
             int selectedPage = selected < 0 ? 0 : selected / pageSize;
@@ -4147,6 +4378,12 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         };
         reverse.setOnClickListener(view -> {
             toggleEpisodeReverse();
+            render[0].run();
+        });
+        mode.setOnClickListener(view -> {
+            inlineEpisodeGridMode = !inlineEpisodeGridMode;
+            updateTvInlineEpisodeLayoutManager(recycler);
+            updateInlineEpisodeModeIcon(mode);
             render[0].run();
         });
 
@@ -4280,6 +4517,90 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         icon.setBackground(background);
     }
 
+    private MaterialButton createInlineEpisodeModeButton() {
+        MaterialButton button = new MaterialButton(this, null, com.google.android.material.R.attr.materialButtonOutlinedStyle);
+        button.setMinWidth(ResUtil.dp2px(72));
+        button.setMinHeight(0);
+        button.setMinimumHeight(0);
+        button.setInsetTop(0);
+        button.setInsetBottom(0);
+        button.setAllCaps(false);
+        button.setSingleLine(true);
+        button.setTextSize(13f);
+        button.setGravity(Gravity.CENTER);
+        button.setPadding(ResUtil.dp2px(10), 0, ResUtil.dp2px(12), 0);
+        button.setIconGravity(MaterialButton.ICON_GRAVITY_TEXT_START);
+        button.setIconPadding(ResUtil.dp2px(4));
+        button.setIconSize(ResUtil.dp2px(16));
+        button.setFocusable(true);
+        button.setFocusableInTouchMode(true);
+        updateInlineEpisodeModeButton(button);
+        button.setOnFocusChangeListener((view, focused) -> applyInlineEpisodeModeButtonState(button, focused));
+        return button;
+    }
+
+    private void updateInlineEpisodeModeButton(MaterialButton button) {
+        boolean switchToList = inlineEpisodeGridMode;
+        button.setText(switchToList ? R.string.detail_episode_view_list : R.string.detail_episode_view_grid);
+        button.setIconResource(switchToList ? R.drawable.ic_site_list : R.drawable.ic_site_grid);
+        button.setContentDescription(getString(switchToList ? R.string.detail_episode_view_list_action : R.string.detail_episode_view_grid_action));
+        applyInlineEpisodeModeButtonState(button, button.hasFocus());
+    }
+
+    private void applyInlineEpisodeModeButtonState(MaterialButton button, boolean focused) {
+        int text = focused ? 0xFFFFFFFF : 0xFFEAF2F8;
+        button.setTextColor(text);
+        button.setIconTint(ColorStateList.valueOf(text));
+        button.setBackgroundTintList(ColorStateList.valueOf(focused ? 0x552196F3 : 0x33263442));
+        button.setStrokeColor(ColorStateList.valueOf(focused ? 0xFF0077FF : 0x44FFFFFF));
+        button.setStrokeWidth(ResUtil.dp2px(focused ? 2 : 1));
+    }
+
+    private void updateInlineEpisodeModeIcon(ImageView icon) {
+        boolean switchToList = inlineEpisodeGridMode;
+        icon.setImageResource(switchToList ? R.drawable.ic_site_list : R.drawable.ic_site_grid);
+        icon.setContentDescription(getString(switchToList ? R.string.detail_episode_view_list_action : R.string.detail_episode_view_grid_action));
+        icon.setColorFilter(0xFFEAF2F8);
+    }
+
+    private void updateInlineEpisodeLayoutManager(RecyclerView recycler) {
+        RecyclerView.LayoutManager current = recycler.getLayoutManager();
+        if (inlineEpisodeGridMode) {
+            int spanCount = inlineEpisodeSpanCount();
+            if (current instanceof GridLayoutManager grid && grid.getSpanCount() == spanCount) return;
+            recycler.setLayoutManager(new GridLayoutManager(this, spanCount));
+        } else {
+            if (current instanceof LinearLayoutManager linear && !(current instanceof GridLayoutManager) && linear.getOrientation() == LinearLayoutManager.VERTICAL) return;
+            recycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
+        }
+    }
+
+    private void updateTvInlineEpisodeLayoutManager(RecyclerView recycler) {
+        RecyclerView.LayoutManager current = recycler.getLayoutManager();
+        if (inlineEpisodeGridMode) {
+            if (current instanceof GridLayoutManager grid && grid.getSpanCount() == 3) return;
+            recycler.setLayoutManager(new GridLayoutManager(this, 3));
+        } else {
+            if (current instanceof LinearLayoutManager linear && !(current instanceof GridLayoutManager) && linear.getOrientation() == LinearLayoutManager.VERTICAL) return;
+            recycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
+        }
+    }
+
+    private int inlineEpisodeDialogPageSize() {
+        return inlineEpisodeGridMode ? 12 : 6;
+    }
+
+    private void scrollInlineEpisodeToSelected(RecyclerView recycler, List<Episode> episodes) {
+        if (selectedEpisode == null || episodes == null) return;
+        int position = episodes.indexOf(selectedEpisode);
+        if (position < 0) return;
+        recycler.scrollToPosition(position);
+        recycler.post(() -> {
+            RecyclerView.ViewHolder holder = recycler.findViewHolderForAdapterPosition(position);
+            if (holder != null) holder.itemView.requestFocus();
+        });
+    }
+
     private int inlineEpisodeSpanCount() {
         int width = ResUtil.getScreenWidth(this);
         if (width >= ResUtil.dp2px(1200)) return 5;
@@ -4342,6 +4663,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void enterInlineFullscreen() {
         if (inlineFullscreen || inlinePiPLayout || isInPictureInPictureMode()) return;
         inlineFullscreen = true;
+        updateDetailThemeButtonVisibility();
         requestedOrientation = getRequestedOrientation();
         playerParent = (ViewGroup) binding.playerPanel.getParent();
         playerLayoutParams = binding.playerPanel.getLayoutParams();
@@ -4478,6 +4800,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         playerLayoutParams = null;
         playerIndex = -1;
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+        updateDetailThemeButtonVisibility();
     }
 
     private void enterInlinePiPLayout() {
@@ -4487,6 +4810,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         inlinePiPIndex = inlinePiPParent.indexOfChild(binding.playerPanel);
         inlinePiPTranslationZ = binding.playerPanel.getTranslationZ();
         inlinePiPLayout = true;
+        updateDetailThemeButtonVisibility();
         // Keep the original source rect so PiP exits back to the inline card.
         inlinePiPSourceFrozen = true;
         inlinePiPParent.removeView(binding.playerPanel);
@@ -4519,6 +4843,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             inlinePiPSourceFrozen = false;
             if (inlinePiP != null) inlinePiP.update(TmdbDetailActivity.this, binding.playerPanel);
         });
+        updateDetailThemeButtonVisibility();
     }
 
     private void scheduleMobileInlineSideControlMarginUpdate() {
@@ -4558,6 +4883,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         saveInlineHistory();
         inlinePlaybackGeneration++;
         inlinePlaybackLoading = false;
+        introSkipPlayback.reset();
         hideInlineControls();
         if (service() != null) {
             player().stop();
@@ -4814,6 +5140,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             applyInlineStartPosition();
             updateInlineButtons(player().isPlaying());
             applyInlineShortDramaMode();
+            requestIntroSkipPlan();
+            applyAutoIntroSkip();
         }
         if (state == Player.STATE_ENDED) checkInlineEnded(true);
         updateInlineDisplayPanel();
@@ -4840,6 +5168,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     @Override
     public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, @NonNull Configuration newConfig) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        updateDetailThemeButtonVisibility();
         if (!isInlinePlayerMode()) return;
         if (isInPictureInPictureMode) {
             hideInlineControls();
@@ -4851,6 +5180,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         inlinePiPLayoutRequested = false;
         updateInlineButtons(service() != null && player() != null && !player().isEmpty() && player().isPlaying());
         updateInlineDisplayPanel();
+        updateDetailThemeButtonVisibility();
     }
 
     @Override
@@ -4961,6 +5291,41 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         if (history != null && service() != null && player() != null && !player().isReleased()) history.setPlayer(player().getPlayerType());
     }
 
+    private void requestIntroSkipPlan() {
+        if (!Setting.isAutoSkipIntroOutro() || player() == null) {
+            introSkipPlayback.reset();
+            return;
+        }
+        IntroSkipService.Query query = buildIntroSkipQuery();
+        if (query == null) return;
+        introSkipPlayback.request(query, this::applyAutoIntroSkip);
+    }
+
+    private boolean applyAutoIntroSkip() {
+        if (!Setting.isAutoSkipIntroOutro() || player() == null) return false;
+        return introSkipPlayback.apply(player(), () -> checkInlineEnded(false));
+    }
+
+    private IntroSkipService.Query buildIntroSkipQuery() {
+        TmdbItem item = matchedTmdbItem;
+        if (item == null || item.getTmdbId() <= 0) return null;
+        int season = 0;
+        int number = 0;
+        if (item.isTv()) {
+            TmdbEpisode tmdbEpisode = selectedEpisode == null ? null : selectedEpisode.getTmdbEpisode();
+            season = tmdbEpisode != null && tmdbEpisode.getSeasonNumber() > 0 ? tmdbEpisode.getSeasonNumber() : selectedSeasonNumber;
+            number = tmdbEpisode != null && tmdbEpisode.getNumber() > 0 ? tmdbEpisode.getNumber() : sourceEpisodeNumber(selectedEpisode);
+            if (season <= 0 || number <= 0) return null;
+        }
+        long duration = player() == null ? 0 : Math.max(0, player().getDuration());
+        return new IntroSkipService.Query(item.getTmdbId(), introSkipImdbId(), item.getMediaType(), season, number, duration);
+    }
+
+    private String introSkipImdbId() {
+        JsonObject externalIds = object(matchedTmdbDetail, "external_ids");
+        return string(externalIds, "imdb_id");
+    }
+
     @Override
     public void onTimeChanged(long time) {
         if (!isInlinePlayerMode() || inlinePlaybackLoading || !isOwner() || history == null || service() == null || player() == null || player().isEmpty()) return;
@@ -4974,6 +5339,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             updateInlineHistoryPlayer();
         }
         if (canUpdateProgress && history.canSave() && history.canSync()) syncInlineHistory();
+        if (canUpdateProgress && applyAutoIntroSkip()) return;
         if (canUpdateProgress && history.getEnding() > 0 && duration > 0 && history.getEnding() + position >= duration) checkInlineEnded(false);
         if (isInlineControlsVisible()) updateMobileInlineControlTime();
         updateInlineDisplayPanel();
@@ -5867,6 +6233,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     private void addMetaChip(String text) {
         if (TextUtils.isEmpty(text)) return;
+        text = normalizeImdbBrand(text);
         ThemeColors colors = lightTheme ? ThemeColors.light() : ThemeColors.dark();
         TextView chip = new TextView(this);
         chip.setText(text);
@@ -5882,6 +6249,12 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         params.setMargins(0, 0, 10, 10);
         chip.setLayoutParams(params);
         binding.metaContainer.addView(chip);
+    }
+
+    private String normalizeImdbBrand(String text) {
+        if (TextUtils.isEmpty(text)) return text;
+        if (text.regionMatches(true, 0, "imdb", 0, 4)) return "IMDB" + text.substring(4);
+        return text.replace("IMDb", "IMDB");
     }
 
     private String buildSubtitle() {
@@ -6025,7 +6398,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private String externalIdLabel() {
         JsonObject ids = object(matchedTmdbDetail, "external_ids");
         String imdb = string(ids, "imdb_id");
-        if (!TextUtils.isEmpty(imdb)) return "IMDb " + imdb;
+        if (!TextUtils.isEmpty(imdb)) return "IMDB " + imdb;
         String tvdb = string(ids, "tvdb_id");
         return TextUtils.isEmpty(tvdb) ? "" : "TVDB " + tvdb;
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/TmdbHeaderView.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/TmdbHeaderView.java
@@ -23,6 +23,7 @@ import com.fongmi.android.tv.ui.adapter.TmdbCastAdapter;
 import com.fongmi.android.tv.ui.helper.TmdbUIAdapter;
 import com.fongmi.android.tv.ui.helper.TmdbNavigation;
 import com.fongmi.android.tv.utils.ResUtil;
+import com.fongmi.android.tv.utils.TmdbImageSelector;
 import com.google.android.flexbox.FlexboxLayout;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.card.MaterialCardView;
@@ -589,14 +590,8 @@ public class TmdbHeaderView {
         TmdbItem item = adapter.getTmdbItem();
         if (item == null) return;
 
-        // 收集所有可用的背景图
+        // 收集所有可用的背景图，优先使用已按设备方向与清晰度筛选的图片。
         backdropPhotos.clear();
-        String mainBackdrop = item.getBackdropUrl();
-        if (!TextUtils.isEmpty(mainBackdrop)) {
-            backdropPhotos.add(mainBackdrop);
-        }
-
-        // 添加所有剧照
         java.util.List<String> photos = adapter.getPhotos();
         if (photos != null) {
             for (String photo : photos) {
@@ -605,6 +600,10 @@ public class TmdbHeaderView {
                 }
             }
         }
+        String mainBackdrop = TmdbImageSelector.originalUrl(item.getBackdropUrl());
+        if (!TextUtils.isEmpty(mainBackdrop) && !backdropPhotos.contains(mainBackdrop)) {
+            backdropPhotos.add(mainBackdrop);
+        }
 
         // 如果只有一张图，直接加载
         if (backdropPhotos.isEmpty()) {
@@ -612,7 +611,7 @@ public class TmdbHeaderView {
         }
 
         if (backdropPhotos.size() == 1) {
-            Glide.with(activity).load(backdropPhotos.get(0)).into(backdropView);
+            loadBackdropIntoView(backdropPhotos.get(0));
             return;
         }
 
@@ -639,6 +638,7 @@ public class TmdbHeaderView {
                 // 使用 Glide 预加载，加载完成后切换
                 Glide.with(activity)
                         .load(nextUrl)
+                        .centerCrop()
                         .listener(new com.bumptech.glide.request.RequestListener<android.graphics.drawable.Drawable>() {
                             @Override
                             public boolean onLoadFailed(com.bumptech.glide.load.engine.GlideException e, Object model, com.bumptech.glide.request.target.Target<android.graphics.drawable.Drawable> target, boolean isFirstResource) {
@@ -654,6 +654,7 @@ public class TmdbHeaderView {
                             public boolean onResourceReady(android.graphics.drawable.Drawable resource, Object model, com.bumptech.glide.request.target.Target<android.graphics.drawable.Drawable> target, com.bumptech.glide.load.DataSource dataSource, boolean isFirstResource) {
                                 // 图片加载完成，切换到这张图
                                 currentBackdropIndex = nextIndex;
+                                backdropView.setScaleType(ImageView.ScaleType.CENTER_CROP);
                                 backdropView.setImageDrawable(resource);
 
                                 // 5秒后切换下一张
@@ -669,11 +670,17 @@ public class TmdbHeaderView {
 
         // 加载第一张
         if (!backdropPhotos.isEmpty()) {
-            Glide.with(activity).load(backdropPhotos.get(0)).into(backdropView);
+            loadBackdropIntoView(backdropPhotos.get(0));
             currentBackdropIndex = 0;
             // 5秒后开始切换
             backdropHandler.postDelayed(backdropRunnable, 5000);
         }
+    }
+
+    private void loadBackdropIntoView(String url) {
+        if (TextUtils.isEmpty(url) || backdropView == null) return;
+        backdropView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+        Glide.with(activity).load(url).centerCrop().into(backdropView);
     }
 
     /**

--- a/app/src/main/java/com/fongmi/android/tv/ui/helper/DetailThemeVisibility.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/helper/DetailThemeVisibility.java
@@ -1,0 +1,23 @@
+package com.fongmi.android.tv.ui.helper;
+
+public final class DetailThemeVisibility {
+
+    private DetailThemeVisibility() {
+    }
+
+    public static boolean showMobileThemeButton(boolean mobile, boolean fullscreen, boolean inlinePiPLayout, boolean pictureInPicture) {
+        return mobile && !isPlayerOverlayActive(fullscreen, inlinePiPLayout, pictureInPicture);
+    }
+
+    public static boolean showLargeScreenThemeButton(boolean mobile, boolean fullscreen, boolean inlinePiPLayout, boolean pictureInPicture) {
+        return !mobile && !isPlayerOverlayActive(fullscreen, inlinePiPLayout, pictureInPicture);
+    }
+
+    public static boolean showFusionThemeButton(boolean fusionDetailPage, boolean fullscreen, boolean pictureInPicture) {
+        return fusionDetailPage && !fullscreen && !pictureInPicture;
+    }
+
+    private static boolean isPlayerOverlayActive(boolean fullscreen, boolean inlinePiPLayout, boolean pictureInPicture) {
+        return fullscreen || inlinePiPLayout || pictureInPicture;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapter.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapter.java
@@ -15,7 +15,9 @@ import com.fongmi.android.tv.event.RefreshEvent;
 import com.fongmi.android.tv.service.PersonalRecommendationService;
 import com.fongmi.android.tv.service.TmdbService;
 import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.utils.ResUtil;
 import com.fongmi.android.tv.utils.Task;
+import com.fongmi.android.tv.utils.Util;
 import com.github.catvod.crawler.SpiderDebug;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -550,7 +552,11 @@ public class TmdbUIAdapter {
      */
     public List<String> getPhotos() {
         if (tmdbDetail == null) return new ArrayList<>();
-        return tmdbService.photos(tmdbDetail, tmdbConfig);
+        return tmdbService.photos(tmdbDetail, tmdbConfig, preferLandscapeBackground());
+    }
+
+    private boolean preferLandscapeBackground() {
+        return !Util.isMobile() || ResUtil.isPad() || ResUtil.getScreenWidth(activity) >= ResUtil.getScreenHeight(activity);
     }
 
     /**

--- a/app/src/main/java/com/fongmi/android/tv/utils/TmdbImageSelector.java
+++ b/app/src/main/java/com/fongmi/android/tv/utils/TmdbImageSelector.java
@@ -1,0 +1,148 @@
+package com.fongmi.android.tv.utils;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class TmdbImageSelector {
+
+    private enum Orientation {
+        LANDSCAPE,
+        PORTRAIT,
+        UNKNOWN
+    }
+
+    public static List<String> backgrounds(JsonObject detail, String imageBase, String backdropBase, boolean preferLandscape, int limit) {
+        List<Candidate> candidates = new ArrayList<>();
+        addImages(candidates, detail, "backdrops", backdropBase, Orientation.LANDSCAPE);
+        addImages(candidates, detail, "posters", imageBase, Orientation.PORTRAIT);
+        addRootImage(candidates, detail, "backdrop_path", backdropBase, Orientation.LANDSCAPE);
+        addRootImage(candidates, detail, "poster_path", imageBase, Orientation.PORTRAIT);
+        Orientation preferred = preferLandscape ? Orientation.LANDSCAPE : Orientation.PORTRAIT;
+        List<Candidate> selected = filter(candidates, preferred);
+        if (selected.isEmpty()) selected = filter(candidates, preferLandscape ? Orientation.PORTRAIT : Orientation.LANDSCAPE);
+        if (selected.isEmpty()) selected = candidates;
+        selected.sort(Comparator
+                .comparingInt((Candidate item) -> item.sourceRank)
+                .thenComparing(Comparator.comparingLong((Candidate item) -> item.pixels).reversed())
+                .thenComparing(Comparator.comparingDouble((Candidate item) -> item.voteAverage).reversed())
+                .thenComparing(Comparator.comparingInt((Candidate item) -> item.voteCount).reversed()));
+        List<String> urls = new ArrayList<>();
+        int max = limit <= 0 ? Integer.MAX_VALUE : limit;
+        for (Candidate candidate : selected) {
+            if (urls.contains(candidate.url)) continue;
+            urls.add(candidate.url);
+            if (urls.size() >= max) break;
+        }
+        return urls;
+    }
+
+    public static String originalUrl(String url) {
+        if (isEmpty(url)) return "";
+        int marker = url.indexOf("/t/p/");
+        if (marker >= 0) {
+            int sizeStart = marker + "/t/p/".length();
+            int sizeEnd = url.indexOf('/', sizeStart);
+            if (sizeEnd > sizeStart) return url.substring(0, sizeStart) + "original" + url.substring(sizeEnd);
+        }
+        return url.replaceFirst("/(w\\d+|h\\d+|original)/", "/original/");
+    }
+
+    private static void addImages(List<Candidate> candidates, JsonObject detail, String key, String base, Orientation fallback) {
+        JsonArray images = array(detail, "images", key);
+        for (JsonElement element : images) {
+            if (!element.isJsonObject()) continue;
+            JsonObject object = element.getAsJsonObject();
+            String path = string(object, "file_path");
+            String url = image(base, path);
+            if (isEmpty(url)) continue;
+            int width = integer(object, "width");
+            int height = integer(object, "height");
+            candidates.add(new Candidate(url, orientation(width, height, fallback), pixels(width, height), number(object, "vote_average"), integer(object, "vote_count"), 0));
+        }
+    }
+
+    private static void addRootImage(List<Candidate> candidates, JsonObject detail, String key, String base, Orientation orientation) {
+        String url = image(base, string(detail, key));
+        if (!isEmpty(url)) candidates.add(new Candidate(url, orientation, 0, 0, 0, 1));
+    }
+
+    private static List<Candidate> filter(List<Candidate> candidates, Orientation orientation) {
+        List<Candidate> result = new ArrayList<>();
+        for (Candidate candidate : candidates) if (candidate.orientation == orientation) result.add(candidate);
+        return result;
+    }
+
+    private static String image(String base, String path) {
+        if (isEmpty(path)) return "";
+        String normalizedBase = originalBase(base);
+        return normalizedBase + (path.startsWith("/") ? path : "/" + path);
+    }
+
+    private static String originalBase(String base) {
+        if (isEmpty(base)) return "";
+        String value = base.trim();
+        if (value.endsWith("/")) value = value.substring(0, value.length() - 1);
+        int marker = value.indexOf("/t/p/");
+        if (marker >= 0) return value.substring(0, marker + "/t/p/".length()) + "original";
+        return value;
+    }
+
+    private static Orientation orientation(int width, int height, Orientation fallback) {
+        if (width > 0 && height > 0) return width >= height ? Orientation.LANDSCAPE : Orientation.PORTRAIT;
+        return fallback == null ? Orientation.UNKNOWN : fallback;
+    }
+
+    private static long pixels(int width, int height) {
+        return Math.max(0, width) * (long) Math.max(0, height);
+    }
+
+    private static JsonArray array(JsonObject object, String... keys) {
+        JsonElement current = object;
+        for (String key : keys) {
+            if (current == null || !current.isJsonObject()) return new JsonArray();
+            JsonObject currentObject = current.getAsJsonObject();
+            if (!currentObject.has(key) || currentObject.get(key).isJsonNull()) return new JsonArray();
+            current = currentObject.get(key);
+        }
+        return current != null && current.isJsonArray() ? current.getAsJsonArray() : new JsonArray();
+    }
+
+    private static String string(JsonObject object, String key) {
+        try {
+            if (object == null || !object.has(key) || object.get(key).isJsonNull()) return "";
+            return object.get(key).getAsString();
+        } catch (Throwable e) {
+            return "";
+        }
+    }
+
+    private static int integer(JsonObject object, String key) {
+        try {
+            if (object == null || !object.has(key) || object.get(key).isJsonNull()) return 0;
+            return object.get(key).getAsInt();
+        } catch (Throwable e) {
+            return 0;
+        }
+    }
+
+    private static double number(JsonObject object, String key) {
+        try {
+            if (object == null || !object.has(key) || object.get(key).isJsonNull()) return 0;
+            return object.get(key).getAsDouble();
+        } catch (Throwable e) {
+            return 0;
+        }
+    }
+
+    private static boolean isEmpty(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private record Candidate(String url, Orientation orientation, long pixels, double voteAverage, int voteCount, int sourceRank) {
+    }
+}

--- a/app/src/main/res/layout/activity_tmdb_detail.xml
+++ b/app/src/main/res/layout/activity_tmdb_detail.xml
@@ -22,7 +22,7 @@
             android:id="@+id/backdrop"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="fitCenter" />
+            android:scaleType="centerCrop" />
 
         <View
             android:id="@+id/backdropShade"
@@ -800,6 +800,14 @@
                                 android:layout_marginTop="10dp"
                                 app:flexWrap="wrap" />
 
+                            <com.google.android.flexbox.FlexboxLayout
+                                android:id="@+id/ratingsContainer"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="4dp"
+                                android:visibility="gone"
+                                app:flexWrap="wrap" />
+
                             <TextView
                                 android:id="@+id/sourceValue"
                                 android:layout_width="match_parent"
@@ -1005,13 +1013,19 @@
                             android:layout_height="36dp"
                             android:layout_marginStart="8dp"
                             android:minHeight="36dp"
-                            android:minWidth="58dp"
-                            android:paddingStart="12dp"
+                            android:minWidth="72dp"
+                            android:paddingStart="10dp"
                             android:paddingEnd="12dp"
-                            android:text="@string/detail_episode_view_list"
+                            android:contentDescription="@string/detail_episode_view_grid_action"
+                            android:text="@string/detail_episode_view_grid"
                             android:textColor="@android:color/white"
                             android:textSize="12sp"
                             app:backgroundTint="#2B3743"
+                            app:icon="@drawable/ic_site_grid"
+                            app:iconGravity="textStart"
+                            app:iconPadding="4dp"
+                            app:iconSize="16dp"
+                            app:iconTint="@android:color/white"
                             app:strokeColor="@android:color/transparent" />
                     </LinearLayout>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -23,6 +23,8 @@
     <string name="detail_episode_forward">正序</string>
     <string name="detail_episode_view_grid">网格</string>
     <string name="detail_episode_view_list">列表</string>
+    <string name="detail_episode_view_grid_action">切换到网格</string>
+    <string name="detail_episode_view_list_action">切换到列表</string>
 
     <!-- Keep -->
     <string name="keep">收藏</string>
@@ -1042,7 +1044,7 @@
     <string name="setting_detail_open_mode">详情页模式</string>
     <string name="setting_detail_open_original">原始详情</string>
     <string name="setting_detail_open_native">TMDB 内嵌增强</string>
-    <string name="setting_detail_open_original_enhanced">原始增强</string>
+    <string name="setting_detail_open_original_enhanced">原生增强</string>
     <string name="setting_detail_open_fusion">沉浸融合</string>
     <string name="setting_detail_open_enhanced">炫彩详情</string>
     <string name="setting_detail_open_player">详情直放</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -23,6 +23,8 @@
     <string name="detail_episode_forward">正序</string>
     <string name="detail_episode_view_grid">網格</string>
     <string name="detail_episode_view_list">列表</string>
+    <string name="detail_episode_view_grid_action">切換到網格</string>
+    <string name="detail_episode_view_list_action">切換到列表</string>
 
     <!-- Keep -->
     <string name="keep">收藏</string>
@@ -981,7 +983,7 @@
     <string name="setting_detail_open_mode">詳情頁模式</string>
     <string name="setting_detail_open_original">原始詳情</string>
     <string name="setting_detail_open_native">TMDB 內嵌增強</string>
-    <string name="setting_detail_open_original_enhanced">原始增強</string>
+    <string name="setting_detail_open_original_enhanced">原生增強</string>
     <string name="setting_detail_open_fusion">沉浸融合</string>
     <string name="setting_detail_open_enhanced">炫彩詳情</string>
     <string name="setting_detail_open_player">詳情直放</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="detail_episode_forward">Forward</string>
     <string name="detail_episode_view_grid">Grid</string>
     <string name="detail_episode_view_list">List</string>
+    <string name="detail_episode_view_grid_action">Switch to grid</string>
+    <string name="detail_episode_view_list_action">Switch to list</string>
 
     <!-- Keep -->
     <string name="keep">Keep</string>
@@ -1058,7 +1060,7 @@
     <string name="setting_detail_open_mode">Detail page mode</string>
     <string name="setting_detail_open_original">Original detail</string>
     <string name="setting_detail_open_native">TMDB embedded enhancement</string>
-    <string name="setting_detail_open_original_enhanced">Original enhancement</string>
+    <string name="setting_detail_open_original_enhanced">Native enhancement</string>
     <string name="setting_detail_open_fusion">Immersive fusion</string>
     <string name="setting_detail_open_enhanced">Colorful detail</string>
     <string name="setting_detail_open_player">Detail direct play</string>

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -116,6 +116,7 @@ import com.fongmi.android.tv.ui.dialog.TmdbSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TitleDialog;
 import com.fongmi.android.tv.ui.dialog.TrackDialog;
 import com.fongmi.android.tv.ui.dialog.VideoContentDialog;
+import com.fongmi.android.tv.ui.helper.DetailThemeVisibility;
 import com.fongmi.android.tv.ui.helper.EpisodeDisplayPolicy;
 import com.fongmi.android.tv.ui.helper.TmdbNavigation;
 import com.fongmi.android.tv.utils.AudioUtil;
@@ -187,6 +188,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     private boolean playHealthRecorded;
     private boolean mNativePersonalTmdbLoading;
     private boolean mNativePersonalDoubanLoading;
+    private boolean mEpisodeGridMode = true;
     private int mEpisodeSpanCount;
     private Runnable mR1;
     private Runnable mR2;
@@ -1167,7 +1169,10 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mBinding.control.next.setVisibility(size < 2 ? View.GONE : View.VISIBLE);
         mBinding.control.prev.setVisibility(size < 2 ? View.GONE : View.VISIBLE);
         mBinding.reverse.setVisibility(size < 2 ? View.GONE : View.VISIBLE);
-        if (mBinding.episodeViewMode != null) mBinding.episodeViewMode.setVisibility(View.GONE);
+        boolean showViewMode = useTmdbCard && size > 1;
+        if (!showViewMode) mEpisodeGridMode = true;
+        updateEpisodeViewModeButton();
+        if (mBinding.episodeViewMode != null) mBinding.episodeViewMode.setVisibility(showViewMode ? View.VISIBLE : View.GONE);
         mBinding.episode.setVisibility(items.isEmpty() ? View.GONE : View.VISIBLE);
         mBinding.more.setVisibility(View.GONE);
         List<EpisodeGroupAdapter.Group> groups = EpisodeGroupAdapter.build(size, getSelectedEpisodePosition(items), mHistory != null && mHistory.isRevSort());
@@ -1188,18 +1193,36 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     }
 
     private void setEpisodeItems(List<Episode> items) {
-        mEpisodeAdapter.setUseTmdbCard(shouldUseTmdbEpisodeCards(items));
-        updateEpisodeSpan(items);
+        boolean useTmdbCard = shouldUseTmdbEpisodeCards(items);
+        if (!useTmdbCard) mEpisodeGridMode = true;
+        mEpisodeAdapter.setUseTmdbCard(useTmdbCard);
+        mEpisodeAdapter.setViewType(useTmdbCard && !mEpisodeGridMode ? ViewType.HORI : ViewType.GRID);
+        updateEpisodeLayout(items);
         mEpisodeAdapter.addAll(items);
+        updateEpisodeViewModeButton();
     }
 
-    private void updateEpisodeSpan(List<Episode> items) {
+    private void updateEpisodeLayout(List<Episode> items) {
+        if (shouldUseTmdbEpisodeCards(items) && !mEpisodeGridMode) {
+            RecyclerView.LayoutManager manager = mBinding.episode.getLayoutManager();
+            if (!(manager instanceof LinearLayoutManager) || manager instanceof GridLayoutManager || ((LinearLayoutManager) manager).getOrientation() != LinearLayoutManager.HORIZONTAL) {
+                mBinding.episode.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
+            }
+            updateEpisodeDecoration(new SpaceItemDecoration(8));
+            return;
+        }
         int span = getEpisodeSpan(items);
-        if (span == mEpisodeSpanCount) return;
         mEpisodeSpanCount = span;
-        mBinding.episode.setLayoutManager(new GridLayoutManager(this, mEpisodeSpanCount));
+        RecyclerView.LayoutManager manager = mBinding.episode.getLayoutManager();
+        if (!(manager instanceof GridLayoutManager) || ((GridLayoutManager) manager).getSpanCount() != mEpisodeSpanCount) {
+            mBinding.episode.setLayoutManager(new GridLayoutManager(this, mEpisodeSpanCount));
+        }
+        updateEpisodeDecoration(new SpaceItemDecoration(mEpisodeSpanCount, 8));
+    }
+
+    private void updateEpisodeDecoration(SpaceItemDecoration decoration) {
         if (mEpisodeDecoration != null) mBinding.episode.removeItemDecoration(mEpisodeDecoration);
-        mBinding.episode.addItemDecoration(mEpisodeDecoration = new SpaceItemDecoration(mEpisodeSpanCount, 8));
+        mBinding.episode.addItemDecoration(mEpisodeDecoration = decoration);
     }
 
     private int getEpisodeSpan(List<Episode> items) {
@@ -1284,7 +1307,20 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     }
 
     private void toggleEpisodeViewMode() {
-        onEpisodes();
+        if (mBinding.episodeViewMode == null || mBinding.episodeViewMode.getVisibility() != View.VISIBLE) {
+            onEpisodes();
+            return;
+        }
+        mEpisodeGridMode = !mEpisodeGridMode;
+        setEpisodeItems(new ArrayList<>(mEpisodeAdapter.getItems()));
+        scrollToPosition(mBinding.episode, mEpisodeAdapter.getPosition());
+    }
+
+    private void updateEpisodeViewModeButton() {
+        if (mBinding.episodeViewMode == null) return;
+        boolean switchToList = mEpisodeGridMode;
+        mBinding.episodeViewMode.setImageResource(switchToList ? R.drawable.ic_site_list : R.drawable.ic_site_grid);
+        mBinding.episodeViewMode.setContentDescription(getString(switchToList ? R.string.detail_episode_view_list_action : R.string.detail_episode_view_grid_action));
     }
 
     private boolean onChange() {
@@ -2129,12 +2165,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
                 break;
             case Player.STATE_READY:
                 recordPlayHealth(true, "");
-                // 非 TMDB 模式：立即隐藏进度条
-                // TMDB 模式：等待图片加载完成回调（onImagesLoaded）
-                android.util.Log.d("VideoActivity", "STATE_READY - mTmdbHeaderView=" + (mTmdbHeaderView != null));
-                if (!shouldUseTmdbDetailLayout()) {
-                    hideProgress();
-                }
+                hideProgress();
                 checkControl();
                 player().reset();
                 applyShortDramaMode();
@@ -2450,6 +2481,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     private void setFullscreen(boolean fullscreen) {
         Util.toggleFullscreen(this, this.fullscreen = fullscreen);
+        updateFusionThemeButtonVisibility();
     }
 
     private boolean isShortDramaSource() {
@@ -2582,6 +2614,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         params.addRule(RelativeLayout.BELOW, R.id.statusBar);
         params.setMargins(0, ResUtil.dp2px(14), ResUtil.dp2px(24), 0);
         ((RelativeLayout) mBinding.getRoot()).addView(mFusionThemeButton, params);
+        updateFusionThemeButtonVisibility();
     }
 
     private void cycleFusionTheme() {
@@ -2617,6 +2650,13 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mFusionThemeButton.setTextColor(light ? 0xFF12202D : 0xFFE9F0F5);
         mFusionThemeButton.setBackgroundTintList(android.content.res.ColorStateList.valueOf(light ? 0xE6E7EDF3 : 0xCC252A32));
         mFusionThemeButton.setStrokeColor(android.content.res.ColorStateList.valueOf(light ? 0x33424B57 : 0x42FFFFFF));
+        updateFusionThemeButtonVisibility();
+    }
+
+    private void updateFusionThemeButtonVisibility() {
+        if (mFusionThemeButton == null) return;
+        boolean show = DetailThemeVisibility.showFusionThemeButton(Setting.isFusionDetailPage(), isFullscreen(), isInPictureInPictureMode());
+        mFusionThemeButton.setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
     private String fusionThemeLabel() {
@@ -3184,6 +3224,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     @Override
     public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, @NonNull Configuration newConfig) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        updateFusionThemeButtonVisibility();
         if (!isFullscreen()) setVideoView(isInPictureInPictureMode);
         if (isInPictureInPictureMode) {
             hideControl();

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/adapter/EpisodeAdapter.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/adapter/EpisodeAdapter.java
@@ -30,7 +30,7 @@ public class EpisodeAdapter extends RecyclerView.Adapter<BaseEpisodeHolder> {
 
     private final OnClickListener listener;
     private final List<Episode> mItems;
-    private final int viewType;
+    private int viewType;
     private boolean useTmdbCard;
 
     public EpisodeAdapter(OnClickListener listener, int viewType) {
@@ -57,6 +57,12 @@ public class EpisodeAdapter extends RecyclerView.Adapter<BaseEpisodeHolder> {
     public void setUseTmdbCard(boolean useTmdbCard) {
         if (this.useTmdbCard == useTmdbCard) return;
         this.useTmdbCard = useTmdbCard;
+        notifyDataSetChanged();
+    }
+
+    public void setViewType(int viewType) {
+        if (this.viewType == viewType) return;
+        this.viewType = viewType;
         notifyDataSetChanged();
     }
 

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/custom/FixedNestedScrollView.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/custom/FixedNestedScrollView.java
@@ -2,8 +2,6 @@ package com.fongmi.android.tv.ui.custom;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.view.MotionEvent;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.widget.NestedScrollView;
@@ -20,24 +18,5 @@ public class FixedNestedScrollView extends NestedScrollView {
 
     public FixedNestedScrollView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-    }
-
-    @Override
-    public boolean onInterceptTouchEvent(MotionEvent ev) {
-        return false;
-    }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent ev) {
-        return false;
-    }
-
-    @Override
-    public void scrollTo(int x, int y) {
-        super.scrollTo(x, 0);
-    }
-
-    @Override
-    public void fling(int velocityY) {
     }
 }

--- a/app/src/test/java/com/fongmi/android/tv/ui/helper/DetailThemeVisibilityTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/helper/DetailThemeVisibilityTest.java
@@ -1,0 +1,34 @@
+package com.fongmi.android.tv.ui.helper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DetailThemeVisibilityTest {
+
+    @Test
+    public void mobileThemeButton_hidesDuringFullscreenAndPipOverlays() {
+        assertTrue(DetailThemeVisibility.showMobileThemeButton(true, false, false, false));
+        assertFalse(DetailThemeVisibility.showMobileThemeButton(true, true, false, false));
+        assertFalse(DetailThemeVisibility.showMobileThemeButton(true, false, true, false));
+        assertFalse(DetailThemeVisibility.showMobileThemeButton(true, false, false, true));
+    }
+
+    @Test
+    public void largeScreenThemeButton_usesLargeScreenOnlyAndHidesDuringPlaybackOverlays() {
+        assertTrue(DetailThemeVisibility.showLargeScreenThemeButton(false, false, false, false));
+        assertFalse(DetailThemeVisibility.showLargeScreenThemeButton(true, false, false, false));
+        assertFalse(DetailThemeVisibility.showLargeScreenThemeButton(false, true, false, false));
+        assertFalse(DetailThemeVisibility.showLargeScreenThemeButton(false, false, true, false));
+        assertFalse(DetailThemeVisibility.showLargeScreenThemeButton(false, false, false, true));
+    }
+
+    @Test
+    public void fusionThemeButton_hidesWhenFullscreenOrPictureInPicture() {
+        assertTrue(DetailThemeVisibility.showFusionThemeButton(true, false, false));
+        assertFalse(DetailThemeVisibility.showFusionThemeButton(false, false, false));
+        assertFalse(DetailThemeVisibility.showFusionThemeButton(true, true, false));
+        assertFalse(DetailThemeVisibility.showFusionThemeButton(true, false, true));
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/utils/TmdbImageSelectorTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/utils/TmdbImageSelectorTest.java
@@ -1,0 +1,84 @@
+package com.fongmi.android.tv.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TmdbImageSelectorTest {
+
+    @Test
+    public void backgrounds_prefersLargestLandscapeOriginal() {
+        JsonObject detail = detail("""
+                {
+                  "images": {
+                    "backdrops": [
+                      {"file_path": "/small.jpg", "width": 1280, "height": 720, "vote_average": 9.0, "vote_count": 50},
+                      {"file_path": "/large.jpg", "width": 3840, "height": 2160, "vote_average": 6.0, "vote_count": 5}
+                    ],
+                    "posters": [
+                      {"file_path": "/poster.jpg", "width": 2000, "height": 3000, "vote_average": 10.0, "vote_count": 100}
+                    ]
+                  },
+                  "backdrop_path": "/fallback_backdrop.jpg",
+                  "poster_path": "/fallback_poster.jpg"
+                }
+                """);
+
+        List<String> urls = TmdbImageSelector.backgrounds(detail, "https://image.tmdb.org/t/p/w500", "https://image.tmdb.org/t/p/w780", true, 2);
+
+        assertEquals("https://image.tmdb.org/t/p/original/large.jpg", urls.get(0));
+        assertEquals("https://image.tmdb.org/t/p/original/small.jpg", urls.get(1));
+    }
+
+    @Test
+    public void backgrounds_prefersPortraitWhenRequested() {
+        JsonObject detail = detail("""
+                {
+                  "images": {
+                    "backdrops": [
+                      {"file_path": "/wide.jpg", "width": 3840, "height": 2160}
+                    ],
+                    "posters": [
+                      {"file_path": "/poster.jpg", "width": 2000, "height": 3000}
+                    ]
+                  }
+                }
+                """);
+
+        List<String> urls = TmdbImageSelector.backgrounds(detail, "https://image.tmdb.org/t/p/w500", "https://image.tmdb.org/t/p/w780", false, 1);
+
+        assertEquals(List.of("https://image.tmdb.org/t/p/original/poster.jpg"), urls);
+    }
+
+    @Test
+    public void backgrounds_fallsBackWhenPreferredOrientationIsMissing() {
+        JsonObject detail = detail("""
+                {
+                  "images": {
+                    "backdrops": [
+                      {"file_path": "/wide.jpg", "width": 1920, "height": 1080}
+                    ],
+                    "posters": []
+                  }
+                }
+                """);
+
+        List<String> urls = TmdbImageSelector.backgrounds(detail, "https://image.tmdb.org/t/p/w500", "https://image.tmdb.org/t/p/w780", false, 1);
+
+        assertEquals(List.of("https://image.tmdb.org/t/p/original/wide.jpg"), urls);
+    }
+
+    @Test
+    public void originalUrl_replacesTmdbSizeSegment() {
+        assertEquals("https://image.tmdb.org/t/p/original/abc.jpg", TmdbImageSelector.originalUrl("https://image.tmdb.org/t/p/w780/abc.jpg"));
+    }
+
+    private JsonObject detail(String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+}


### PR DESCRIPTION
Hide detail theme controls during fullscreen playback, improve artwork selection and detail-mode ratings, 和 polish episode/detail interactions across mobile and TV. Verification: ran DetailThemeVisibility unit test, mobile armeabi_v7a debug build, leanback armeabi_v7a debug build, and installed the mobile package for emulator validation.