### PR TITLE
feat(video): 改进融合主题细节页面的文本颜色和背景样式

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/TmdbHeaderView.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/TmdbHeaderView.java
@@ -1398,7 +1398,7 @@ public class TmdbHeaderView {
     }
 
     private void styleFusionBackdropLabels(boolean dark) {
-        for (int id : BACKDROP_SECTION_LABELS) styleFusionBackdropText(id, dark ? COLOR_FUSION_BACKDROP_TEXT : 0xFF12202D, dark);
+        for (int id : BACKDROP_SECTION_LABELS) styleFusionBackdropText(id, COLOR_FUSION_BACKDROP_TEXT, true);
     }
 
     private void styleFusionExternalLinks(boolean dark) {
@@ -1461,12 +1461,18 @@ public class TmdbHeaderView {
         if (view == null) return;
         view.setTextColor(color);
         if (shadow) applyFusionTextShadow(view);
+        else if (Setting.isFusionDetailPage() && isLightDetailChrome()) applyFusionLightTextShadow(view);
         else clearTextShadow(view);
     }
 
     private void applyFusionTextShadow(TextView view) {
         if (view == null) return;
         view.setShadowLayer(ResUtil.dp2px(2), 0, ResUtil.dp2px(1), COLOR_FUSION_TEXT_SHADOW);
+    }
+
+    private void applyFusionLightTextShadow(TextView view) {
+        if (view == null) return;
+        view.setShadowLayer(ResUtil.dp2px(2), 0, ResUtil.dp2px(1), 0xCCFFFFFF);
     }
 
     private void clearBackdropTextShadows() {
@@ -1818,9 +1824,15 @@ public class TmdbHeaderView {
         linkItem.setPadding(0, 12, 0, 12);
         linkItem.setClickable(true);
         linkItem.setFocusable(true);
+        android.graphics.drawable.GradientDrawable contentBackground = null;
+        if (lightChrome) {
+            contentBackground = new android.graphics.drawable.GradientDrawable();
+            contentBackground.setColor(0x40FFFFFF);
+            contentBackground.setCornerRadius(ResUtil.dp2px(10));
+        }
         android.graphics.drawable.Drawable background = new android.graphics.drawable.RippleDrawable(
                 android.content.res.ColorStateList.valueOf(lightChrome ? 0x1A12202D : 0x33FFFFFF),
-                null,
+                contentBackground,
                 null
         );
         linkItem.setBackground(background);

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -1024,6 +1024,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
             mBinding.actor.setVisibility(View.GONE);
             mBinding.contentLayout.setVisibility(View.GONE);
         }
+        applyFusionNativeTextColors();
     }
 
     private void setText(TextView view, int resId, String text) {
@@ -1031,7 +1032,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         view.setText(Sniffer.buildClickable(resId > 0 ? getString(resId, text) : text, this::clickableSpan), TextView.BufferType.SPANNABLE);
         view.setVisibility(text.isEmpty() ? View.GONE : View.VISIBLE);
         if (view == mBinding.content) setContentVisible();
-        view.setLinkTextColor(Color.WHITE);
+        view.setLinkTextColor(Setting.isFusionDetailPage() && isFusionLightTheme() ? 0xFF1D8F5A : Color.WHITE);
         CustomMovement.bind(view);
     }
 
@@ -2675,7 +2676,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     }
 
     private void cycleFusionTheme() {
-        Setting.putTmdbDetailTheme(Setting.nextTmdbDetailTheme(Setting.getTmdbDetailTheme()));
+        Setting.putTmdbDetailTheme(isFusionLightTheme() ? 1 : 2);
         applyFusionThemeSurface();
         updateFusionThemeButton();
         if (mTmdbHeaderView != null && mTmdbUIAdapter != null && mTmdbUIAdapter.isLoaded()) {
@@ -2698,6 +2699,24 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mBinding.scroll.setBackgroundColor(Color.TRANSPARENT);
         mBinding.swipeLayout.setBackgroundColor(Color.TRANSPARENT);
         mBinding.progressLayout.setBackgroundColor(Color.TRANSPARENT);
+        applyFusionNativeTextColors();
+    }
+
+    private void applyFusionNativeTextColors() {
+        if (!Setting.isFusionDetailPage() || mBinding.nativeContentContainer == null) return;
+        tintFusionNativeTextTree(mBinding.nativeContentContainer, isFusionLightTheme());
+    }
+
+    private void tintFusionNativeTextTree(View view, boolean light) {
+        if (view instanceof RecyclerView) return;
+        if (view instanceof TextView textView) {
+            textView.setTextColor(light ? 0xFF12202D : 0xFFFFFFFF);
+            textView.setLinkTextColor(light ? 0xFF1D8F5A : Color.WHITE);
+            if (light) textView.setShadowLayer(0, 0, 0, 0);
+            else textView.setShadowLayer(ResUtil.dp2px(2), 0, ResUtil.dp2px(1), 0xB0000000);
+        }
+        if (!(view instanceof ViewGroup group)) return;
+        for (int i = 0; i < group.getChildCount(); i++) tintFusionNativeTextTree(group.getChildAt(i), light);
     }
 
     private void updateFusionThemeButton() {
@@ -2717,15 +2736,14 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     }
 
     private String fusionThemeLabel() {
-        if (Setting.isTmdbCinemaStyle()) return getString(R.string.detail_theme_dark);
         int theme = Setting.getTmdbDetailTheme();
+        if (Setting.isTmdbCinemaStyle()) return Setting.resolveTmdbDetailLightTheme(theme, isSystemNight()) ? getString(R.string.detail_theme_light) : getString(R.string.detail_theme_dark);
         if (theme == 1) return getString(R.string.detail_theme_dark);
         if (theme == 2) return getString(R.string.detail_theme_light);
         return getString(R.string.detail_theme_auto);
     }
 
     private boolean isFusionLightTheme() {
-        if (Setting.isTmdbCinemaStyle()) return false;
         return Setting.resolveTmdbDetailLightTheme(Setting.getTmdbDetailTheme(), isSystemNight());
     }
 

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/holder/EpisodeGridHolder.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/holder/EpisodeGridHolder.java
@@ -63,8 +63,7 @@ public class EpisodeGridHolder extends BaseEpisodeHolder {
         binding.text.setVisibility(View.GONE);
         binding.card.setVisibility(View.VISIBLE);
         binding.card.setSelected(item.isSelected());
-        binding.card.setOnClickListener(v -> listener.onItemClick(item));
-        bindDetailLongClick(item, binding.getRoot(), binding.card, binding.imageFrame, binding.still, binding.textPanel, binding.cardTitle, binding.overview);
+        bindCardActions(item, binding.getRoot(), binding.card, binding.imageFrame, binding.still, binding.textPanel, binding.cardTitle, binding.overview);
 
         binding.cardTitle.setText(EpisodeAdapter.getTitle(item));
         binding.cardTitle.setSelected(item.isSelected());
@@ -122,6 +121,15 @@ public class EpisodeGridHolder extends BaseEpisodeHolder {
             view.setOnTouchListener(null);
             view.setOnLongClickListener(longClickListener);
         }
+    }
+
+    private void bindCardActions(Episode item, View... views) {
+        View.OnClickListener clickListener = view -> listener.onItemClick(item);
+        for (View view : views) {
+            if (view == null) continue;
+            view.setOnClickListener(clickListener);
+        }
+        bindDetailLongClick(item, views);
     }
 
     private FragmentActivity getActivity(View view) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/holder/EpisodeHoriHolder.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/holder/EpisodeHoriHolder.java
@@ -46,8 +46,7 @@ public class EpisodeHoriHolder extends BaseEpisodeHolder {
             binding.card.setVisibility(View.VISIBLE);
 
             binding.card.setSelected(item.isSelected());
-            binding.card.setOnClickListener(v -> listener.onItemClick(item));
-            bindDetailLongClick(item, binding.getRoot(), binding.card, binding.still, binding.cardTitle, binding.overview);
+            bindCardActions(item, binding.getRoot(), binding.card, binding.still, binding.cardTitle, binding.overview);
 
             // 标题
             binding.cardTitle.setText(EpisodeAdapter.getTitle(item));
@@ -104,6 +103,15 @@ public class EpisodeHoriHolder extends BaseEpisodeHolder {
             view.setOnTouchListener(null);
             view.setOnLongClickListener(longClickListener);
         }
+    }
+
+    private void bindCardActions(Episode item, View... views) {
+        View.OnClickListener clickListener = view -> listener.onItemClick(item);
+        for (View view : views) {
+            if (view == null) continue;
+            view.setOnClickListener(clickListener);
+        }
+        bindDetailLongClick(item, views);
     }
 
     private FragmentActivity getActivity(View view) {


### PR DESCRIPTION
- 修复了融合主题背景标签的颜色设置问题，统一使用COLOR_FUSION_BACKDROP_TEXT
- 为轻量详情页添加了浅色文本阴影效果，增强可读性
- 在外部链接中添加了浅色主题下的文本阴影支持
- 为视频详情页面的原生内容容器应用了融合主题的文本颜色
- 实现了递归遍历视图树来应用融合主题文本颜色的功能
- 优化了链接文本颜色在不同主题下的显示效果
- 调整了融合主题切换逻辑，使其更符合当前主题状态
- 更新了融合主题标签的显示逻辑，正确显示当前主题模式

refactor(episode): 统一卡片点击事件绑定方式

- 将剧集网格和水平布局中的卡片点击事件绑定重构为统一的bindCardActions方法
- 避免重复的setOnClickListener调用，提高代码复用性
- 保持原有的长按功能不变，确保交互体验一致