### PR TITLE
feat(cast): 添加演员卡片焦点样式效果

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/presenter/TmdbCastPresenter.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/presenter/TmdbCastPresenter.java
@@ -1,5 +1,6 @@
 package com.fongmi.android.tv.ui.presenter;
 
+import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -9,8 +10,13 @@ import androidx.leanback.widget.Presenter;
 import com.bumptech.glide.Glide;
 import com.fongmi.android.tv.bean.TmdbPerson;
 import com.fongmi.android.tv.databinding.AdapterTmdbCastBinding;
+import com.fongmi.android.tv.utils.ResUtil;
+import com.google.android.material.card.MaterialCardView;
 
 public class TmdbCastPresenter extends Presenter {
+
+    private static final int STROKE_NORMAL = 0x33FFFFFF;
+    private static final int STROKE_FOCUSED = 0xFFFFFFFF;
 
     private final OnClickListener mListener;
 
@@ -31,6 +37,7 @@ public class TmdbCastPresenter extends Presenter {
     public void onBindViewHolder(Presenter.ViewHolder viewHolder, Object item) {
         TmdbPerson person = (TmdbPerson) item;
         ViewHolder holder = (ViewHolder) viewHolder;
+        bindFocusStyle(holder.binding.getRoot());
         holder.binding.name.setText(person.getName());
         holder.binding.role.setText(person.getSubtitle());
         if (!person.getProfileUrl().isEmpty()) {
@@ -43,6 +50,18 @@ public class TmdbCastPresenter extends Presenter {
 
     @Override
     public void onUnbindViewHolder(Presenter.ViewHolder viewHolder) {
+    }
+
+    private void bindFocusStyle(MaterialCardView card) {
+        applyFocusStyle(card, card.hasFocus());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) card.setDefaultFocusHighlightEnabled(false);
+        card.setOnFocusChangeListener((view, focused) -> applyFocusStyle(card, focused));
+    }
+
+    private void applyFocusStyle(MaterialCardView card, boolean focused) {
+        card.setStrokeColor(focused ? STROKE_FOCUSED : STROKE_NORMAL);
+        card.setStrokeWidth(ResUtil.dp2px(focused ? 3 : 1));
+        card.setCardElevation(0);
     }
 
     public static class ViewHolder extends Presenter.ViewHolder {

--- a/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
@@ -302,6 +302,10 @@ public class PlayerManager implements ParseCallback {
         return playerType == PlayerSetting.IJK;
     }
 
+    public boolean useNativeVideoOutput() {
+        return PlayerSetting.useNativeVideoOutput(playerType);
+    }
+
     private String getPlayerText(int type) {
         String[] items = ResUtil.getStringArray(R.array.select_player_kernel);
         return type >= 0 && type < items.length ? items[type] : items[PlayerSetting.EXO];

--- a/app/src/main/java/com/fongmi/android/tv/setting/PlayerSetting.java
+++ b/app/src/main/java/com/fongmi/android/tv/setting/PlayerSetting.java
@@ -48,6 +48,14 @@ public class PlayerSetting {
         return Prefers.getInt("render", 0);
     }
 
+    public static int getRender(int player) {
+        return useNativeVideoOutput(player) ? 0 : getRender();
+    }
+
+    public static boolean useNativeVideoOutput(int player) {
+        return player == IJK || player == SYSTEM;
+    }
+
     public static void putRender(int render) {
         Prefers.put("render", render);
     }

--- a/app/src/main/java/com/fongmi/android/tv/setting/Setting.java
+++ b/app/src/main/java/com/fongmi/android/tv/setting/Setting.java
@@ -685,7 +685,7 @@ public class Setting {
     }
 
     public static int getTmdbDetailTheme() {
-        return clampTmdbDetailTheme(Prefers.getInt("tmdb_detail_theme", 0));
+        return clampTmdbDetailTheme(Prefers.getInt("tmdb_detail_theme", 2));
     }
 
     public static void putTmdbDetailTheme(int theme) {
@@ -701,18 +701,16 @@ public class Setting {
     }
 
     public static int nextTmdbDetailTheme(int theme) {
-        return (clampTmdbDetailTheme(theme) + 1) % 3;
+        return clampTmdbDetailTheme(theme) == 2 ? 1 : 2;
     }
 
     public static boolean resolveTmdbDetailLightTheme(int theme, boolean systemNight) {
         int value = clampTmdbDetailTheme(theme);
-        if (value == 1) return false;
-        if (value == 2) return true;
-        return !systemNight;
+        return value != 1;
     }
 
     static int clampTmdbDetailTheme(int theme) {
-        return Math.max(0, Math.min(theme, 2));
+        return theme == 1 ? 1 : 2;
     }
 
     public static boolean isHomeHistory() {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
@@ -278,7 +278,7 @@ public abstract class PlaybackActivity extends BaseActivity implements MediaCont
         if (getExoView().getPlayer() == null) {
             getExoView().setPlayer(player().getPlayer());
             syncShutter();
-            if (player().isIjk()) getExoView().post(this::syncShutter);
+            if (player().useNativeVideoOutput()) getExoView().post(this::syncShutter);
         }
         onSurfaceAttached();
     }
@@ -289,9 +289,9 @@ public abstract class PlaybackActivity extends BaseActivity implements MediaCont
 
     private void syncShutter(boolean restoreExo) {
         if (mService == null) return;
-        boolean ijk = player().isIjk();
+        boolean nativeOutput = player().useNativeVideoOutput();
         View shutter = getExoView().findViewById(androidx.media3.ui.R.id.exo_shutter);
-        if (ijk) {
+        if (nativeOutput) {
             getExoView().setShutterBackgroundColor(Color.TRANSPARENT);
             if (shutter != null) shutter.setVisibility(View.GONE);
         } else if (restoreExo) {
@@ -311,8 +311,7 @@ public abstract class PlaybackActivity extends BaseActivity implements MediaCont
     }
 
     private int getRender() {
-        if (mService != null && player().isIjk()) return 0;
-        return PlayerSetting.getRender();
+        return mService == null ? PlayerSetting.getRender() : PlayerSetting.getRender(player().getPlayerType());
     }
 
     private void releasePlaybackService() {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -1242,10 +1242,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     private int themeModeLabel() {
-        if (isCinemaMode()) return lightTheme ? R.string.detail_theme_light : R.string.detail_theme_dark;
-        if (detailThemeMode == 1) return R.string.detail_theme_dark;
-        if (detailThemeMode == 2) return R.string.detail_theme_light;
-        return R.string.detail_theme_auto;
+        return lightTheme ? R.string.detail_theme_light : R.string.detail_theme_dark;
     }
 
     private void setCard(MaterialCardView card, int background, int stroke) {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbPersonActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbPersonActivity.java
@@ -523,6 +523,7 @@ public class TmdbPersonActivity extends BaseActivity {
         tint(binding.worksCount, secondary);
         tint(binding.empty, secondary);
         binding.biography.setTextColor(light ? 0xDD12202D : 0xDDEAF2F8);
+        updateFilters();
     }
 
     private void tint(TextView view, int color) {
@@ -530,10 +531,7 @@ public class TmdbPersonActivity extends BaseActivity {
     }
 
     private boolean resolveLightTheme() {
-        int mode = Setting.getTmdbDetailTheme();
-        if (mode == 1) return false;
-        if (mode == 2) return true;
-        return (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) != Configuration.UI_MODE_NIGHT_YES;
+        return Setting.resolveTmdbDetailLightTheme(Setting.getTmdbDetailTheme(), (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES);
     }
 
     private void showPhotoDialog(int position, String url) {

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/TmdbPersonDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/TmdbPersonDialog.java
@@ -6,6 +6,7 @@ import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.text.TextUtils;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,6 +17,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.widget.NestedScrollView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -65,6 +67,7 @@ public class TmdbPersonDialog {
     private LinearLayout filterSection;
     private RecyclerView photosRecycler;
     private RecyclerView worksRecycler;
+    private NestedScrollView contentScroll;
     private ChipGroup departmentChips;
     private ChipGroup mediaChips;
 
@@ -115,6 +118,7 @@ public class TmdbPersonDialog {
 
         dialog.show();
         applyWindowAttrs();
+        bringDialogToFront();
         requestInitialFocus();
         loadPersonDetail();
     }
@@ -124,12 +128,21 @@ public class TmdbPersonDialog {
         Window window = dialog.getWindow();
         if (window != null) {
             window.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT);
+            window.setGravity(Gravity.CENTER);
             window.setBackgroundDrawableResource(android.R.color.transparent);
             window.setDimAmount(0f);
             window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) window.getDecorView().setDefaultFocusHighlightEnabled(false);
             window.getDecorView().setStateListAnimator(null);
         }
+    }
+
+    private void bringDialogToFront() {
+        if (dialog == null || dialog.getWindow() == null) return;
+        View decor = dialog.getWindow().getDecorView();
+        decor.bringToFront();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) decor.setTranslationZ(1000f);
+        decor.post(decor::bringToFront);
     }
 
     private void initView(View view) {
@@ -143,6 +156,7 @@ public class TmdbPersonDialog {
         filterSection = view.findViewById(R.id.filterSection);
         photosRecycler = view.findViewById(R.id.photosRecycler);
         worksRecycler = view.findViewById(R.id.worksRecycler);
+        contentScroll = view.findViewById(R.id.contentScroll);
         departmentChips = view.findViewById(R.id.departmentChips);
         mediaChips = view.findViewById(R.id.mediaChips);
         View closeBtn = view.findViewById(R.id.closeBtn);
@@ -234,7 +248,7 @@ public class TmdbPersonDialog {
             if (dialog != null && dialog.isShowing()) {
                 photoAdapter.setItems(photos);
                 photosSection.setVisibility(View.VISIBLE);
-                requestInitialFocus();
+                keepTopPositionDuringInitialRender();
             }
         });
     }
@@ -412,26 +426,26 @@ public class TmdbPersonDialog {
         workAdapter.setItems(items.subList(0, initialCount));
         worksRecycler.scrollToPosition(0);
         worksRecycler.setVisibility(items.isEmpty() ? View.GONE : View.VISIBLE);
-        requestInitialFocus();
+        keepTopPositionDuringInitialRender();
     }
 
     private void requestInitialFocus() {
         if (!Util.isLeanback() || initialFocusDone || dialog == null || !dialog.isShowing()) return;
-        if (requestRecyclerFocus(photosRecycler) || requestRecyclerFocus(worksRecycler)) initialFocusDone = true;
+        View panel = dialog.findViewById(R.id.panel);
+        View root = dialog.findViewById(R.id.root);
+        View target = panel != null ? panel : root;
+        if (target == null) return;
+        target.setFocusable(true);
+        target.setFocusableInTouchMode(true);
+        if (target.requestFocus()) initialFocusDone = true;
+        keepTopPositionDuringInitialRender();
     }
 
-    private boolean requestRecyclerFocus(RecyclerView recyclerView) {
-        if (recyclerView == null || recyclerView.getVisibility() != View.VISIBLE) return false;
-        RecyclerView.Adapter<?> adapter = recyclerView.getAdapter();
-        if (adapter == null || adapter.getItemCount() == 0) return false;
-        RecyclerView.ViewHolder holder = recyclerView.findViewHolderForAdapterPosition(0);
-        if (holder != null && holder.itemView.requestFocus()) return true;
-        recyclerView.post(() -> {
-            if (initialFocusDone || dialog == null || !dialog.isShowing()) return;
-            RecyclerView.ViewHolder postedHolder = recyclerView.findViewHolderForAdapterPosition(0);
-            if (postedHolder != null && postedHolder.itemView.requestFocus()) initialFocusDone = true;
-        });
-        return false;
+    private void keepTopPositionDuringInitialRender() {
+        if (!Util.isLeanback() || contentScroll == null || dialog == null || !dialog.isShowing()) return;
+        bringDialogToFront();
+        contentScroll.scrollTo(0, 0);
+        contentScroll.post(() -> contentScroll.scrollTo(0, 0));
     }
 
     /**

--- a/app/src/main/res/layout/adapter_tmdb_cast.xml
+++ b/app/src/main/res/layout/adapter_tmdb_cast.xml
@@ -9,7 +9,6 @@
     android:clickable="true"
     android:focusable="true"
     android:focusableInTouchMode="true"
-    android:foreground="?attr/selectableItemBackground"
     app:cardBackgroundColor="#16202A"
     app:cardCornerRadius="14dp"
     app:cardElevation="0dp"

--- a/app/src/main/res/layout/dialog_tmdb_person.xml
+++ b/app/src/main/res/layout/dialog_tmdb_person.xml
@@ -24,6 +24,7 @@
         app:strokeWidth="1dp">
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/contentScroll"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fillViewport="true"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1138,7 +1138,6 @@
     <string name="detail_source_empty">暂无可用站源</string>
     <string name="detail_source_episode_empty">暂无可用选集或站源</string>
     <string name="detail_source_searching">正在搜索站源...</string>
-    <string name="detail_theme_auto">主题：自动</string>
     <string name="detail_theme_dark">主题：深色</string>
     <string name="detail_theme_light">主题：浅色</string>
     <string name="detail_tmdb_cast">演员</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1077,7 +1077,6 @@
     <string name="detail_source_empty">暫無可用站源</string>
     <string name="detail_source_episode_empty">暫無可用選集或站源</string>
     <string name="detail_source_searching">正在搜尋站源...</string>
-    <string name="detail_theme_auto">主題：自動</string>
     <string name="detail_theme_dark">主題：深色</string>
     <string name="detail_theme_light">主題：淺色</string>
     <string name="detail_tmdb_cast">演員</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1154,7 +1154,6 @@
     <string name="detail_source_empty">No available source</string>
     <string name="detail_source_episode_empty">No available episodes or source</string>
     <string name="detail_source_searching">Searching sources...</string>
-    <string name="detail_theme_auto">Theme: Auto</string>
     <string name="detail_theme_dark">Theme: Dark</string>
     <string name="detail_theme_light">Theme: Light</string>
     <string name="detail_tmdb_cast">Cast</string>

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -949,12 +949,14 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mTmdbAutoDialogShown = false;
         if (tmdbMode) {
             hideTmdbHeader();
+            setNativeDetailInfoVisible(false);
             mBinding.quick.setVisibility(View.GONE);
             mBinding.search.setVisibility(View.GONE);
             if (mBinding.videoShadow != null) mBinding.videoShadow.setVisibility(View.GONE);
             mBinding.progressLayout.showProgress();
         } else {
             restoreFlagAndEpisodeFromTmdb();
+            setNativeDetailInfoVisible(true);
             mBinding.search.setVisibility(View.VISIBLE);
             if (mBinding.videoShadow != null) mBinding.videoShadow.setVisibility(View.VISIBLE);
             android.util.Log.d("VideoActivity", "setDetail - 调用 showContent()");
@@ -1008,23 +1010,28 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         // 基于 TMDB 开关和配置是否就绪
         boolean tmdbMode = shouldUseTmdbDetailLayout();
         if (!tmdbMode) {
-            mBinding.name.setVisibility(View.VISIBLE);
-            mBinding.contentLayout.setVisibility(View.VISIBLE);
+            setNativeDetailInfoVisible(true);
             setText(mBinding.director, R.string.detail_director, item.getDirector());
             setText(mBinding.actor, R.string.detail_actor, item.getActor());
             setText(mBinding.remark, 0, item.getRemarks());
             setOther(mBinding.other, item);
             setText(mBinding.content, 0, item.getContent());
         } else {
-            // TMDB 模式下确保隐藏原生内容的各个元素
-            mBinding.name.setVisibility(View.GONE);
-            mBinding.remark.setVisibility(View.GONE);
-            mBinding.other.setVisibility(View.GONE);
-            mBinding.director.setVisibility(View.GONE);
-            mBinding.actor.setVisibility(View.GONE);
-            mBinding.contentLayout.setVisibility(View.GONE);
+            setNativeDetailInfoVisible(false);
         }
         applyFusionNativeTextColors();
+    }
+
+    private void setNativeDetailInfoVisible(boolean visible) {
+        int visibility = visible ? View.VISIBLE : View.GONE;
+        mBinding.name.setVisibility(visibility);
+        mBinding.remark.setVisibility(visibility);
+        mBinding.site.setVisibility(visibility);
+        mBinding.other.setVisibility(visibility);
+        mBinding.director.setVisibility(visibility);
+        mBinding.actor.setVisibility(visibility);
+        mBinding.contentLayout.setVisibility(visibility);
+        mBinding.actionRow.setVisibility(visibility);
     }
 
     private void setText(TextView view, int resId, String text) {
@@ -2596,8 +2603,8 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
             }
         });
 
-        // TMDB 模式下：隐藏原生内容元素（但保持容器可见，因为 TMDB 内容也在里面）
-        mBinding.contentLayout.setVisibility(View.GONE);
+        // TMDB 模式下：隐藏原生详情信息（但保持容器可见，因为 TMDB 内容也在里面）
+        setNativeDetailInfoVisible(false);
         mBinding.quick.setVisibility(View.GONE);
         mBinding.search.setVisibility(View.GONE);
         if (mBinding.videoShadow != null) mBinding.videoShadow.setVisibility(View.GONE);  // 隐藏播放器下方的阴影
@@ -2736,11 +2743,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     }
 
     private String fusionThemeLabel() {
-        int theme = Setting.getTmdbDetailTheme();
-        if (Setting.isTmdbCinemaStyle()) return Setting.resolveTmdbDetailLightTheme(theme, isSystemNight()) ? getString(R.string.detail_theme_light) : getString(R.string.detail_theme_dark);
-        if (theme == 1) return getString(R.string.detail_theme_dark);
-        if (theme == 2) return getString(R.string.detail_theme_light);
-        return getString(R.string.detail_theme_auto);
+        return isFusionLightTheme() ? getString(R.string.detail_theme_light) : getString(R.string.detail_theme_dark);
     }
 
     private boolean isFusionLightTheme() {
@@ -2761,6 +2764,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mTmdbContentLoaded = true;
         hideTmdbHeader();
         restoreFlagAndEpisodeFromTmdb();
+        setNativeDetailInfoVisible(true);
         mBinding.search.setVisibility(View.VISIBLE);
         if (mBinding.videoShadow != null) mBinding.videoShadow.setVisibility(View.VISIBLE);
         setText(item);
@@ -3024,7 +3028,6 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     private View[] getTmdbMovableViews() {
         return new View[]{
-                mBinding.site,
                 mBinding.flagTitleBar,
                 mBinding.flag,
                 mBinding.episodeTitleBar,

--- a/app/src/test/java/com/fongmi/android/tv/setting/PlayerSettingTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/setting/PlayerSettingTest.java
@@ -1,0 +1,23 @@
+package com.fongmi.android.tv.setting;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PlayerSettingTest {
+
+    @Test
+    public void nativeVideoOutput_includesIjkAndSystemPlayers() {
+        assertFalse(PlayerSetting.useNativeVideoOutput(PlayerSetting.EXO));
+        assertTrue(PlayerSetting.useNativeVideoOutput(PlayerSetting.IJK));
+        assertTrue(PlayerSetting.useNativeVideoOutput(PlayerSetting.SYSTEM));
+    }
+
+    @Test
+    public void nativeVideoOutput_forcesSurfaceRender() {
+        assertEquals(0, PlayerSetting.getRender(PlayerSetting.IJK));
+        assertEquals(0, PlayerSetting.getRender(PlayerSetting.SYSTEM));
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/setting/SettingDetailModeTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/setting/SettingDetailModeTest.java
@@ -30,26 +30,26 @@ public class SettingDetailModeTest {
     }
 
     @Test
-    public void legacyDetailTheme_clampsToOldAutoDarkLightRange() {
-        assertEquals(0, Setting.clampTmdbDetailTheme(-1));
-        assertEquals(0, Setting.clampTmdbDetailTheme(0));
+    public void detailTheme_migratesUnknownAndLegacyAutoToLight() {
+        assertEquals(2, Setting.clampTmdbDetailTheme(-1));
+        assertEquals(2, Setting.clampTmdbDetailTheme(0));
         assertEquals(1, Setting.clampTmdbDetailTheme(1));
         assertEquals(2, Setting.clampTmdbDetailTheme(2));
         assertEquals(2, Setting.clampTmdbDetailTheme(3));
     }
 
     @Test
-    public void legacyDetailTheme_cyclesAutoDarkLight() {
+    public void detailTheme_cyclesOnlyBetweenLightAndDark() {
         assertEquals(1, Setting.nextTmdbDetailTheme(0));
         assertEquals(2, Setting.nextTmdbDetailTheme(1));
-        assertEquals(0, Setting.nextTmdbDetailTheme(2));
-        assertEquals(0, Setting.nextTmdbDetailTheme(9));
+        assertEquals(1, Setting.nextTmdbDetailTheme(2));
+        assertEquals(1, Setting.nextTmdbDetailTheme(9));
     }
 
     @Test
-    public void legacyDetailTheme_resolvesAutoAgainstSystemNightMode() {
+    public void detailTheme_resolvesLegacyAutoAsLightRegardlessOfSystemMode() {
         assertTrue(Setting.resolveTmdbDetailLightTheme(0, false));
-        assertFalse(Setting.resolveTmdbDetailLightTheme(0, true));
+        assertTrue(Setting.resolveTmdbDetailLightTheme(0, true));
         assertFalse(Setting.resolveTmdbDetailLightTheme(1, false));
         assertFalse(Setting.resolveTmdbDetailLightTheme(1, true));
         assertTrue(Setting.resolveTmdbDetailLightTheme(2, false));

--- a/app/src/test/java/com/fongmi/android/tv/ui/helper/TmdbCinemaThemeTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/helper/TmdbCinemaThemeTest.java
@@ -9,9 +9,9 @@ import static org.junit.Assert.assertTrue;
 public class TmdbCinemaThemeTest {
 
     @Test
-    public void resolveLight_followsAutoDarkLightThemeModes() {
+    public void resolveLight_usesOnlyLightAndDarkThemeModes() {
         assertTrue(TmdbCinemaTheme.resolveLight(0, false));
-        assertFalse(TmdbCinemaTheme.resolveLight(0, true));
+        assertTrue(TmdbCinemaTheme.resolveLight(0, true));
         assertFalse(TmdbCinemaTheme.resolveLight(1, false));
         assertTrue(TmdbCinemaTheme.resolveLight(2, true));
     }


### PR DESCRIPTION
为演员卡片添加聚焦时的边框高亮效果，提升TV端用户界面体验，
通过MaterialCardView的strokeColor和strokeWidth属性实现视觉反馈

---

fix(player): 修复原生视频输出渲染设置问题

调整播放器渲染逻辑，确保IJK和系统播放器在使用原生视频输出时
正确应用surface渲染模式，避免视频显示异常

---

refactor(setting): 简化TMDB详情主题模式配置

移除自动主题模式，将主题选择简化为仅浅色和深色两种模式，
优化主题切换逻辑并更新相关测试用例

---

feat(dialog): 优化TMDB人物对话框显示和滚动行为

改进人物详情对话框的窗口层级管理，添加内容滚动视图以改善
初始渲染时的定位问题，并优化对话框前置显示效果

---

style(cast): 移除演员适配器前景波纹效果

移除演员卡片的可选择项目背景，保持统一的视觉风格

---

test(setting): 添加播放器渲染设置测试用例

增加针对原生视频输出和渲染设置的单元测试，确保不同播放器
类型下的渲染行为符合预期