### PR TITLE
Sync upstream and add subtitle matching

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebHomeTV
 
-WebHomeTV 是基于 FongMi / CatVod 生态二次开发的 Android 影音应用,保留原有点播、直播、Spider、解析、投屏、本地 HTTP 服务等能力,并重点增强了 **WebHome 自定义首页**、**App Native SDK**、**管理页面**、**远程托管**、**WebHome 扩展**、**登录态学习/同步**、**网盘链接检测**、**站点健康排序**、**观影记录同步** 和 **Nostr/TMDB 推荐首页**。
+WebHomeTV 是基于 [FongMi](https://github.com/FongMi/TV) / CatVod 生态二次开发的 Android 影音应用,保留原有点播、直播、Spider、解析、投屏、本地 HTTP 服务等能力,并重点增强了 **WebHome 自定义首页**、**App Native SDK**、**管理页面**、**远程托管**、**WebHome 扩展**、**登录态学习/同步**、**网盘链接检测**、**站点健康排序**、**观影记录同步** 和 **Nostr/TMDB 推荐首页**。
 
 项目的核心目标不是替换 CSP/Spider 体系,而是让 CSP 站点首页变成一个真正可开发的网页应用:开发者用 HTML/CSS/JavaScript 定制首页,再通过 App 暴露的 Native 能力完成搜索、播放、跨域请求、资源代理、最近观看、网盘检测和状态同步。
 
@@ -306,7 +306,7 @@ Release/apk/leanback-armeabi_v7a.apk
 
 ### GitHub 手动发布
 
-仓库内置 `.github/workflows/android-release.yml`,只支持在 GitHub Actions 页面手动触发,不会在每次 push 代码时自动打包。默认 tag 会按当前 `versionName` 生成 `v5.5.2-sdk28-yyyyMMddHHmm`,也可以手动填写同格式 tag。
+仓库内置 `.github/workflows/android-release.yml`,只支持在 GitHub Actions 页面手动触发,不会在每次 push 代码时自动打包。默认 tag 会按当前 `versionName` 生成 `v5.5.4-sdk28-yyyyMMddHHmm`,也可以手动填写同格式 tag。
 
 工作流会构建 4 个 release APK,生成同名更新清单 JSON,发布到 GitHub Release,并可同步到 CNB 镜像仓库 `apk/` 目录。正式发布前建议在 GitHub Secrets 配置:
 
@@ -363,7 +363,7 @@ other/        Logo 图片和辅助工具
 
 ### 上游基线
 
-本项目二开起始于原版影视 commit `bec0f1d2fc22f394ba05f8e63a9ef2ba7ecbba0e`,当前已同步合并到原版影视 commit `1242ac7b307793569e843563b5442b24688a84c7`。
+本项目二开起始于[原版影视](https://github.com/FongMi/TV) commit `bec0f1d2fc22f394ba05f8e63a9ef2ba7ecbba0e`,当前已同步合并到[原版影视](https://github.com/FongMi/TV) commit `8fb8279873124348d77b515dc79723ed768c675d`。
 
 ### 友情链接
 [![Linux.do](https://img.shields.io/badge/-Linux.do-1c1c1e?style=flat-square&logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMiIgYmFzZVByb2ZpbGU9InRpbnktcHMiIHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4IiB2aWV3Qm94PSIwIDAgMTIwIDEyMCI+CiAgPGNsaXBQYXRoIGlkPSJhIj4KICAgIDxjaXJjbGUgY3g9IjYwIiBjeT0iNjAiIHI9IjQ3Ii8+CiAgPC9jbGlwUGF0aD4KICA8Y2lyY2xlIGZpbGw9IiNmMGYwZjAiIGN4PSI2MCIgY3k9IjYwIiByPSI1MCIvPgogIDxyZWN0IGZpbGw9IiMxYzFjMWUiIGNsaXAtcGF0aD0idXJsKCNhKSIgeD0iMTAiIHk9IjEwIiB3aWR0aD0iMTAwIiBoZWlnaHQ9IjMwIi8+CiAgPHJlY3QgZmlsbD0iI2YwZjBmMCIgY2xpcC1wYXRoPSJ1cmwoI2EpIiB4PSIxMCIgeT0iNDAiIHdpZHRoPSIxMDAiIGhlaWdodD0iNDAiLz4KICA8cmVjdCBmaWxsPSIjZmZiMDAzIiBjbGlwLXBhdGg9InVybCgjYSkiIHg9IjEwIiB5PSI4MCIgd2lkdGg9IjEwMCIgaGVpZ2h0PSIzMCIvPgo8L3N2Zz4K)](https://linux.do/)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "com.silent.android.webhtv"
         minSdk libs.versions.minSdk.get().toInteger()
         targetSdk libs.versions.targetSdk.get().toInteger()
-        versionCode 552
-        versionName "5.5.2"
+        versionCode 554
+        versionName "5.5.4"
         buildConfigField "String", "BUILD_TIME", "\"${buildTime}\""
         buildConfigField "String", "BUILD_TAG", "\"${releaseTag}\""
         javaCompileOptions {

--- a/app/src/leanback/AndroidManifest.xml
+++ b/app/src/leanback/AndroidManifest.xml
@@ -187,6 +187,11 @@
             android:screenOrientation="sensorLandscape" />
 
         <activity
+            android:name=".ui.activity.SettingSubtitleActivity"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
+            android:screenOrientation="sensorLandscape" />
+
+        <activity
             android:name=".ui.activity.SettingEnhanceActivity"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:screenOrientation="sensorLandscape" />

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
@@ -1154,7 +1154,10 @@ public class LiveActivity extends PlaybackActivity implements GroupAdapter.OnCli
     protected void onStart() {
         super.onStart();
         mClock.stop().start();
-        if (mOsd != null) mOsd.start();
+        if (mOsd != null) {
+            mOsd.setDiagnosticsVisible(PlayerSetting.isOsdDiagnostics());
+            mOsd.start();
+        }
     }
 
     @Override

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingActivity.java
@@ -113,6 +113,7 @@ public class SettingActivity extends BaseActivity implements ConfigListener, Sit
         mBinding.enhance.setOnClickListener(this::onEnhance);
         mBinding.player.setOnClickListener(this::onPlayer);
         mBinding.danmaku.setOnClickListener(this::onDanmaku);
+        mBinding.subtitle.setOnClickListener(this::onSubtitle);
         mBinding.personal.setOnClickListener(this::onPersonal);
         mBinding.restore.setOnClickListener(this::onRestore);
         mBinding.version.setOnClickListener(this::onVersion);
@@ -237,6 +238,10 @@ public class SettingActivity extends BaseActivity implements ConfigListener, Sit
 
     private void onDanmaku(View view) {
         SettingDanmakuActivity.start(this);
+    }
+
+    private void onSubtitle(View view) {
+        SettingSubtitleActivity.start(this);
     }
 
     private void onPersonal(View view) {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingPlayerActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingPlayerActivity.java
@@ -325,4 +325,5 @@ public class SettingPlayerActivity extends BaseActivity implements UaListener, B
         PlayerSetting.putBackground(PlayerSetting.isBackgroundOn() ? 0 : 1);
         mBinding.backgroundText.setText(getSwitch(PlayerSetting.isBackgroundOn()));
     }
+
 }

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingSubtitleActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingSubtitleActivity.java
@@ -1,0 +1,87 @@
+package com.fongmi.android.tv.ui.activity;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+
+import androidx.viewbinding.ViewBinding;
+
+import com.fongmi.android.tv.R;
+import com.fongmi.android.tv.databinding.ActivitySettingSubtitleBinding;
+import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.ui.base.BaseActivity;
+import com.fongmi.android.tv.ui.dialog.SubtitleSettingsDialog;
+import com.fongmi.android.tv.utils.ResUtil;
+
+public class SettingSubtitleActivity extends BaseActivity {
+
+    private ActivitySettingSubtitleBinding mBinding;
+    private String[] subtitleLanguageLabels;
+    private String[] subtitleLanguageValues;
+
+    public static void start(Activity activity) {
+        activity.startActivity(new Intent(activity, SettingSubtitleActivity.class));
+    }
+
+    private String getSwitch(boolean value) {
+        return getString(value ? R.string.setting_on : R.string.setting_off);
+    }
+
+    @Override
+    protected ViewBinding getBinding() {
+        return mBinding = ActivitySettingSubtitleBinding.inflate(getLayoutInflater());
+    }
+
+    @Override
+    protected void initView(Bundle savedInstanceState) {
+        mBinding.subtitleAutoMatch.requestFocus();
+        subtitleLanguageLabels = ResUtil.getStringArray(R.array.select_subtitle_language);
+        subtitleLanguageValues = ResUtil.getStringArray(R.array.select_subtitle_language_value);
+        mBinding.subtitleAutoMatchText.setText(getSwitch(Setting.isSubtitleAutoMatchEnabled()));
+        mBinding.subtitleLanguageText.setText(getSubtitleLanguageText());
+        mBinding.subtitleAssrtTokenText.setText(getSubtitleAssrtTokenText());
+    }
+
+    @Override
+    protected void initEvent() {
+        mBinding.subtitleAutoMatch.setOnClickListener(this::setSubtitleAutoMatch);
+        mBinding.subtitleLanguage.setOnClickListener(this::onSubtitleLanguage);
+        mBinding.subtitleAssrtToken.setOnClickListener(this::onSubtitleAssrtToken);
+    }
+
+    private void setSubtitleAutoMatch(View view) {
+        Setting.putSubtitleAutoMatchEnabled(!Setting.isSubtitleAutoMatchEnabled());
+        mBinding.subtitleAutoMatchText.setText(getSwitch(Setting.isSubtitleAutoMatchEnabled()));
+    }
+
+    private void onSubtitleLanguage(View view) {
+        SubtitleSettingsDialog.showPreferredLanguage(this, subtitleLanguageLabels, subtitleLanguageValues, Setting.getSubtitlePreferredLanguage(), value -> {
+            Setting.putSubtitlePreferredLanguage(value);
+            mBinding.subtitleLanguageText.setText(getSubtitleLanguageText());
+        });
+    }
+
+    private void onSubtitleAssrtToken(View view) {
+        SubtitleSettingsDialog.showAssrtToken(this, Setting.getSubtitleAssrtToken(), value -> {
+            Setting.putSubtitleAssrtToken(value);
+            mBinding.subtitleAssrtTokenText.setText(getSubtitleAssrtTokenText());
+        });
+    }
+
+    private String getSubtitleLanguageText() {
+        int index = getSubtitleLanguageIndex();
+        return subtitleLanguageLabels != null && index >= 0 && index < subtitleLanguageLabels.length ? subtitleLanguageLabels[index] : Setting.getSubtitlePreferredLanguage();
+    }
+
+    private int getSubtitleLanguageIndex() {
+        if (subtitleLanguageValues == null) return 0;
+        for (int i = 0; i < subtitleLanguageValues.length; i++) if (TextUtils.equals(subtitleLanguageValues[i], Setting.getSubtitlePreferredLanguage())) return i;
+        return 0;
+    }
+
+    private String getSubtitleAssrtTokenText() {
+        return getString(TextUtils.isEmpty(Setting.getSubtitleAssrtToken()) ? R.string.setting_unconfigured : R.string.setting_configured);
+    }
+}

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -93,7 +93,7 @@ import com.fongmi.android.tv.ui.custom.CustomSeekView;
 import com.fongmi.android.tv.ui.custom.PlayerOsdController;
 import com.fongmi.android.tv.ui.dialog.ContentDialog;
 import com.fongmi.android.tv.ui.dialog.DanmakuDialog;
-import com.fongmi.android.tv.ui.dialog.EpisodeDialog;
+import com.fongmi.android.tv.ui.dialog.EpisodeListDialog;
 import com.fongmi.android.tv.ui.dialog.QuickSearchDialog;
 import com.fongmi.android.tv.ui.dialog.SubtitleDialog;
 import com.fongmi.android.tv.ui.dialog.TmdbSearchDialog;
@@ -825,6 +825,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
         mActionButtons = new HashMap<>();
         addActionButton(PlayerButtonSetting.NEXT, mBinding.control.action.next);
         addActionButton(PlayerButtonSetting.PREV, mBinding.control.action.prev);
+        addActionButton(PlayerButtonSetting.EPISODES, mBinding.control.action.episodes);
         addActionButton(PlayerButtonSetting.RESET, mBinding.control.action.reset);
         addActionButton(PlayerButtonSetting.CHANGE, mBinding.control.action.change2);
         addActionButton(PlayerButtonSetting.FULLSCREEN, mBinding.control.action.fullscreen);
@@ -1322,6 +1323,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
         updateEpisodeFallbackStillUrl();
         mEpisodeAdapter.setUseTmdbCard(useTmdbCards);
         mEpisodeGridAdapter.setUseTmdbCard(useTmdbCards);
+        applyActionButtonVisibility();
         mEpisodeAdapter.addAll(items);
         mEpisodeGridAdapter.addAll(items);
 
@@ -1806,6 +1808,12 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
         showControl(exit ? mBinding.control.action.fullscreen : mBinding.control.action.player);
     }
 
+    private void onEpisodes() {
+        if (mFlagAdapter.getItemCount() == 0 || mEpisodeAdapter.getItemCount() < 2) return;
+        hideControl();
+        EpisodeListDialog.create().flags(mFlagAdapter.getItems()).show(this);
+    }
+
     private void onRepeat() {
         player().setRepeatOne(!player().isRepeatOne());
         mBinding.control.action.repeat.setSelected(player().isRepeatOne());
@@ -2116,11 +2124,6 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
     private void onToggle() {
         if (isVisible(mBinding.control.getRoot())) hideControl();
         else showControl(getFocus2());
-    }
-
-    private void onEpisodes() {
-        if (mEpisodeAdapter == null || mEpisodeAdapter.getItemCount() == 0) return;
-        EpisodeDialog.create().episodes(mEpisodeAdapter.getItems()).reverseAction(this::onRevSort).show(this);
     }
 
     private void showProgress() {
@@ -4170,7 +4173,10 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
     protected void onStart() {
         super.onStart();
         mClock.stop().start();
-        if (mOsd != null) mOsd.start();
+        if (mOsd != null) {
+            mOsd.setDiagnosticsVisible(PlayerSetting.isOsdDiagnostics());
+            mOsd.start();
+        }
     }
 
     @Override

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -79,6 +79,7 @@ import com.fongmi.android.tv.setting.PlayerButtonSetting;
 import com.fongmi.android.tv.setting.PlayerSetting;
 import com.fongmi.android.tv.setting.Setting;
 import com.fongmi.android.tv.setting.SiteHealthStore;
+import com.fongmi.android.tv.subtitle.SubtitlePlaybackSession;
 import com.fongmi.android.tv.ui.adapter.ArrayAdapter;
 import com.fongmi.android.tv.ui.adapter.BackdropAdapter;
 import com.fongmi.android.tv.ui.adapter.EpisodeAdapter;
@@ -96,6 +97,7 @@ import com.fongmi.android.tv.ui.dialog.DanmakuDialog;
 import com.fongmi.android.tv.ui.dialog.EpisodeListDialog;
 import com.fongmi.android.tv.ui.dialog.QuickSearchDialog;
 import com.fongmi.android.tv.ui.dialog.SubtitleDialog;
+import com.fongmi.android.tv.ui.dialog.SubtitleManualSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TmdbSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TitleDialog;
 import com.fongmi.android.tv.ui.dialog.TrackDialog;
@@ -131,7 +133,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.Listener, TrackDialog.Listener, ArrayAdapter.OnClickListener, FlagAdapter.OnClickListener, EpisodeAdapter.OnClickListener, QualityAdapter.OnClickListener, QuickAdapter.OnClickListener, ParseAdapter.OnClickListener, Clock.Callback {
+public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.Listener, TrackDialog.Listener, ArrayAdapter.OnClickListener, FlagAdapter.OnClickListener, EpisodeAdapter.OnClickListener, QualityAdapter.OnClickListener, QuickAdapter.OnClickListener, ParseAdapter.OnClickListener, Clock.Callback, SubtitlePlaybackSession.Host {
 
     private static final int SHORT_DRAMA_SCALE = 0; // 0=原始(适合TV), 4=裁剪(适合手机)
     private static final int TMDB_DETAIL_LOAD_TIMEOUT = 8000;
@@ -161,6 +163,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
     private QuickSearchDialog mQuickSearchDialog;
     private PlayerOsdController mOsd;
     private final IntroSkipPlayback mIntroSkipPlayback = new IntroSkipPlayback();
+    private final SubtitlePlaybackSession subtitlePlaybackSession = new SubtitlePlaybackSession(this);
     private CustomKeyDownVod mKeyDown;
     private SiteViewModel mViewModel;
     private List<String> mBroken;
@@ -1001,6 +1004,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
         mBinding.scroll.scrollTo(0, 0);
         mClock.setCallback(null);
         updateNavigationKey();
+        subtitlePlaybackSession.stop(this);
         player().reset();
         player().stop();
         saveHistory();
@@ -1253,6 +1257,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
         mBinding.control.parse.setVisibility(isUseParse() ? View.VISIBLE : View.GONE);
         if (redirectToContentHandler(result)) return;
         startPlayer(getHistoryKey(), result, isUseParse(), getSite().getTimeout(), buildMetadata());
+        subtitlePlaybackSession.onPlaybackStarted(this, result);
         if (DanmakuApi.canSearch()) DanmakuApi.search(mHistory.getVodName(), getEpisode().getName(), danmaku -> {
             if (DanmakuSetting.isSpiderFirst() && !result.getDanmaku().isEmpty()) player().addDanmaku(danmaku);
             else player().setDanmaku(danmaku);
@@ -1460,6 +1465,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
         updateActionQuality(result);
         beginPlayHealth();
         startPlayer(getHistoryKey(), result, isUseParse(), getSite().getTimeout(), buildMetadata());
+        subtitlePlaybackSession.onPlaybackStarted(this, result);
     }
 
     private void reverseEpisode(boolean scroll) {
@@ -2012,6 +2018,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
 
     private void onRefresh() {
         saveHistory();
+        subtitlePlaybackSession.stop(this);
         player().stop();
         player().clear();
         mClock.setCallback(null);
@@ -2107,7 +2114,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
     }
 
     private void onTrack(View view) {
-        TrackDialog.create().type(Integer.parseInt(view.getTag().toString())).player(player()).show(this);
+        TrackDialog.create().type(Integer.parseInt(view.getTag().toString())).player(player()).search(this::showSubtitleSearch).show(this);
         hideControl();
     }
 
@@ -2593,6 +2600,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
     @Override
     protected void onError(String msg) {
         recordPlayHealth(false, msg);
+        subtitlePlaybackSession.stop(this);
         Track.delete(player().getKey());
         mClock.setCallback(null);
         player().resetTrack();
@@ -2652,8 +2660,12 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
 
     @Override
     public void onSubtitleClick() {
-        SubtitleDialog.create().view(mBinding.exo.getSubtitleView()).show(this);
+        SubtitleDialog.create().view(mBinding.exo.getSubtitleView()).search(() -> SubtitleManualSearchDialog.show(this, subtitlePlaybackSession, this)).show(this);
         App.post(this::hideControl, 100);
+    }
+
+    private void showSubtitleSearch() {
+        SubtitleManualSearchDialog.show(this, subtitlePlaybackSession, this);
     }
 
     @Override
@@ -4205,6 +4217,7 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
 
     @Override
     protected void onDestroy() {
+        subtitlePlaybackSession.stop(this);
         mClock.release();
         saveHistory(true);
         DanmakuApi.cancel();
@@ -4220,5 +4233,47 @@ public class VideoActivity extends PlaybackActivity implements CustomKeyDownVod.
         mViewModel.getSearchProgress().removeObserver(mObserveSearchProgress);
         SiteHealthStore.flush();
         super.onDestroy();
+    }
+
+    @Override
+    public String getSubtitlePlaybackKey() {
+        return getHistoryKey();
+    }
+
+    @Override
+    public Site getSubtitleSite() {
+        return getSite();
+    }
+
+    @Override
+    public Vod getSubtitleVod() {
+        return mVod;
+    }
+
+    @Override
+    public Episode getSubtitleEpisode() {
+        return getEpisode();
+    }
+
+    @Override
+    public TmdbItem getSubtitleTmdbItem() {
+        TmdbItem item = mTmdbUIAdapter == null ? null : mTmdbUIAdapter.getTmdbItem();
+        return item == null ? getTmdbItem() : item;
+    }
+
+    @Override
+    public TmdbEpisode getSubtitleTmdbEpisode() {
+        Episode episode = getEpisode();
+        return episode == null ? null : episode.getTmdbEpisode();
+    }
+
+    @Override
+    public PlayerManager getSubtitlePlayer() {
+        return player();
+    }
+
+    @Override
+    public boolean isSubtitleHostActive() {
+        return !isFinishing() && !isDestroyed() && service() != null && player() != null && !player().isReleased() && !player().isEmpty() && isOwner();
     }
 }

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/ArrayAdapter.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/ArrayAdapter.java
@@ -22,6 +22,7 @@ public class ArrayAdapter extends RecyclerView.Adapter<ArrayAdapter.ViewHolder> 
     private final String backward;
     private final String forward;
     private final String reverse;
+    private View.OnKeyListener keyListener;
     private int nextFocusDown;
     private int nextFocusUp;
     private int segmentSize;
@@ -73,6 +74,11 @@ public class ArrayAdapter extends RecyclerView.Adapter<ArrayAdapter.ViewHolder> 
         notifyDataSetChanged();
     }
 
+    public void setOnKeyListener(View.OnKeyListener keyListener) {
+        this.keyListener = keyListener;
+        notifyDataSetChanged();
+    }
+
     @Override
     public int getItemCount() {
         return mItems.size();
@@ -90,6 +96,7 @@ public class ArrayAdapter extends RecyclerView.Adapter<ArrayAdapter.ViewHolder> 
         holder.binding.text.setText(text);
         holder.binding.text.setNextFocusUpId(nextFocusUp == 0 ? View.NO_ID : nextFocusUp);
         holder.binding.text.setNextFocusDownId(nextFocusDown == 0 ? View.NO_ID : nextFocusDown);
+        holder.binding.text.setOnKeyListener(keyListener);
         if (text.equals(reverse)) holder.binding.getRoot().setOnClickListener(view -> mListener.onRevSort());
         else if (text.equals(backward) || text.equals(forward)) holder.binding.getRoot().setOnClickListener(view -> mListener.onRevPlay(holder.binding.text));
         else holder.binding.getRoot().setOnClickListener(null);

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/EpisodeAdapter.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/EpisodeAdapter.java
@@ -45,6 +45,7 @@ public class EpisodeAdapter extends RecyclerView.Adapter<EpisodeAdapter.ViewHold
     private final List<Episode> mItems;
     private final int maxWidth;
     private final int spacing;
+    private View.OnKeyListener keyListener;
     private int nextFocusDown;
     private int nextFocusUp;
     private int column;
@@ -54,14 +55,22 @@ public class EpisodeAdapter extends RecyclerView.Adapter<EpisodeAdapter.ViewHold
     private String fallbackStillUrl = "";
 
     public EpisodeAdapter(OnClickListener listener) {
-        this(listener, null);
+        this(listener, null, ResUtil.getScreenWidth() - ResUtil.dp2px(48));
     }
 
     public EpisodeAdapter(OnClickListener listener, OnLongClickListener longClickListener) {
+        this(listener, longClickListener, ResUtil.getScreenWidth() - ResUtil.dp2px(48));
+    }
+
+    public EpisodeAdapter(OnClickListener listener, int maxWidth) {
+        this(listener, null, maxWidth);
+    }
+
+    public EpisodeAdapter(OnClickListener listener, OnLongClickListener longClickListener, int maxWidth) {
         mListener = listener;
         mLongClickListener = longClickListener;
         mItems = new ArrayList<>();
-        maxWidth = ResUtil.getScreenWidth() - ResUtil.dp2px(48);
+        this.maxWidth = Math.max(ResUtil.dp2px(240), maxWidth);
         spacing = ResUtil.dp2px(8);
         column = 1;
     }
@@ -161,6 +170,11 @@ public class EpisodeAdapter extends RecyclerView.Adapter<EpisodeAdapter.ViewHold
         notifyDataSetChanged();
     }
 
+    public void setOnKeyListener(View.OnKeyListener keyListener) {
+        this.keyListener = keyListener;
+        notifyDataSetChanged();
+    }
+
     public void setColumn(int column) {
         column = Math.max(1, column);
         if (this.column == column) return;
@@ -168,9 +182,17 @@ public class EpisodeAdapter extends RecyclerView.Adapter<EpisodeAdapter.ViewHold
         notifyDataSetChanged();
     }
 
+    public int getColumn() {
+        return column;
+    }
+
     public static int getColumn(List<Episode> items) {
+        return getColumn(items, ResUtil.getScreenWidth() - ResUtil.dp2px(48));
+    }
+
+    public static int getColumn(List<Episode> items, int maxWidth) {
         int maxTextWidth = 0;
-        int maxWidth = ResUtil.getScreenWidth() - ResUtil.dp2px(48);
+        maxWidth = Math.max(ResUtil.dp2px(240), maxWidth);
         int spacing = ResUtil.dp2px(8);
         int padding = ResUtil.dp2px(40);
         EpisodeTitleCompact.apply(items);

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/FlagAdapter.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/FlagAdapter.java
@@ -1,6 +1,7 @@
 package com.fongmi.android.tv.ui.adapter;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -19,6 +20,7 @@ public class FlagAdapter extends RecyclerView.Adapter<FlagAdapter.ViewHolder> {
 
     private final OnClickListener mListener;
     private final List<Flag> mItems;
+    private View.OnKeyListener keyListener;
     private int nextFocusDown;
 
     public FlagAdapter(OnClickListener listener) {
@@ -92,6 +94,11 @@ public class FlagAdapter extends RecyclerView.Adapter<FlagAdapter.ViewHolder> {
         return getItemCount() == 0;
     }
 
+    public void setOnKeyListener(View.OnKeyListener keyListener) {
+        this.keyListener = keyListener;
+        notifyDataSetChanged();
+    }
+
     @Override
     public int getItemCount() {
         return mItems.size();
@@ -109,6 +116,7 @@ public class FlagAdapter extends RecyclerView.Adapter<FlagAdapter.ViewHolder> {
         holder.binding.text.setText(item.getShow());
         holder.binding.text.setSelected(item.isSelected());
         holder.binding.text.setNextFocusDownId(nextFocusDown);
+        holder.binding.text.setOnKeyListener(keyListener);
         holder.binding.getRoot().setOnClickListener(v -> mListener.onItemClick(item));
     }
 

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeListDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeListDialog.java
@@ -1,0 +1,341 @@
+package com.fongmi.android.tv.ui.dialog;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.leanback.widget.BaseGridView;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewbinding.ViewBinding;
+
+import com.fongmi.android.tv.R;
+import com.fongmi.android.tv.bean.Episode;
+import com.fongmi.android.tv.bean.Flag;
+import com.fongmi.android.tv.databinding.DialogEpisodeListBinding;
+import com.fongmi.android.tv.ui.adapter.ArrayAdapter;
+import com.fongmi.android.tv.ui.adapter.EpisodeAdapter;
+import com.fongmi.android.tv.ui.adapter.FlagAdapter;
+import com.fongmi.android.tv.utils.KeyUtil;
+import com.fongmi.android.tv.utils.ResUtil;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EpisodeListDialog extends BaseAlertDialog implements FlagAdapter.OnClickListener, ArrayAdapter.OnClickListener, EpisodeAdapter.OnClickListener {
+
+    private final List<Integer> segmentStarts;
+
+    private DialogEpisodeListBinding binding;
+    private EpisodeAdapter episodeAdapter;
+    private ArrayAdapter arrayAdapter;
+    private FlagAdapter flagAdapter;
+    private DialogInterface.OnDismissListener dismissListener;
+    private List<Flag> flags;
+    private int panelWidth;
+
+    public EpisodeListDialog() {
+        segmentStarts = new ArrayList<>();
+    }
+
+    public static EpisodeListDialog create() {
+        return new EpisodeListDialog();
+    }
+
+    public EpisodeListDialog flags(List<Flag> flags) {
+        this.flags = flags;
+        return this;
+    }
+
+    public EpisodeListDialog dismissListener(DialogInterface.OnDismissListener dismissListener) {
+        this.dismissListener = dismissListener;
+        return this;
+    }
+
+    public void show(FragmentActivity activity) {
+        for (Fragment fragment : activity.getSupportFragmentManager().getFragments()) if (fragment instanceof EpisodeListDialog) return;
+        show(activity.getSupportFragmentManager(), null);
+    }
+
+    @Override
+    protected ViewBinding getBinding() {
+        return binding = DialogEpisodeListBinding.inflate(getLayoutInflater());
+    }
+
+    @Override
+    protected MaterialAlertDialogBuilder getBuilder() {
+        return builder().setView(getBinding().getRoot());
+    }
+
+    @Override
+    protected void initView() {
+        panelWidth = getPanelWidth();
+        setRecyclerView();
+        flagAdapter.addAll(flags == null ? new ArrayList<>() : flags);
+        setEpisodes(getSelectedFlag());
+        binding.flag.setSelectedPosition(flagAdapter.getPosition());
+    }
+
+    private void setRecyclerView() {
+        int spacing = ResUtil.dp2px(8);
+        binding.flag.setHorizontalSpacing(spacing);
+        binding.flag.setRowHeight(ViewGroup.LayoutParams.WRAP_CONTENT);
+        binding.flag.setAdapter(flagAdapter = new FlagAdapter(this));
+        flagAdapter.setOnKeyListener((view, keyCode, event) -> onFlagKey(event));
+        binding.array.setHorizontalSpacing(spacing);
+        binding.array.setRowHeight(ViewGroup.LayoutParams.WRAP_CONTENT);
+        binding.array.setAdapter(arrayAdapter = new ArrayAdapter(this));
+        arrayAdapter.setOnKeyListener((view, keyCode, event) -> onArrayKey(event));
+        binding.array.setOnKeyListener((view, keyCode, event) -> onArrayKey(event));
+        binding.episode.setHorizontalSpacing(spacing);
+        binding.episode.setVerticalSpacing(spacing);
+        binding.episode.setAdapter(episodeAdapter = new EpisodeAdapter(this, getEpisodeContentWidth()));
+        episodeAdapter.setOnKeyListener((view, keyCode, event) -> onEpisodeKey(event));
+        binding.episode.setOnKeyListener((view, keyCode, event) -> onEpisodeKey(event));
+        binding.flag.setOnKeyListener((view, keyCode, event) -> onFlagKey(event));
+        binding.array.addOnChildViewHolderSelectedListener(new androidx.leanback.widget.OnChildViewHolderSelectedListener() {
+            @Override
+            public void onChildViewHolderSelected(@NonNull RecyclerView parent, @Nullable RecyclerView.ViewHolder child, int position, int subposition) {
+                if (child != null && position >= 0 && position < segmentStarts.size()) scrollToEpisode(segmentStarts.get(position), false);
+            }
+        });
+    }
+
+    private int getPanelWidth() {
+        int screen = ResUtil.getScreenWidth(requireContext());
+        return Math.max(ResUtil.dp2px(420), Math.min(ResUtil.dp2px(680), Math.round(screen * 0.42f)));
+    }
+
+    private int getEpisodeContentWidth() {
+        return panelWidth - ResUtil.dp2px(40);
+    }
+
+    private Flag getSelectedFlag() {
+        if (flagAdapter == null || flagAdapter.getItemCount() == 0) return null;
+        return flagAdapter.get(flagAdapter.getPosition());
+    }
+
+    private void setEpisodes(Flag flag) {
+        if (flag == null) return;
+        List<Episode> episodes = flag.getEpisodes();
+        int column = EpisodeAdapter.getColumn(episodes, getEpisodeContentWidth());
+        binding.episode.setNumColumns(column);
+        episodeAdapter.setColumn(column);
+        episodeAdapter.addAll(episodes);
+        setSegments(episodes.size());
+        scrollToSelectedEpisode();
+    }
+
+    private void setSegments(int size) {
+        int segment = getEpisodeSegmentSize(size);
+        List<String> items = new ArrayList<>();
+        segmentStarts.clear();
+        if (size > segment) for (int i = 0; i < size; i += segment) {
+            segmentStarts.add(i);
+            items.add((i + 1) + "-" + Math.min(i + segment, size));
+        }
+        arrayAdapter.setSegmentSize(segment);
+        arrayAdapter.addAll(items);
+        binding.array.setVisibility(items.isEmpty() ? View.GONE : View.VISIBLE);
+        flagAdapter.setNextFocusDown(items.isEmpty() ? R.id.episode : R.id.array);
+        arrayAdapter.setNextFocus(R.id.flag, R.id.episode);
+        episodeAdapter.setNextFocusUp(items.isEmpty() ? R.id.flag : R.id.array);
+        episodeAdapter.setNextFocusDown(0);
+    }
+
+    private boolean onFlagKey(KeyEvent event) {
+        if (!KeyUtil.isActionDown(event) || !KeyUtil.isDownKey(event)) return false;
+        focusLowerFromFlag();
+        return true;
+    }
+
+    private boolean onArrayKey(KeyEvent event) {
+        if (!KeyUtil.isActionDown(event)) return false;
+        if (KeyUtil.isUpKey(event)) {
+            focusFlag();
+            return true;
+        }
+        if (KeyUtil.isDownKey(event)) {
+            focusEpisodeFromArray();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean onEpisodeKey(KeyEvent event) {
+        if (!KeyUtil.isActionDown(event) || !KeyUtil.isUpKey(event)) return false;
+        int position = getFocusedPosition(binding.episode);
+        int column = Math.max(1, episodeAdapter.getColumn());
+        if (position == RecyclerView.NO_POSITION || position >= column) return false;
+        focusUpperFromEpisode();
+        return true;
+    }
+
+    private void focusUpperFromEpisode() {
+        if (isVisible(binding.array) && arrayAdapter.getItemCount() > 0) focusArray();
+        else focusFlag();
+    }
+
+    private void focusLowerFromFlag() {
+        if (isVisible(binding.array) && arrayAdapter.getItemCount() > 0) focusArray();
+        else focusPosition(binding.episode, episodeAdapter.getPosition());
+    }
+
+    private void focusEpisodeFromArray() {
+        int position = binding.array.getSelectedPosition();
+        int start = position >= 0 && position < segmentStarts.size() ? segmentStarts.get(position) : episodeAdapter.getPosition();
+        focusPosition(binding.episode, start);
+    }
+
+    private void focusFlag() {
+        focusPosition(binding.flag, flagAdapter.getPosition());
+    }
+
+    private void focusArray() {
+        int position = Math.max(0, binding.array.getSelectedPosition());
+        focusPosition(binding.array, position);
+    }
+
+    private int getFocusedPosition(RecyclerView recycler) {
+        View child = recycler.getFocusedChild();
+        return child == null ? RecyclerView.NO_POSITION : recycler.getChildAdapterPosition(child);
+    }
+
+    private void focusPosition(BaseGridView grid, int position) {
+        if (grid.getAdapter() == null || grid.getAdapter().getItemCount() == 0) return;
+        position = Math.max(0, Math.min(position, grid.getAdapter().getItemCount() - 1));
+        int target = position;
+        grid.setSelectedPosition(target);
+        grid.post(() -> {
+            RecyclerView.ViewHolder holder = grid.findViewHolderForAdapterPosition(target);
+            if (holder != null) holder.itemView.requestFocus();
+            else grid.requestFocus();
+        });
+    }
+
+    private boolean isVisible(View view) {
+        return view.getVisibility() == View.VISIBLE;
+    }
+
+    private int getEpisodeSegmentSize(int size) {
+        return size <= 60 ? 20 : 40;
+    }
+
+    private void scrollToSelectedEpisode() {
+        int position = episodeAdapter.getPosition();
+        scrollToSegment(position);
+        scrollToEpisode(position, true);
+    }
+
+    private void scrollToSegment(int episodePosition) {
+        if (segmentStarts.isEmpty()) return;
+        int target = 0;
+        for (int i = 0; i < segmentStarts.size(); i++) if (episodePosition >= segmentStarts.get(i)) target = i;
+        binding.array.setSelectedPosition(target);
+        binding.array.scrollToPosition(target);
+    }
+
+    private void scrollToEpisode(int position, boolean requestFocus) {
+        if (position < 0 || position >= episodeAdapter.getItemCount()) return;
+        binding.episode.post(() -> {
+            if (binding == null) return;
+            binding.episode.setSelectedPosition(position);
+            if (requestFocus) binding.episode.requestFocus();
+        });
+    }
+
+    @Override
+    public void onItemClick(Flag item) {
+        ((FlagAdapter.OnClickListener) requireActivity()).onItemClick(item);
+        flagAdapter.notifyItemRangeChanged(0, flagAdapter.getItemCount());
+        setEpisodes(item);
+    }
+
+    @Override
+    public void onItemClick(Episode item) {
+        ((EpisodeAdapter.OnClickListener) requireActivity()).onItemClick(item);
+        dismiss();
+    }
+
+    @Override
+    public void onRevSort() {
+    }
+
+    @Override
+    public void onRevPlay(TextView view) {
+    }
+
+    @Override
+    public void onDismiss(@NonNull DialogInterface dialog) {
+        super.onDismiss(dialog);
+        if (dismissListener != null) dismissListener.onDismiss(dialog);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable android.os.Bundle savedInstanceState) {
+        Dialog dialog = super.onCreateDialog(savedInstanceState);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setWindowAnimations(0);
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+            window.setDimAmount(0f);
+        }
+        return dialog;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        Window window = getDialog() == null ? null : getDialog().getWindow();
+        if (window == null || binding == null) return;
+        window.getDecorView().setPadding(0, 0, 0, 0);
+        clearParentPaddingAndFillHeight();
+        window.setGravity(Gravity.END | Gravity.BOTTOM);
+        WindowManager.LayoutParams params = window.getAttributes();
+        params.width = panelWidth;
+        params.height = WindowManager.LayoutParams.MATCH_PARENT;
+        params.gravity = Gravity.END | Gravity.BOTTOM;
+        params.x = 0;
+        params.y = 0;
+        window.setAttributes(params);
+        window.setLayout(panelWidth, WindowManager.LayoutParams.MATCH_PARENT);
+        binding.getRoot().post(() -> {
+            clearParentPaddingAndFillHeight();
+            window.setLayout(panelWidth, WindowManager.LayoutParams.MATCH_PARENT);
+        });
+    }
+
+    private void clearParentPaddingAndFillHeight() {
+        View view = binding.getRoot();
+        fillHeight(view);
+        while (view.getParent() instanceof View parent) {
+            if (parent instanceof ViewGroup group) group.setPadding(0, 0, 0, 0);
+            fillHeight(parent);
+            view = parent;
+        }
+    }
+
+    private void fillHeight(View view) {
+        ViewGroup.LayoutParams params = view.getLayoutParams();
+        if (params != null) {
+            params.width = ViewGroup.LayoutParams.MATCH_PARENT;
+            params.height = ViewGroup.LayoutParams.MATCH_PARENT;
+            view.setLayoutParams(params);
+        }
+        view.setMinimumHeight(ResUtil.getScreenHeight(requireContext()));
+    }
+}

--- a/app/src/leanback/res/layout/activity_setting.xml
+++ b/app/src/leanback/res/layout/activity_setting.xml
@@ -264,6 +264,25 @@
         </androidx.appcompat.widget.LinearLayoutCompat>
 
         <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/selector_item"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/setting_subtitle"
+                android:textColor="@color/white"
+                android:textSize="18sp" />
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <androidx.appcompat.widget.LinearLayoutCompat
             android:id="@+id/personal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/leanback/res/layout/activity_setting_subtitle.xml
+++ b/app/src/leanback/res/layout/activity_setting_subtitle.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/subtitleAutoMatch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/selector_item"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/player_subtitle_auto_match"
+                android:textColor="@color/white"
+                android:textSize="18sp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/subtitleAutoMatchText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end"
+                android:textColor="@color/white"
+                android:textSize="18sp"
+                tools:text="开" />
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/subtitleLanguage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/selector_item"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/player_subtitle_language"
+                android:textColor="@color/white"
+                android:textSize="18sp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/subtitleLanguageText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="end"
+                android:singleLine="true"
+                android:textColor="@color/white"
+                android:textSize="18sp"
+                tools:text="中文优先" />
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/subtitleAssrtToken"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/selector_item"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/player_subtitle_assrt_token"
+                android:textColor="@color/white"
+                android:textSize="18sp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/subtitleAssrtTokenText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="end"
+                android:singleLine="true"
+                android:textColor="@color/white"
+                android:textSize="18sp"
+                tools:text="已配置" />
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+    </androidx.appcompat.widget.LinearLayoutCompat>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/leanback/res/layout/dialog_episode_list.xml
+++ b/app/src/leanback/res/layout/dialog_episode_list.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/shape_quick_search_dialog"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:orientation="vertical"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:gravity="center_vertical"
+        android:text="@string/play_episodes"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <androidx.leanback.widget.HorizontalGridView
+        android:id="@+id/flag"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        tools:itemCount="3"
+        tools:listitem="@layout/adapter_flag" />
+
+    <androidx.leanback.widget.HorizontalGridView
+        android:id="@+id/array"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:layout_marginTop="12dp"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:visibility="gone"
+        tools:itemCount="4"
+        tools:listitem="@layout/adapter_array"
+        tools:visibility="visible" />
+
+    <androidx.leanback.widget.VerticalGridView
+        android:id="@+id/episode"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        android:layout_weight="1"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:paddingBottom="16dp"
+        tools:itemCount="40"
+        tools:listitem="@layout/adapter_episode" />
+
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/leanback/res/layout/dialog_subtitle.xml
+++ b/app/src/leanback/res/layout/dialog_subtitle.xml
@@ -55,4 +55,15 @@
         android:padding="8dp"
         android:src="@drawable/ic_subtitle_reset" />
 
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/search"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_subtitle"
+        android:contentDescription="@string/subtitle_manual_search"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:padding="8dp"
+        android:src="@drawable/ic_action_search" />
+
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/leanback/res/layout/dialog_track.xml
+++ b/app/src/leanback/res/layout/dialog_track.xml
@@ -35,6 +35,18 @@
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/search"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/subtitle_manual_search"
+            android:focusable="true"
+            android:src="@drawable/ic_action_search"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/subtitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/leanback/res/layout/view_control_vod_action.xml
+++ b/app/src/leanback/res/layout/view_control_vod_action.xml
@@ -30,7 +30,7 @@
             android:id="@+id/episodes"
             style="@style/Control"
             android:layout_marginEnd="12dp"
-            android:text="@string/detail_episode"
+            android:text="@string/play_episodes"
             android:visibility="gone"
             tools:visibility="visible" />
 

--- a/app/src/main/java/com/fongmi/android/tv/bean/Episode.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Episode.java
@@ -2,7 +2,6 @@ package com.fongmi.android.tv.bean;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
 
@@ -55,7 +54,7 @@ public class Episode implements Parcelable, Diffable<Episode> {
     }
 
     public String getName() {
-        return TextUtils.isEmpty(name) ? "" : name;
+        return isEmpty(name) ? "" : name;
     }
 
     public void setName(String name) {
@@ -63,7 +62,7 @@ public class Episode implements Parcelable, Diffable<Episode> {
     }
 
     public String getDesc() {
-        return TextUtils.isEmpty(desc) ? "" : desc;
+        return isEmpty(desc) ? "" : desc;
     }
 
     public String getRawDisplayName() {
@@ -71,7 +70,7 @@ public class Episode implements Parcelable, Diffable<Episode> {
     }
 
     public String getDisplayName() {
-        return TextUtils.isEmpty(displayName) ? getRawDisplayName() : displayName;
+        return isEmpty(displayName) ? getRawDisplayName() : displayName;
     }
 
     public void setDisplayName(String displayName) {
@@ -79,7 +78,7 @@ public class Episode implements Parcelable, Diffable<Episode> {
     }
 
     public String getUrl() {
-        return TextUtils.isEmpty(url) ? "" : url;
+        return isEmpty(url) ? "" : url;
     }
 
     public int getIndex() {
@@ -129,8 +128,12 @@ public class Episode implements Parcelable, Diffable<Episode> {
 
     public boolean matches(Episode other) {
         if (other == null) return false;
-        if (!TextUtils.isEmpty(getUrl()) && !TextUtils.isEmpty(other.getUrl())) return getUrl().equals(other.getUrl());
+        if (!isEmpty(getUrl()) && !isEmpty(other.getUrl())) return getUrl().equals(other.getUrl());
         return matchesName(other);
+    }
+
+    private boolean isEmpty(String value) {
+        return value == null || value.length() == 0;
     }
 
     public Episode trans() {

--- a/app/src/main/java/com/fongmi/android/tv/bean/Sub.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Sub.java
@@ -1,7 +1,5 @@
 package com.fongmi.android.tv.bean;
 
-import android.text.TextUtils;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
@@ -29,7 +27,7 @@ public class Sub {
         Sub sub = new Sub();
         sub.url = path;
         sub.name = UrlUtil.path(path);
-        sub.flag = C.SELECTION_FLAG_FORCED;
+        sub.flag = C.SELECTION_FLAG_DEFAULT;
         sub.format = PlayerHelper.getSubtitleMimeType(sub.name);
         return sub;
     }
@@ -44,19 +42,19 @@ public class Sub {
     }
 
     public String getUrl() {
-        return TextUtils.isEmpty(url) ? "" : url;
+        return isEmpty(url) ? "" : url;
     }
 
     public String getName() {
-        return TextUtils.isEmpty(name) ? "" : name;
+        return isEmpty(name) ? "" : name;
     }
 
     public String getLang() {
-        return TextUtils.isEmpty(lang) ? "" : lang;
+        return isEmpty(lang) ? "" : lang;
     }
 
     public String getFormat() {
-        return TextUtils.isEmpty(format) ? "" : format;
+        return isEmpty(format) ? "" : format;
     }
 
     public int getFlag() {
@@ -69,6 +67,10 @@ public class Sub {
 
     public boolean isForced() {
         return (flag & C.SELECTION_FLAG_FORCED) != 0;
+    }
+
+    private boolean isEmpty(String value) {
+        return value == null || value.length() == 0;
     }
 
     public void setFlag(int flag) {

--- a/app/src/main/java/com/fongmi/android/tv/bean/Track.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Track.java
@@ -45,6 +45,11 @@ public class Track {
         AppDatabase.get().getTrackDao().delete(key);
     }
 
+    public static void delete(String key, int type) {
+        if (TextUtils.isEmpty(key)) return;
+        AppDatabase.get().getTrackDao().delete(key, type);
+    }
+
     public int getId() {
         return id;
     }

--- a/app/src/main/java/com/fongmi/android/tv/db/dao/TrackDao.java
+++ b/app/src/main/java/com/fongmi/android/tv/db/dao/TrackDao.java
@@ -20,4 +20,7 @@ public abstract class TrackDao extends BaseDao<Track> {
 
     @Query("DELETE FROM Track WHERE `key` = :key")
     public abstract void delete(String key);
+
+    @Query("DELETE FROM Track WHERE `key` = :key AND `type` = :type")
+    public abstract void delete(String key, int type);
 }

--- a/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
@@ -380,8 +380,11 @@ public class PlayerManager implements ParseCallback {
     }
 
     public void setSub(Sub sub) {
-        if (spec != null) spec.setSub(sub);
-        setMediaItem();
+        if (sub == null || spec == null) return;
+        Track.delete(getKey(), C.TRACK_TYPE_TEXT);
+        engine.resetTrack(C.TRACK_TYPE_TEXT);
+        spec.setSub(sub);
+        restartCurrentItemWithState();
     }
 
     public void setFormat(String format) {
@@ -666,6 +669,25 @@ public class PlayerManager implements ParseCallback {
             return;
         }
         setMediaItemNow(timeout, true);
+    }
+
+    private void restartCurrentItemWithState() {
+        if (spec == null || spec.getUrl() == null || engine == null || player == null) return;
+        if (player.getCurrentMediaItem() == null || player.getPlaybackState() == Player.STATE_IDLE) {
+            setMediaItem();
+            return;
+        }
+        if (!ensurePlayerAvailableForPlayback()) return;
+        long position = Math.max(0, player.getCurrentPosition());
+        boolean playWhenReady = player.getPlayWhenReady();
+        if (SpiderDebug.isEnabled()) SpiderDebug.log("player", "restart media item for subtitle position=%d play=%s spec=%s", position, playWhenReady, debugSpec());
+        App.removeCallbacks(runnable);
+        currentDanmakuUrl = null;
+        setDanmakus(spec.getDanmakus());
+        initTrack = false;
+        waitingLutBeforePlay = false;
+        engine.restart(spec.checkUa(), position, playWhenReady);
+        App.post(runnable, Constant.TIMEOUT_PLAY);
     }
 
     private void awaitLocalProxyAndSetMediaItem(int seq, long timeout) {

--- a/app/src/main/java/com/fongmi/android/tv/player/engine/ExoPlayerEngine.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/engine/ExoPlayerEngine.java
@@ -153,6 +153,11 @@ public class ExoPlayerEngine implements PlayerEngine {
     }
 
     @Override
+    public void resetTrack(int type) {
+        TrackUtil.reset(player, type);
+    }
+
+    @Override
     public boolean haveTrack(int type) {
         return TrackUtil.count(getCurrentTracks(), type) > 0;
     }

--- a/app/src/main/java/com/fongmi/android/tv/player/engine/IjkPlayerEngine.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/engine/IjkPlayerEngine.java
@@ -1,5 +1,6 @@
 package com.fongmi.android.tv.player.engine;
 
+import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.PlaybackException;
@@ -68,11 +69,27 @@ public class IjkPlayerEngine implements PlayerEngine {
 
     @Override
     public void start(PlaySpec spec) {
+        start(spec, C.TIME_UNSET, true);
+    }
+
+    @Override
+    public void start(PlaySpec spec, boolean playWhenReady) {
+        start(spec, C.TIME_UNSET, playWhenReady);
+    }
+
+    @Override
+    public void start(PlaySpec spec, long position, boolean playWhenReady) {
         this.spec = spec;
-        SpiderDebug.log("player-engine", "start ijk decode=%d url=%s headers=%s", decode, spec.getUrl(), spec.getHeaders());
-        player.setMediaItem(ExoUtil.getMediaItem(spec, decode));
+        SpiderDebug.log("player-engine", "start ijk decode=%d position=%d play=%s url=%s headers=%s", decode, position, playWhenReady, spec.getUrl(), spec.getHeaders());
+        player.setMediaItem(ExoUtil.getMediaItem(spec, decode), position);
         player.prepare();
-        player.play();
+        if (playWhenReady) player.play();
+        else player.pause();
+    }
+
+    @Override
+    public void restart(PlaySpec spec, long position, boolean playWhenReady) {
+        start(spec, position, playWhenReady);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/player/engine/PlayerEngine.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/engine/PlayerEngine.java
@@ -60,6 +60,10 @@ public interface PlayerEngine {
 
     void resetTrack();
 
+    default void resetTrack(int type) {
+        resetTrack();
+    }
+
     boolean haveTrack(int type);
 
     Tracks getCurrentTracks();

--- a/app/src/main/java/com/fongmi/android/tv/player/engine/SystemPlayerEngine.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/engine/SystemPlayerEngine.java
@@ -1,5 +1,6 @@
 package com.fongmi.android.tv.player.engine;
 
+import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.PlaybackException;
@@ -67,11 +68,27 @@ public class SystemPlayerEngine implements PlayerEngine {
 
     @Override
     public void start(PlaySpec spec) {
+        start(spec, C.TIME_UNSET, true);
+    }
+
+    @Override
+    public void start(PlaySpec spec, boolean playWhenReady) {
+        start(spec, C.TIME_UNSET, playWhenReady);
+    }
+
+    @Override
+    public void start(PlaySpec spec, long position, boolean playWhenReady) {
         this.spec = spec;
-        SpiderDebug.log("player-engine", "start system decode=%d url=%s headers=%s", decode, spec.getUrl(), spec.getHeaders());
-        player.setMediaItem(ExoUtil.getMediaItem(spec, decode));
+        SpiderDebug.log("player-engine", "start system decode=%d position=%d play=%s url=%s headers=%s", decode, position, playWhenReady, spec.getUrl(), spec.getHeaders());
+        player.setMediaItem(ExoUtil.getMediaItem(spec, decode), position);
         player.prepare();
-        player.play();
+        if (playWhenReady) player.play();
+        else player.pause();
+    }
+
+    @Override
+    public void restart(PlaySpec spec, long position, boolean playWhenReady) {
+        start(spec, position, playWhenReady);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/player/exo/ExoUtil.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/exo/ExoUtil.java
@@ -113,7 +113,7 @@ public class ExoUtil {
         return extras.keySet().stream().filter(key -> extras.getString(key) != null).collect(Collectors.toMap(key -> key, extras::getString));
     }
 
-    private static int getRenderMode(int decode) {
+    static int getRenderMode(int decode) {
         if (decode == PlayerEngine.HARD && PlayerSetting.isExoEnhanced()) return DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF;
         return decode == PlayerEngine.HARD ? DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON : DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER;
     }

--- a/app/src/main/java/com/fongmi/android/tv/player/exo/TrackUtil.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/exo/TrackUtil.java
@@ -8,7 +8,6 @@ import androidx.media3.common.TrackGroup;
 import androidx.media3.common.TrackSelectionOverride;
 import androidx.media3.common.TrackSelectionParameters;
 import androidx.media3.common.Tracks;
-import androidx.media3.common.C;
 
 import com.fongmi.android.tv.bean.Track;
 import com.fongmi.android.tv.player.PlayerHelper;
@@ -25,6 +24,10 @@ public class TrackUtil {
 
     public static void reset(Player player) {
         player.setTrackSelectionParameters(player.getTrackSelectionParameters().buildUpon().clearOverrides().setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, false).setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, false).setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false).build());
+    }
+
+    public static void reset(Player player, int type) {
+        player.setTrackSelectionParameters(player.getTrackSelectionParameters().buildUpon().clearOverridesOfType(type).setTrackTypeDisabled(type, false).build());
     }
 
     public static boolean preferAAC(Player player) {

--- a/app/src/main/java/com/fongmi/android/tv/server/process/Proxy.java
+++ b/app/src/main/java/com/fongmi/android/tv/server/process/Proxy.java
@@ -8,17 +8,21 @@ import com.github.catvod.crawler.SpiderDebug;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import fi.iki.elonen.NanoHTTPD.Response.IStatus;
 import fi.iki.elonen.NanoHTTPD.Response.Status;
 
 public class Proxy implements Process {
 
+    private static final String INVALID_RESPONSE = "Invalid proxy response";
     private static final AtomicLong STREAM_ID = new AtomicLong();
     private static final long PROGRESS_INTERVAL_NS = TimeUnit.SECONDS.toNanos(5);
 
@@ -34,25 +38,55 @@ public class Proxy implements Process {
             params.putAll(session.getHeaders());
             params.putAll(files);
             SpiderDebug.log("proxy", "request uri=%s method=%s do=%s params=%s", url, session.getMethod(), params.get("do"), params);
-            Object[] rs = BaseLoader.get().proxy(params);
-            if (rs == null) {
-                SpiderDebug.log("proxy", "response null do=%s uri=%s", params.get("do"), url);
-                return Nano.error("Proxy response is null");
-            }
-            if (rs[0] instanceof Response) {
-                SpiderDebug.log("proxy", "response object do=%s type=%s", params.get("do"), rs[0].getClass().getName());
-                return (Response) rs[0];
-            }
-            SpiderDebug.log("proxy", "response do=%s status=%s mime=%s body=%s headers=%s", params.get("do"), rs.length > 0 ? rs[0] : null, rs.length > 1 ? rs[1] : null, rs.length > 2 && rs[2] != null ? rs[2].getClass().getName() : null, rs.length > 3 ? rs[3] : null);
-            Map<String, String> headers = headers(rs);
-            InputStream stream = wrapStream(params, headers, (InputStream) rs[2]);
-            Response response = NanoHTTPD.newChunkedResponse(Status.lookup((Integer) rs[0]), (String) rs[1], stream);
-            if (headers != null) for (Map.Entry<String, String> entry : headers.entrySet()) response.addHeader(entry.getKey(), entry.getValue());
-            return response;
+            return createResponse(params, url, BaseLoader.get().proxy(params));
         } catch (Throwable e) {
             e.printStackTrace();
             SpiderDebug.log("proxy", e);
-            return Nano.error(e.getMessage());
+            return Nano.error(Objects.toString(e.getMessage(), e.toString()));
+        }
+    }
+
+    private Response createResponse(Map<String, String> params, String url, Object[] rs) {
+        if (rs == null || rs.length == 0) {
+            SpiderDebug.log("proxy", "response invalid do=%s uri=%s reason=null_or_empty", params.get("do"), url);
+            return Nano.error(INVALID_RESPONSE);
+        }
+        if (rs[0] instanceof Response response) {
+            SpiderDebug.log("proxy", "response object do=%s type=%s", params.get("do"), rs[0].getClass().getName());
+            return response;
+        }
+        if (rs.length < 3 || !(rs[0] instanceof Integer code) || !(rs[2] instanceof InputStream stream)) {
+            SpiderDebug.log("proxy", "response invalid do=%s status=%s mime=%s body=%s headers=%s", params.get("do"), rs.length > 0 ? rs[0] : null, rs.length > 1 ? rs[1] : null, rs.length > 2 ? rs[2] : null, rs.length > 3 ? rs[3] : null);
+            return Nano.error(INVALID_RESPONSE);
+        }
+        SpiderDebug.log("proxy", "response do=%s status=%s mime=%s body=%s headers=%s", params.get("do"), code, rs[1], stream.getClass().getName(), rs.length > 3 ? rs[3] : null);
+        Map<String, String> headers = headers(rs.length > 3 ? rs[3] : null);
+        stream = wrapStream(params, headers, stream);
+        Response response = NanoHTTPD.newChunkedResponse(toStatus(code), Objects.toString(rs[1], null), stream);
+        addHeaders(response, headers);
+        return response;
+    }
+
+    private static void addHeaders(Response response, Map<String, String> headers) {
+        if (headers == null) return;
+        for (Map.Entry<String, String> entry : headers.entrySet()) response.addHeader(entry.getKey(), entry.getValue());
+    }
+
+    private static IStatus toStatus(int code) {
+        Status status = Status.lookup(code);
+        return status != null ? status : code >= 100 && code <= 599 ? new ProxyStatus(code) : Status.INTERNAL_ERROR;
+    }
+
+    private record ProxyStatus(int code) implements IStatus {
+
+        @Override
+        public String getDescription() {
+            return code + " Proxy Status";
+        }
+
+        @Override
+        public int getRequestStatus() {
+            return code;
         }
     }
 
@@ -67,9 +101,14 @@ public class Proxy implements Process {
         return new DebugInputStream(stream, id, label);
     }
 
-    @SuppressWarnings("unchecked")
-    private static Map<String, String> headers(Object[] rs) {
-        return rs.length > 3 && rs[3] instanceof Map ? (Map<String, String>) rs[3] : null;
+    private static Map<String, String> headers(Object headers) {
+        if (!(headers instanceof Map<?, ?> map)) return null;
+        Map<String, String> result = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) continue;
+            result.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+        return result;
     }
 
     private static String label(Map<String, String> params) {

--- a/app/src/main/java/com/fongmi/android/tv/setting/Setting.java
+++ b/app/src/main/java/com/fongmi/android/tv/setting/Setting.java
@@ -979,6 +979,30 @@ public class Setting {
         Prefers.put("play_back_to_detail", backToDetail);
     }
 
+    public static boolean isSubtitleAutoMatchEnabled() {
+        return Prefers.getBoolean("subtitle_auto_match", true);
+    }
+
+    public static void putSubtitleAutoMatchEnabled(boolean enabled) {
+        Prefers.put("subtitle_auto_match", enabled);
+    }
+
+    public static String getSubtitlePreferredLanguage() {
+        return Prefers.getString("subtitle_preferred_language", "zh");
+    }
+
+    public static void putSubtitlePreferredLanguage(String language) {
+        Prefers.put("subtitle_preferred_language", language == null || language.isEmpty() ? "zh" : language);
+    }
+
+    public static String getSubtitleAssrtToken() {
+        return Prefers.getString("subtitle_assrt_token");
+    }
+
+    public static void putSubtitleAssrtToken(String token) {
+        Prefers.put("subtitle_assrt_token", token);
+    }
+
     public static boolean isAutoSkipIntroOutro() {
         return Prefers.getBoolean("auto_skip_intro_outro", true);
     }

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleAutoController.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleAutoController.java
@@ -1,0 +1,71 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchResult;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+import com.fongmi.android.tv.utils.Task;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public final class SubtitleAutoController {
+
+    public interface Callback {
+        void onSubtitleResult(SubtitleRequest request, SubtitleMatchResult result);
+    }
+
+    private final SubtitleMatchService matchService;
+    private final Callback callback;
+    private final Map<String, ScheduledFuture<?>> scheduled;
+    private final Map<String, Integer> generations;
+
+    public SubtitleAutoController(Callback callback) {
+        this(new SubtitleMatchService(), callback);
+    }
+
+    SubtitleAutoController(SubtitleMatchService matchService, Callback callback) {
+        this.matchService = matchService;
+        this.callback = callback;
+        this.scheduled = new ConcurrentHashMap<>();
+        this.generations = new ConcurrentHashMap<>();
+    }
+
+    public void onPlaybackStarted(SubtitleRequest request) {
+        schedule(request, 0L);
+    }
+
+    public void onEpisodeChanged(SubtitleRequest request) {
+        schedule(request, 250L);
+    }
+
+    public void onSourceChanged(SubtitleRequest request) {
+        schedule(request, 250L);
+    }
+
+    public void onStop(String playbackKey) {
+        if (playbackKey == null) return;
+        generations.merge(playbackKey, 1, Integer::sum);
+        ScheduledFuture<?> future = scheduled.remove(playbackKey);
+        if (future != null) future.cancel(false);
+        matchService.cancel(playbackKey);
+    }
+
+    private void schedule(SubtitleRequest request, long delayMs) {
+        if (request == null || request.getPlaybackKey().isEmpty()) return;
+        if (!Setting.isSubtitleAutoMatchEnabled()) return;
+        String playbackKey = request.getPlaybackKey();
+        ScheduledFuture<?> old = scheduled.remove(playbackKey);
+        if (old != null) old.cancel(false);
+        int generation = generations.merge(playbackKey, 1, Integer::sum);
+        ScheduledFuture<?> future = Task.scheduler().schedule(() -> {
+            if (generation != generations.getOrDefault(playbackKey, 0)) return;
+            matchService.autoMatch(request, (currentRequest, result) -> {
+                if (generation != generations.getOrDefault(playbackKey, 0)) return;
+                callback.onSubtitleResult(currentRequest, result);
+            });
+        }, delayMs, TimeUnit.MILLISECONDS);
+        scheduled.put(playbackKey, future);
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleContextBuilder.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleContextBuilder.java
@@ -1,0 +1,52 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.subtitle.model.ResolvedMediaIdentity;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+
+public final class SubtitleContextBuilder {
+
+    private final SubtitleTmdbResolver resolver;
+    private final SubtitleTitleParser parser;
+
+    public SubtitleContextBuilder() {
+        this(new SubtitleTmdbResolver(), new SubtitleTitleParser());
+    }
+
+    SubtitleContextBuilder(SubtitleTmdbResolver resolver, SubtitleTitleParser parser) {
+        this.resolver = resolver;
+        this.parser = parser;
+    }
+
+    public SubtitleContext build(SubtitleRequest request) {
+        ResolvedMediaIdentity identity = resolver.resolve(request);
+        String canonicalTitle = !SubtitleStrings.isEmpty(identity.getCanonicalTitle()) ? identity.getCanonicalTitle() : parser.cleanTitle(request.getVodName());
+        String originalTitle = identity.getOriginalTitle();
+        int year = identity.getYear() > 0 ? identity.getYear() : parser.firstYear(request.getVodYear());
+        int seasonNumber = identity.getSeasonNumber() > 0 ? identity.getSeasonNumber() : request.getSeasonNumber();
+        int episodeNumber = identity.getEpisodeNumber() > 0 ? identity.getEpisodeNumber() : request.getEpisodeNumber();
+        String episodeTitle = !SubtitleStrings.isEmpty(identity.getEpisodeTitle()) ? identity.getEpisodeTitle() : parser.cleanTitle(request.getEpisodeName());
+        String originalLanguage = request.getTmdbItem() == null ? "" : request.getTmdbItem().getOriginalLanguage();
+        String originCountry = request.getTmdbItem() == null ? "" : request.getTmdbItem().getOriginCountry();
+
+        SubtitleContext.Builder builder = SubtitleContext.builder()
+                .playbackKey(request.getPlaybackKey())
+                .siteKey(request.getSiteKey())
+                .vodId(request.getVodId())
+                .mediaType(identity.getMediaType())
+                .canonicalTitle(canonicalTitle)
+                .originalTitle(originalTitle)
+                .year(year)
+                .seasonNumber(seasonNumber)
+                .episodeNumber(episodeNumber)
+                .episodeTitle(episodeTitle)
+                .preferredLanguage(request.getPreferredLanguage())
+                .originalLanguage(originalLanguage)
+                .originCountry(originCountry)
+                .identity(identity)
+                .networkStream(true);
+
+        for (String alias : parser.aliases(request.getVodName(), request.getVodRemarks(), request.getEpisodeName())) builder.addAlias(alias);
+        return builder.build();
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleInjector.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleInjector.java
@@ -1,0 +1,14 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.bean.Sub;
+import com.fongmi.android.tv.subtitle.model.SubtitleAsset;
+
+public final class SubtitleInjector {
+
+    public Sub toSub(SubtitleAsset asset) {
+        if (asset == null) return null;
+        Sub sub = Sub.create(asset.getDisplayName(), asset.getUri(), asset.getLanguage(), asset.getMimeType());
+        if (asset.getSelectionFlag() != 0) sub.setFlag(asset.getSelectionFlag());
+        return sub;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleMatchService.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleMatchService.java
@@ -1,0 +1,166 @@
+package com.fongmi.android.tv.subtitle;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.fongmi.android.tv.App;
+import com.fongmi.android.tv.subtitle.model.SubtitleAsset;
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchResult;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+import com.fongmi.android.tv.subtitle.provider.SubtitleProviderRegistry;
+import com.fongmi.android.tv.utils.Task;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
+public final class SubtitleMatchService {
+
+    private static final String TAG = "SubtitleMatch";
+
+    public interface Listener {
+        void onComplete(SubtitleRequest request, SubtitleMatchResult result);
+    }
+
+    private final SubtitleContextBuilder contextBuilder;
+    private final SubtitleQueryPlanner queryPlanner;
+    private final SubtitleProviderRegistry registry;
+    private final SubtitleRanker ranker;
+    private final Map<String, Future<?>> jobs;
+    private final Map<String, Integer> generations;
+
+    public SubtitleMatchService() {
+        this(new SubtitleContextBuilder(), new SubtitleQueryPlanner(), new SubtitleProviderRegistry(), new SubtitleRanker());
+    }
+
+    SubtitleMatchService(SubtitleContextBuilder contextBuilder, SubtitleQueryPlanner queryPlanner, SubtitleProviderRegistry registry, SubtitleRanker ranker) {
+        this.contextBuilder = contextBuilder;
+        this.queryPlanner = queryPlanner;
+        this.registry = registry;
+        this.ranker = ranker;
+        this.jobs = new ConcurrentHashMap<>();
+        this.generations = new ConcurrentHashMap<>();
+    }
+
+    public void autoMatch(SubtitleRequest request, Listener listener) {
+        if (request == null) return;
+        if (request.isManualOnly()) {
+            Log.i(TAG, "auto skipped reason=manual_only title=" + request.getVodName());
+            dispatch(listener, request, SubtitleMatchResult.skipped("manual_only"));
+            return;
+        }
+        if (registry.enabledProviders().isEmpty()) {
+            Log.w(TAG, "auto skipped reason=provider_unavailable title=" + request.getVodName());
+            dispatch(listener, request, SubtitleMatchResult.skipped("provider_unavailable"));
+            return;
+        }
+        Log.i(TAG, "auto start title=" + request.getVodName() + " episode=" + request.getEpisodeName() + " trigger=" + request.getTrigger());
+        String playbackKey = request.getPlaybackKey();
+        cancel(playbackKey);
+        int generation = generations.merge(playbackKey, 1, Integer::sum);
+        Future<?> job = Task.searchExecutor().submit(() -> runAutoMatch(request, generation, listener));
+        jobs.put(playbackKey, job);
+    }
+
+    public void manualSearch(SubtitleRequest request, Listener listener) {
+        manualSearch(request, "", listener);
+    }
+
+    public void manualSearch(SubtitleRequest request, String keyword, Listener listener) {
+        if (request == null) return;
+        if (registry.enabledProviders().isEmpty()) {
+            Log.w(TAG, "manual skipped reason=provider_unavailable title=" + request.getVodName());
+            dispatch(listener, request, SubtitleMatchResult.skipped("provider_unavailable"));
+            return;
+        }
+        String text = keyword == null ? "" : keyword.trim();
+        Log.i(TAG, "manual start title=" + request.getVodName() + " episode=" + request.getEpisodeName() + " keyword=" + text);
+        Task.searchExecutor().submit(() -> {
+            SubtitleMatchResult result;
+            try {
+                SubtitleContext context = contextBuilder.build(request);
+                List<com.fongmi.android.tv.subtitle.model.SubtitleQuery> queries = TextUtils.isEmpty(text) ? queryPlanner.build(context) : queryPlanner.buildManual(context, text);
+                Log.i(TAG, "manual context title=" + context.getCanonicalTitle() + " original=" + context.getOriginalTitle() + " year=" + context.getYear() + " tmdb=" + context.hasTmdbIdentity() + " custom=" + !TextUtils.isEmpty(text) + " queries=" + queries.size());
+                List<SubtitleCandidate> ranked = ranker.rank(registry.search(queries, context), context);
+                Log.i(TAG, "manual ranked count=" + ranked.size() + " best=" + best(ranked));
+                result = SubtitleMatchResult.noMatch(ranked, ranked.isEmpty() ? "empty_result" : "manual_candidates");
+            } catch (Throwable e) {
+                Log.w(TAG, "manual error " + e.getMessage(), e);
+                result = SubtitleMatchResult.error(e.getMessage());
+            }
+            dispatch(listener, request, result);
+        });
+    }
+
+    public void resolve(SubtitleRequest request, SubtitleCandidate candidate, Listener listener) {
+        if (request == null || candidate == null) return;
+        Log.i(TAG, "resolve start provider=" + candidate.getProvider() + " id=" + candidate.getCandidateId() + " name=" + candidate.getDisplayName());
+        Task.searchExecutor().submit(() -> {
+            SubtitleMatchResult result;
+            try {
+                SubtitleContext context = contextBuilder.build(request);
+                SubtitleAsset asset = registry.resolve(candidate, context);
+                Log.i(TAG, "resolve result matched=" + (asset != null) + " provider=" + candidate.getProvider() + " id=" + candidate.getCandidateId());
+                result = asset == null ? SubtitleMatchResult.noMatch(List.of(candidate), "resolve_failed") : SubtitleMatchResult.matched(candidate, asset, List.of(candidate));
+            } catch (Throwable e) {
+                Log.w(TAG, "resolve error provider=" + candidate.getProvider() + " id=" + candidate.getCandidateId() + " error=" + e.getMessage(), e);
+                result = SubtitleMatchResult.error(e.getMessage());
+            }
+            dispatch(listener, request, result);
+        });
+    }
+
+    public void cancel(String playbackKey) {
+        if (playbackKey == null) return;
+        generations.merge(playbackKey, 1, Integer::sum);
+        Future<?> job = jobs.remove(playbackKey);
+        if (job != null) job.cancel(true);
+    }
+
+    private void runAutoMatch(SubtitleRequest request, int generation, Listener listener) {
+        SubtitleMatchResult result;
+        try {
+            SubtitleContext context = contextBuilder.build(request);
+            List<com.fongmi.android.tv.subtitle.model.SubtitleQuery> queries = queryPlanner.build(context);
+            Log.i(TAG, "auto context title=" + context.getCanonicalTitle() + " original=" + context.getOriginalTitle() + " year=" + context.getYear() + " tmdb=" + context.hasTmdbIdentity() + " queries=" + queries.size());
+            List<SubtitleCandidate> ranked = ranker.rank(registry.search(queries, context), context);
+            SubtitleCandidate selected = ranker.pickBest(ranked, context);
+            Log.i(TAG, "auto ranked count=" + ranked.size() + " selected=" + best(selected) + " best=" + best(ranked));
+            if (selected == null) {
+                result = SubtitleMatchResult.noMatch(ranked, ranked.isEmpty() ? "empty_result" : "below_threshold");
+            } else {
+                SubtitleAsset asset = registry.resolve(selected, context);
+                Log.i(TAG, "auto resolve matched=" + (asset != null) + " selected=" + best(selected));
+                result = asset == null ? SubtitleMatchResult.noMatch(ranked, "resolve_failed") : SubtitleMatchResult.matched(selected, asset, ranked);
+            }
+        } catch (Throwable e) {
+            Log.w(TAG, "auto error " + e.getMessage(), e);
+            result = SubtitleMatchResult.error(e.getMessage());
+        }
+        if (!isCurrent(request.getPlaybackKey(), generation)) return;
+        jobs.remove(request.getPlaybackKey());
+        dispatch(listener, request, result);
+    }
+
+    private boolean isCurrent(String playbackKey, int generation) {
+        return generation == generations.getOrDefault(playbackKey, 0);
+    }
+
+    private void dispatch(Listener listener, SubtitleRequest request, SubtitleMatchResult result) {
+        if (listener == null) return;
+        if (result != null) Log.i(TAG, "dispatch status=" + result.getStatus() + " reason=" + result.getReason() + " candidates=" + result.getCandidates().size());
+        App.post(() -> listener.onComplete(request, result));
+    }
+
+    private String best(List<SubtitleCandidate> ranked) {
+        return ranked == null || ranked.isEmpty() ? "" : best(ranked.get(0));
+    }
+
+    private String best(SubtitleCandidate candidate) {
+        if (candidate == null) return "";
+        return candidate.getProvider() + ":" + candidate.getCandidateId() + ":" + candidate.getScore() + ":" + candidate.getDisplayName();
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitlePlaybackSession.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitlePlaybackSession.java
@@ -1,0 +1,327 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.R;
+import com.fongmi.android.tv.bean.Episode;
+import com.fongmi.android.tv.bean.Result;
+import com.fongmi.android.tv.bean.Site;
+import com.fongmi.android.tv.bean.Sub;
+import com.fongmi.android.tv.bean.TmdbEpisode;
+import com.fongmi.android.tv.bean.TmdbItem;
+import com.fongmi.android.tv.bean.Vod;
+import com.fongmi.android.tv.player.PlayerManager;
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchResult;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchStatus;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+import com.fongmi.android.tv.subtitle.model.SubtitleTrigger;
+import com.fongmi.android.tv.utils.Notify;
+import com.fongmi.android.tv.utils.ResUtil;
+
+import java.util.List;
+
+public final class SubtitlePlaybackSession {
+
+    interface Controller {
+
+        interface Callback {
+            void onSubtitleResult(SubtitleRequest request, SubtitleMatchResult result);
+        }
+
+        void bind(Callback callback);
+
+        void onPlaybackStarted(SubtitleRequest request);
+
+        void onEpisodeChanged(SubtitleRequest request);
+
+        void onSourceChanged(SubtitleRequest request);
+
+        void onStop(String playbackKey);
+
+        void manualSearch(SubtitleRequest request, Callback callback);
+
+        default void manualSearch(SubtitleRequest request, String keyword, Callback callback) {
+            manualSearch(request, callback);
+        }
+
+        void resolve(SubtitleRequest request, SubtitleCandidate candidate, Callback callback);
+    }
+
+    interface ResultApplier {
+        boolean apply(Host host, Sub sub);
+    }
+
+    interface ResultNotifier {
+        void notify(Host host, SubtitleRequest request, SubtitleMatchResult result, boolean applied);
+    }
+
+    public interface ManualCallback {
+        void onSubtitleResult(SubtitleRequest request, SubtitleMatchResult result, boolean applied);
+    }
+
+    public interface Host {
+        String getSubtitlePlaybackKey();
+
+        Site getSubtitleSite();
+
+        Vod getSubtitleVod();
+
+        Episode getSubtitleEpisode();
+
+        TmdbItem getSubtitleTmdbItem();
+
+        TmdbEpisode getSubtitleTmdbEpisode();
+
+        PlayerManager getSubtitlePlayer();
+
+        boolean isSubtitleHostActive();
+    }
+
+    private final Controller controller;
+    private final SubtitleRequestFactory requestFactory;
+    private final SubtitleInjector injector;
+    private final ResultApplier resultApplier;
+    private final ResultNotifier resultNotifier;
+    private SubtitleRequest currentRequest;
+    private String currentEpisodeMarker;
+    private boolean active;
+
+    public SubtitlePlaybackSession(Host host) {
+        this(host, new DefaultController(), new SubtitleRequestFactory(), new SubtitleInjector(), DefaultResultApplier.INSTANCE, DefaultResultNotifier.INSTANCE);
+    }
+
+    SubtitlePlaybackSession(Host host, Controller controller, SubtitleRequestFactory requestFactory, SubtitleInjector injector, ResultApplier resultApplier) {
+        this(host, controller, requestFactory, injector, resultApplier, DefaultResultNotifier.INSTANCE);
+    }
+
+    SubtitlePlaybackSession(Host host, Controller controller, SubtitleRequestFactory requestFactory, SubtitleInjector injector, ResultApplier resultApplier, ResultNotifier resultNotifier) {
+        this.controller = controller == null ? new DefaultController() : controller;
+        this.requestFactory = requestFactory == null ? new SubtitleRequestFactory() : requestFactory;
+        this.injector = injector == null ? new SubtitleInjector() : injector;
+        this.resultApplier = resultApplier == null ? DefaultResultApplier.INSTANCE : resultApplier;
+        this.resultNotifier = resultNotifier == null ? DefaultResultNotifier.INSTANCE : resultNotifier;
+        this.currentEpisodeMarker = "";
+        this.controller.bind((request, result) -> onSubtitleResult(host, request, result));
+    }
+
+    public void onPlaybackStarted(Host host, Result result) {
+        if (host == null) return;
+        String playbackKey = host.getSubtitlePlaybackKey();
+        if (SubtitleStrings.isEmpty(playbackKey)) return;
+        if (hasProvidedSubtitle(result)) {
+            stop(host);
+            return;
+        }
+
+        SubtitleTrigger trigger = resolveTrigger(host);
+        SubtitleRequest request = requestFactory.create(playbackKey, host.getSubtitleSite(), host.getSubtitleVod(), host.getSubtitleEpisode(), result, host.getSubtitleTmdbItem(), host.getSubtitleTmdbEpisode(), trigger);
+        if (request == null || SubtitleStrings.isEmpty(request.getPlayUrl())) {
+            stop(host);
+            return;
+        }
+
+        currentRequest = request;
+        currentEpisodeMarker = episodeMarker(host.getSubtitleEpisode());
+        active = true;
+
+        if (trigger == SubtitleTrigger.AUTO_PLAY) controller.onPlaybackStarted(request);
+        else if (trigger == SubtitleTrigger.EPISODE_SWITCH) controller.onEpisodeChanged(request);
+        else controller.onSourceChanged(request);
+    }
+
+    public void stop(Host host) {
+        active = false;
+        currentRequest = null;
+        currentEpisodeMarker = "";
+        if (host != null && !SubtitleStrings.isEmpty(host.getSubtitlePlaybackKey())) controller.onStop(host.getSubtitlePlaybackKey());
+    }
+
+    public void manualSearch(Host host, ManualCallback callback) {
+        manualSearch(host, "", callback);
+    }
+
+    public void manualSearch(Host host, String keyword, ManualCallback callback) {
+        if (callback == null) return;
+        if (!canManualSearch(host)) {
+            callback.onSubtitleResult(currentRequest, SubtitleMatchResult.error("inactive"), false);
+            return;
+        }
+        SubtitleRequest request = currentRequest;
+        controller.manualSearch(request, keyword, (current, result) -> {
+            if (request != currentRequest || !isActive(host)) return;
+            callback.onSubtitleResult(current, result, false);
+        });
+    }
+
+    public String getManualSearchKeyword(Host host) {
+        if (!canManualSearch(host)) return "";
+        return manualKeyword(currentRequest);
+    }
+
+    public void resolveManual(Host host, SubtitleCandidate candidate, ManualCallback callback) {
+        if (callback == null) return;
+        if (!canManualSearch(host) || candidate == null) {
+            callback.onSubtitleResult(currentRequest, SubtitleMatchResult.error("inactive"), false);
+            return;
+        }
+        SubtitleRequest request = currentRequest;
+        controller.resolve(request, candidate, (current, result) -> {
+            if (request != currentRequest || !isActive(host)) return;
+            boolean applied = applyMatchedSubtitle(host, result);
+            callback.onSubtitleResult(current, result, applied);
+        });
+    }
+
+    private void onSubtitleResult(Host host, SubtitleRequest request, SubtitleMatchResult result) {
+        if (host == null || request == null || result == null) return;
+        if (request != currentRequest) return;
+        if (!host.isSubtitleHostActive()) return;
+        if (result.getStatus() != SubtitleMatchStatus.MATCHED || result.getAsset() == null) {
+            resultNotifier.notify(host, request, result, false);
+            return;
+        }
+
+        boolean applied = applyMatchedSubtitle(host, result);
+        resultNotifier.notify(host, request, result, applied);
+    }
+
+    private boolean applyMatchedSubtitle(Host host, SubtitleMatchResult result) {
+        if (result == null || result.getStatus() != SubtitleMatchStatus.MATCHED || result.getAsset() == null) return false;
+        Sub sub = injector.toSub(result.getAsset());
+        if (sub == null) return false;
+        return resultApplier.apply(host, sub);
+    }
+
+    private SubtitleTrigger resolveTrigger(Host host) {
+        if (!active) return SubtitleTrigger.AUTO_PLAY;
+        return SubtitleStrings.equals(currentEpisodeMarker, episodeMarker(host.getSubtitleEpisode())) ? SubtitleTrigger.SOURCE_SWITCH : SubtitleTrigger.EPISODE_SWITCH;
+    }
+
+    private boolean hasProvidedSubtitle(Result result) {
+        if (result == null) return false;
+        List<Sub> subs = result.getSubs();
+        return subs != null && !subs.isEmpty();
+    }
+
+    private boolean canManualSearch(Host host) {
+        return currentRequest != null && isActive(host);
+    }
+
+    private boolean isActive(Host host) {
+        return host != null && active && host.isSubtitleHostActive();
+    }
+
+    private String manualKeyword(SubtitleRequest request) {
+        if (request == null) return "";
+        String title = firstNonEmpty(request.getTmdbItem() == null ? "" : request.getTmdbItem().getTitle(), request.getVodName());
+        if (SubtitleStrings.isEmpty(title)) return "";
+        int season = request.getSeasonNumber();
+        int episode = request.getEpisodeNumber();
+        if (season > 0 && episode > 0) return String.format(java.util.Locale.US, "%s S%02dE%02d", title, season, episode);
+        if (episode > 0) return title + " 第" + episode + "集";
+        String year = request.getVodYear();
+        return !SubtitleStrings.isEmpty(year) && !title.contains(year) ? title + " " + year : title;
+    }
+
+    private String firstNonEmpty(String first, String second) {
+        return !SubtitleStrings.isEmpty(first) ? first : SubtitleStrings.isEmpty(second) ? "" : second;
+    }
+
+    private String episodeMarker(Episode episode) {
+        if (episode == null) return "";
+        if (!SubtitleStrings.isEmpty(episode.getUrl())) return episode.getUrl();
+        if (episode.getNumber() > 0) return String.valueOf(episode.getNumber());
+        return episode.getName();
+    }
+
+    private static final class DefaultController implements Controller {
+
+        private Callback callback;
+        private final SubtitleAutoController delegate = new SubtitleAutoController((request, result) -> {
+            if (callback != null) callback.onSubtitleResult(request, result);
+        });
+        private final SubtitleMatchService manualService = new SubtitleMatchService();
+
+        @Override
+        public void bind(Callback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void onPlaybackStarted(SubtitleRequest request) {
+            delegate.onPlaybackStarted(request);
+        }
+
+        @Override
+        public void onEpisodeChanged(SubtitleRequest request) {
+            delegate.onEpisodeChanged(request);
+        }
+
+        @Override
+        public void onSourceChanged(SubtitleRequest request) {
+            delegate.onSourceChanged(request);
+        }
+
+        @Override
+        public void onStop(String playbackKey) {
+            delegate.onStop(playbackKey);
+        }
+
+        @Override
+        public void manualSearch(SubtitleRequest request, Callback callback) {
+            manualSearch(request, "", callback);
+        }
+
+        @Override
+        public void manualSearch(SubtitleRequest request, String keyword, Callback callback) {
+            manualService.manualSearch(request, keyword, (current, result) -> {
+                if (callback != null) callback.onSubtitleResult(current, result);
+            });
+        }
+
+        @Override
+        public void resolve(SubtitleRequest request, SubtitleCandidate candidate, Callback callback) {
+            manualService.resolve(request, candidate, (current, result) -> {
+                if (callback != null) callback.onSubtitleResult(current, result);
+            });
+        }
+    }
+
+    private enum DefaultResultApplier implements ResultApplier {
+        INSTANCE;
+
+        @Override
+        public boolean apply(Host host, Sub sub) {
+            if (host == null || sub == null) return false;
+            PlayerManager player = host.getSubtitlePlayer();
+            if (player == null || player.isReleased()) return false;
+            player.setSub(sub);
+            return true;
+        }
+    }
+
+    private enum DefaultResultNotifier implements ResultNotifier {
+        INSTANCE;
+
+        @Override
+        public void notify(Host host, SubtitleRequest request, SubtitleMatchResult result, boolean applied) {
+            if (result == null || result.getStatus() == SubtitleMatchStatus.CANCELED) return;
+            switch (result.getStatus()) {
+                case MATCHED -> {
+                    String name = result.getAsset() == null ? "" : result.getAsset().getDisplayName();
+                    Notify.show(ResUtil.getString(applied ? R.string.subtitle_auto_match_hit : R.string.subtitle_auto_match_hit_not_applied, name));
+                }
+                case NO_MATCH -> Notify.show(R.string.subtitle_auto_match_empty);
+                case SKIPPED -> {
+                    if ("provider_unavailable".equals(result.getReason())) Notify.show(R.string.subtitle_auto_match_provider_unavailable);
+                }
+                case ERROR -> Notify.show(ResUtil.getString(R.string.subtitle_auto_match_failed, readableReason(result.getReason())));
+                default -> {
+                }
+            }
+        }
+
+        private String readableReason(String reason) {
+            return SubtitleStrings.isEmpty(reason) ? ResUtil.getString(R.string.subtitle_auto_match_unknown_reason) : reason;
+        }
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleQueryPlanner.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleQueryPlanner.java
@@ -1,0 +1,82 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleQuery;
+import com.fongmi.android.tv.subtitle.model.SubtitleQuerySource;
+import com.fongmi.android.tv.subtitle.model.SubtitleStrictness;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class SubtitleQueryPlanner {
+
+    public List<SubtitleQuery> build(SubtitleContext context) {
+        List<SubtitleQuery> queries = new ArrayList<>();
+        Set<String> dedupe = new LinkedHashSet<>();
+        if (context == null || SubtitleStrings.isEmpty(context.getCanonicalTitle())) return queries;
+
+        if ("tv".equalsIgnoreCase(context.getMediaType())) {
+            addEpisodeQueries(context, queries, dedupe);
+        } else {
+            addMovieQueries(context, queries, dedupe);
+        }
+        return queries;
+    }
+
+    public List<SubtitleQuery> buildManual(SubtitleContext context, String keyword) {
+        String text = keyword == null ? "" : keyword.trim();
+        if (SubtitleStrings.isEmpty(text)) return build(context);
+        List<SubtitleQuery> queries = new ArrayList<>();
+        int year = context == null ? 0 : context.getYear();
+        int season = context == null ? -1 : context.getSeasonNumber();
+        int episode = context == null ? -1 : context.getEpisodeNumber();
+        String language = context == null || SubtitleStrings.isEmpty(context.getPreferredLanguage()) ? "zh" : context.getPreferredLanguage();
+        queries.add(new SubtitleQuery(text, text, language, SubtitleQuerySource.SOURCE_TITLE, SubtitleStrictness.FALLBACK, year, season, episode));
+        return queries;
+    }
+
+    private void addMovieQueries(SubtitleContext context, List<SubtitleQuery> queries, Set<String> dedupe) {
+        add(queries, dedupe, new SubtitleQuery(key(context.getCanonicalTitle(), context.getYear()), withYear(context.getCanonicalTitle(), context.getYear()), "zh", SubtitleQuerySource.TMDB_TITLE, context.hasTmdbIdentity() ? SubtitleStrictness.STRICT : SubtitleStrictness.NORMAL, context.getYear(), -1, -1));
+        if (!SubtitleStrings.isEmpty(context.getOriginalTitle()) && !context.getOriginalTitle().equals(context.getCanonicalTitle())) {
+            add(queries, dedupe, new SubtitleQuery(key(context.getOriginalTitle(), context.getYear()), withYear(context.getOriginalTitle(), context.getYear()), "zh", SubtitleQuerySource.TMDB_ORIGINAL_TITLE, SubtitleStrictness.NORMAL, context.getYear(), -1, -1));
+        }
+        add(queries, dedupe, new SubtitleQuery(key(context.getCanonicalTitle(), 0), context.getCanonicalTitle(), "zh", SubtitleQuerySource.SOURCE_TITLE, SubtitleStrictness.FALLBACK, context.getYear(), -1, -1));
+        for (String alias : context.getAliases()) add(queries, dedupe, new SubtitleQuery(key(alias, 0), alias, "zh", SubtitleQuerySource.SOURCE_TITLE, SubtitleStrictness.FALLBACK, context.getYear(), -1, -1));
+    }
+
+    private void addEpisodeQueries(SubtitleContext context, List<SubtitleQuery> queries, Set<String> dedupe) {
+        if (context.getSeasonNumber() > 0 && context.getEpisodeNumber() > 0) {
+            String sxe = String.format("%s S%02dE%02d", context.getCanonicalTitle(), context.getSeasonNumber(), context.getEpisodeNumber());
+            add(queries, dedupe, new SubtitleQuery(key(sxe, 0), sxe, "zh", SubtitleQuerySource.EPISODE_CODE, context.hasTmdbIdentity() ? SubtitleStrictness.STRICT : SubtitleStrictness.NORMAL, context.getYear(), context.getSeasonNumber(), context.getEpisodeNumber()));
+        }
+        if (context.getEpisodeNumber() > 0) {
+            String numbered = context.getCanonicalTitle() + " 第" + context.getEpisodeNumber() + "集";
+            add(queries, dedupe, new SubtitleQuery(key(numbered, 0), numbered, "zh", SubtitleQuerySource.EPISODE_CODE, SubtitleStrictness.NORMAL, context.getYear(), context.getSeasonNumber(), context.getEpisodeNumber()));
+        }
+        if (!SubtitleStrings.isEmpty(context.getEpisodeTitle())) {
+            String title = context.getCanonicalTitle() + " " + context.getEpisodeTitle();
+            add(queries, dedupe, new SubtitleQuery(key(title, 0), title, "zh", SubtitleQuerySource.EPISODE_TITLE, SubtitleStrictness.NORMAL, context.getYear(), context.getSeasonNumber(), context.getEpisodeNumber()));
+        }
+        add(queries, dedupe, new SubtitleQuery(key(context.getCanonicalTitle(), 0), context.getCanonicalTitle(), "zh", SubtitleQuerySource.SOURCE_TITLE, SubtitleStrictness.FALLBACK, context.getYear(), context.getSeasonNumber(), context.getEpisodeNumber()));
+        if (!SubtitleStrings.isEmpty(context.getOriginalTitle()) && !context.getOriginalTitle().equals(context.getCanonicalTitle())) {
+            add(queries, dedupe, new SubtitleQuery(key(context.getOriginalTitle(), 0), context.getOriginalTitle(), "zh", SubtitleQuerySource.TMDB_ORIGINAL_TITLE, SubtitleStrictness.FALLBACK, context.getYear(), context.getSeasonNumber(), context.getEpisodeNumber()));
+        }
+    }
+
+    private void add(List<SubtitleQuery> queries, Set<String> dedupe, SubtitleQuery query) {
+        if (query == null || SubtitleStrings.isEmpty(query.getText())) return;
+        String value = query.getText().trim();
+        if (!dedupe.add(value)) return;
+        queries.add(query);
+    }
+
+    private String key(String title, int year) {
+        return title + "|" + year;
+    }
+
+    private String withYear(String title, int year) {
+        return year > 0 ? title + " " + year : title;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleRanker.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleRanker.java
@@ -1,0 +1,137 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchType;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+public final class SubtitleRanker {
+
+    public List<SubtitleCandidate> rank(List<SubtitleCandidate> candidates, SubtitleContext context) {
+        List<SubtitleCandidate> ranked = new ArrayList<>();
+        if (candidates == null) return ranked;
+        for (SubtitleCandidate candidate : candidates) ranked.add(score(candidate, context));
+        ranked.sort(Comparator.comparingInt(SubtitleCandidate::getScore).reversed().thenComparing(SubtitleCandidate::getDisplayName));
+        return ranked;
+    }
+
+    public SubtitleCandidate pickBest(List<SubtitleCandidate> ranked, SubtitleContext context) {
+        if (ranked == null || ranked.isEmpty()) return null;
+        SubtitleCandidate best = ranked.get(0);
+        int threshold = threshold(context, ranked.size());
+        if (best.getScore() < threshold) return null;
+        if (!context.hasTmdbIdentity() && ranked.size() > 1 && best.getScore() - ranked.get(1).getScore() < 5) return null;
+        return best;
+    }
+
+    private SubtitleCandidate score(SubtitleCandidate candidate, SubtitleContext context) {
+        int score = candidate.getScore();
+        SubtitleMatchType matchType = SubtitleMatchType.METADATA_FUZZY;
+        String haystack = normalize(candidate.getDisplayName() + " " + candidate.getReleaseInfo());
+        if (contains(haystack, context.getCanonicalTitle())) score += context.hasTmdbIdentity() ? 35 : 28;
+        else for (String alias : context.getAliases()) if (contains(haystack, alias)) {
+            score += 14;
+            break;
+        }
+        if (!SubtitleStrings.isEmpty(context.getOriginalTitle()) && contains(haystack, context.getOriginalTitle())) score += 18;
+        if (context.getYear() > 0) {
+            if (candidate.getYear() == context.getYear() || haystack.contains(String.valueOf(context.getYear()))) score += 12;
+            else if (candidate.getYear() > 0) score -= 6;
+        }
+        if (context.getSeasonNumber() > 0 && context.getEpisodeNumber() > 0) {
+            boolean seasonMatch = candidate.getSeasonNumber() == context.getSeasonNumber() || haystack.contains(String.format(Locale.US, "s%02de%02d", context.getSeasonNumber(), context.getEpisodeNumber()));
+            boolean episodeMatch = candidate.getEpisodeNumber() == context.getEpisodeNumber() || haystack.contains("第" + context.getEpisodeNumber() + "集");
+            if (seasonMatch && episodeMatch) {
+                score += 30;
+                matchType = context.hasTmdbIdentity() ? SubtitleMatchType.TMDB_EXACT : SubtitleMatchType.METADATA_STRICT;
+            } else if (candidate.getSeasonNumber() > 0 || candidate.getEpisodeNumber() > 0) {
+                score -= 12;
+            }
+        } else if (context.getEpisodeNumber() > 0 && candidate.getEpisodeNumber() == context.getEpisodeNumber()) {
+            score += 12;
+            matchType = SubtitleMatchType.METADATA_STRICT;
+        }
+        if (!SubtitleStrings.isEmpty(context.getEpisodeTitle()) && contains(haystack, context.getEpisodeTitle())) score += 10;
+        score += languageScore(candidate.getLanguage(), context.getPreferredLanguage());
+        score += formatScore(candidate.getFormat());
+        if (matchType == SubtitleMatchType.METADATA_FUZZY && score >= (context.hasTmdbIdentity() ? 72 : 65)) matchType = SubtitleMatchType.METADATA_STRICT;
+        return candidate.withScore(score, matchType);
+    }
+
+    private int threshold(SubtitleContext context, int count) {
+        if (context == null) return 70;
+        if (context.hasTmdbIdentity()) return "tv".equalsIgnoreCase(context.getMediaType()) ? 60 : 55;
+        if ("tv".equalsIgnoreCase(context.getMediaType())) return context.getEpisodeNumber() > 0 ? 68 : 78;
+        if (context.getYear() <= 0 && count > 1) return 78;
+        return 70;
+    }
+
+    private int languageScore(String language, String preferredLanguage) {
+        String normalized = normalizeLanguage(language);
+        String preferred = normalizeLanguageCode(preferredLanguage);
+        if (SubtitleStrings.isEmpty(preferred) || "any".equals(preferred)) return 0;
+        if (matchesPreferredLanguage(normalized, preferred)) return "zh".equals(preferred) ? 15 : 12;
+        if (preferred.startsWith("zh") && isChineseLanguage(normalized)) return 10;
+        return 0;
+    }
+
+    private boolean matchesPreferredLanguage(String language, String preferred) {
+        if (language.contains(preferred)) return true;
+        return switch (preferred) {
+            case "zh" -> isChineseLanguage(language);
+            case "zhhans" -> containsAny(language, "simplified", "simplifiedchinese", "简体", "简中", "简", "chs", "sc", "gb", "zhhans");
+            case "zhhant" -> containsAny(language, "traditional", "traditionalchinese", "繁体", "繁中", "繁", "cht", "tc", "big5", "zhhant");
+            case "en" -> containsAny(language, "english", "英文", "英语", "英語", "eng", "en");
+            case "ja" -> containsAny(language, "japanese", "日语", "日文", "日語", "jp", "ja");
+            case "ko" -> containsAny(language, "korean", "韩语", "韓語", "韩文", "韓文", "kr", "ko");
+            default -> false;
+        };
+    }
+
+    private boolean isChineseLanguage(String language) {
+        return containsAny(language, "中文", "中字", "双语", "雙語", "简", "繁", "粵", "粤", "国语", "國語", "chi", "chs", "cht", "zh");
+    }
+
+    private String normalizeLanguage(String value) {
+        return normalize(value);
+    }
+
+    private String normalizeLanguageCode(String value) {
+        String normalized = normalize(value).replace("traditional", "hant").replace("simplified", "hans");
+        if (SubtitleStrings.isEmpty(normalized)) return "zh";
+        if (normalized.startsWith("zhhans") || normalized.equals("chs") || normalized.equals("sc")) return "zhhans";
+        if (normalized.startsWith("zhhant") || normalized.startsWith("zhtw") || normalized.equals("cht") || normalized.equals("tc")) return "zhhant";
+        if (normalized.startsWith("zh")) return "zh";
+        if (normalized.startsWith("en")) return "en";
+        if (normalized.startsWith("ja") || normalized.equals("jp")) return "ja";
+        if (normalized.startsWith("ko") || normalized.equals("kr")) return "ko";
+        if (normalized.equals("any") || normalized.equals("all")) return "any";
+        return normalized;
+    }
+
+    private boolean containsAny(String value, String... needles) {
+        for (String needle : needles) if (!SubtitleStrings.isEmpty(needle) && value.contains(needle.toLowerCase(Locale.ROOT))) return true;
+        return false;
+    }
+
+    private int formatScore(String format) {
+        if (SubtitleStrings.isEmpty(format)) return 0;
+        String lower = format.toLowerCase(Locale.ROOT);
+        if (lower.contains("ssa") || lower.contains("ass")) return 10;
+        if (lower.contains("srt")) return 6;
+        if (lower.contains("vtt")) return 4;
+        return 0;
+    }
+
+    private boolean contains(String haystack, String needle) {
+        return !SubtitleStrings.isEmpty(needle) && normalize(haystack).contains(normalize(needle));
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9\u4e00-\u9fa5]+", "");
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleRequestFactory.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleRequestFactory.java
@@ -1,0 +1,47 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.bean.Episode;
+import com.fongmi.android.tv.bean.Result;
+import com.fongmi.android.tv.bean.Site;
+import com.fongmi.android.tv.bean.TmdbEpisode;
+import com.fongmi.android.tv.bean.TmdbItem;
+import com.fongmi.android.tv.bean.Vod;
+import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+import com.fongmi.android.tv.subtitle.model.SubtitleTrigger;
+
+public class SubtitleRequestFactory {
+
+    public SubtitleRequest create(String playbackKey, Site site, Vod vod, Episode episode, Result result, TmdbItem tmdbItem, TmdbEpisode tmdbEpisode, SubtitleTrigger trigger) {
+        if (result == null) return null;
+        String vodName = firstNonEmpty(vod == null ? "" : vod.getName(), tmdbItem == null ? "" : tmdbItem.getTitle());
+        String episodeName = episode == null ? "" : firstNonEmpty(episode.getDisplayName(), episode.getDesc(), episode.getName());
+        int seasonNumber = tmdbEpisode == null ? -1 : tmdbEpisode.getSeasonNumber();
+        int episodeNumber = tmdbEpisode != null && tmdbEpisode.getNumber() > 0 ? tmdbEpisode.getNumber() : episode == null ? -1 : episode.getNumber();
+
+        return SubtitleRequest.builder()
+                .playbackKey(playbackKey)
+                .siteKey(site == null ? "" : site.getKey())
+                .siteName(site == null ? "" : site.getName())
+                .vodId(vod == null ? "" : vod.getId())
+                .vodName(vodName)
+                .vodRemarks(vod == null ? "" : vod.getRemarks())
+                .vodYear(vod == null ? "" : vod.getYear())
+                .episodeName(episodeName)
+                .playUrl(result.getRealUrl())
+                .playHeaders(result.getHeader())
+                .preferredLanguage(Setting.getSubtitlePreferredLanguage())
+                .trigger(trigger)
+                .allowTmdbLookup(Setting.isTmdbReady())
+                .tmdbItem(tmdbItem)
+                .tmdbEpisode(tmdbEpisode)
+                .seasonNumber(seasonNumber)
+                .episodeNumber(episodeNumber)
+                .build();
+    }
+
+    private String firstNonEmpty(String... values) {
+        for (String value : values) if (!SubtitleStrings.isEmpty(value)) return value;
+        return "";
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleStrings.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleStrings.java
@@ -1,0 +1,17 @@
+package com.fongmi.android.tv.subtitle;
+
+final class SubtitleStrings {
+
+    private SubtitleStrings() {
+    }
+
+    static boolean isEmpty(CharSequence value) {
+        return value == null || value.length() == 0;
+    }
+
+    static boolean equals(CharSequence first, CharSequence second) {
+        if (first == second) return true;
+        if (first == null || second == null) return false;
+        return first.toString().contentEquals(second);
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleTitleParser.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleTitleParser.java
@@ -1,0 +1,135 @@
+package com.fongmi.android.tv.subtitle;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class SubtitleTitleParser {
+
+    private static final Pattern EPISODE_PATTERN = Pattern.compile("(?i)(?:s(\\d{1,2})[-._\\s]*e(\\d{1,3})|第\\s*([0-9零〇一二三四五六七八九十两百]+)\\s*[集话話])");
+    private static final Pattern SEASON_PATTERN = Pattern.compile("(?i)(?:第\\s*([0-9零〇一二三四五六七八九十两百]+)\\s*[季部]|season\\s*([0-9]{1,2})|s([0-9]{1,2})(?:[-._\\s]*e[0-9]{1,3})?)");
+
+    public String cleanTitle(String text) {
+        if (SubtitleStrings.isEmpty(text)) return "";
+
+        String raw = text.trim();
+        String clean = raw;
+        clean = clean.replaceAll("(?i)\\.(mkv|mp4|avi|mov|wmv|flv|rmvb|ts|m2ts)$", "");
+        clean = clean.replaceAll("[\\[【「『(（][^\\]】」』)）]{1,40}[\\]】」』)）]", " ");
+        clean = clean.replaceAll("(?i)S\\d+E\\d+", " ");
+        clean = clean.replaceAll("(?i)\\b(S\\d{1,2}|Season\\s*\\d{1,2})\\b", " ");
+        clean = clean.replaceAll("(?i)第\\d+季", " ");
+        clean = clean.replaceAll("(?i)第\\d+集", " ");
+        clean = clean.replaceAll("第\\s*[一二三四五六七八九十百零〇两0-9]+\\s*[季部]", " ");
+        clean = clean.replaceAll("第\\s*[一二三四五六七八九十百零〇两0-9]+\\s*[集话話]", " ");
+        clean = clean.replaceAll("(?i)\\b(HD|4K|8K|1080P|2160P|720P|HDR|HDR10|DV|BluRay|WEB[- ]?DL|HDTV|BDRip|Remux|HEVC|H\\.?265|H\\.?264|x265|x264)\\b", " ");
+        clean = clean.replaceAll("(?<!\\d)(19\\d{2}|20\\d{2})(?!\\d)", " ");
+        clean = clean.replaceAll("(国语版|国配版|普通话版|粤语版|原声版|配音版|中字版|字幕版|台版|台湾版|港版|大陆版|内地版|中国版|泰版|韩版|日版|美版|英版)", " ");
+        clean = clean.replaceAll("(臻彩|高码|高码率|无水印|无台标|国语|国配|国粤|粤语|中字|字幕|内封|简繁|双语|官中|杜比|合集|全集|完结|未删减|加长版|修复版)", " ");
+        clean = clean.replaceAll("[._\\-+]+", " ");
+        clean = clean.trim().replaceAll("\\s+", " ");
+        clean = clean.replaceAll("^[\\s:：,，.。·|/\\\\]+|[\\s:：,，.。·|/\\\\]+$", "");
+        return SubtitleStrings.isEmpty(clean) ? raw : clean;
+    }
+
+    public int firstYear(String text) {
+        if (SubtitleStrings.isEmpty(text)) return 0;
+        Matcher matcher = Pattern.compile("\\b(19\\d{2}|20\\d{2})\\b").matcher(text);
+        return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
+    }
+
+    public int seasonNumber(String text) {
+        if (SubtitleStrings.isEmpty(text)) return -1;
+        Matcher matcher = SEASON_PATTERN.matcher(text);
+        while (matcher.find()) {
+            int number = normalizeSourceNumber(firstNonEmptyGroup(matcher, 1, 2, 3));
+            if (number > 0) return number;
+        }
+        return -1;
+    }
+
+    public int episodeNumber(String text) {
+        if (SubtitleStrings.isEmpty(text)) return -1;
+        Matcher matcher = EPISODE_PATTERN.matcher(text);
+        while (matcher.find()) {
+            String sxeEpisode = matcher.group(2);
+            if (!SubtitleStrings.isEmpty(sxeEpisode)) return Integer.parseInt(sxeEpisode.replaceFirst("^0+(?!$)", ""));
+            int number = normalizeSourceNumber(firstNonEmptyGroup(matcher, 3));
+            if (number > 0) return number;
+        }
+        return -1;
+    }
+
+    public List<String> aliases(String... values) {
+        Set<String> aliases = new LinkedHashSet<>();
+        for (String value : values) {
+            if (SubtitleStrings.isEmpty(value)) continue;
+            String clean = cleanTitle(value);
+            if (!SubtitleStrings.isEmpty(clean)) aliases.add(clean);
+            int year = firstYear(value);
+            if (year > 0) {
+                String trimmed = removeYear(value, year);
+                if (!SubtitleStrings.isEmpty(trimmed)) aliases.add(trimmed);
+            }
+        }
+        return new ArrayList<>(aliases);
+    }
+
+    public String removeYear(String text, int year) {
+        if (SubtitleStrings.isEmpty(text) || year <= 0) return cleanTitle(text);
+        String cleaned = text.replaceAll("(?<!\\d)" + year + "(?!\\d)", " ");
+        cleaned = cleaned.replaceAll("[._\\-+]+", " ").replaceAll("\\s+", " ").trim();
+        return cleanTitle(cleaned);
+    }
+
+    private String firstNonEmptyGroup(Matcher matcher, int... groups) {
+        for (int group : groups) {
+            String value = matcher.group(group);
+            if (!SubtitleStrings.isEmpty(value)) return value;
+        }
+        return "";
+    }
+
+    private int normalizeSourceNumber(String value) {
+        if (SubtitleStrings.isEmpty(value)) return -1;
+        value = value.trim();
+        try {
+            if (value.matches("\\d+")) return Integer.parseInt(value.replaceFirst("^0+(?!$)", ""));
+        } catch (Exception ignored) {
+            return -1;
+        }
+        int number = parseSmallChineseNumber(value);
+        return number > 0 ? number : -1;
+    }
+
+    private int parseSmallChineseNumber(String value) {
+        if (SubtitleStrings.isEmpty(value)) return 0;
+        value = value.replace("两", "二").replace("零", "").replace("〇", "");
+        if (value.matches("[一二三四五六七八九]")) return chineseDigit(value.charAt(0));
+        int tenIndex = value.indexOf("十");
+        if (tenIndex >= 0) {
+            int tens = tenIndex == 0 ? 1 : chineseDigit(value.charAt(tenIndex - 1));
+            int ones = tenIndex == value.length() - 1 ? 0 : chineseDigit(value.charAt(tenIndex + 1));
+            return tens * 10 + ones;
+        }
+        return 0;
+    }
+
+    private int chineseDigit(char value) {
+        return switch (value) {
+            case '一' -> 1;
+            case '二' -> 2;
+            case '三' -> 3;
+            case '四' -> 4;
+            case '五' -> 5;
+            case '六' -> 6;
+            case '七' -> 7;
+            case '八' -> 8;
+            case '九' -> 9;
+            default -> 0;
+        };
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleTmdbResolver.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleTmdbResolver.java
@@ -1,0 +1,63 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.bean.TmdbEpisode;
+import com.fongmi.android.tv.bean.TmdbItem;
+import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.subtitle.model.ResolvedMediaIdentity;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+
+public final class SubtitleTmdbResolver {
+
+    private final SubtitleTitleParser parser;
+
+    public SubtitleTmdbResolver() {
+        this(new SubtitleTitleParser());
+    }
+
+    SubtitleTmdbResolver(SubtitleTitleParser parser) {
+        this.parser = parser;
+    }
+
+    public ResolvedMediaIdentity resolve(SubtitleRequest request) {
+        TmdbItem tmdbItem = request.getTmdbItem();
+        TmdbEpisode tmdbEpisode = request.getTmdbEpisode();
+        if (tmdbItem == null && request.isAllowTmdbLookup() && !SubtitleStrings.isEmpty(request.getSiteKey()) && !SubtitleStrings.isEmpty(request.getVodId())) {
+            tmdbItem = Setting.getTmdbMatchCache().find(request.getSiteKey(), request.getVodId());
+        }
+
+        ResolvedMediaIdentity.Builder builder = ResolvedMediaIdentity.builder();
+        if (tmdbItem != null) {
+            builder.tmdbId(tmdbItem.getTmdbId())
+                    .mediaType(tmdbItem.getMediaType())
+                    .canonicalTitle(tmdbItem.getTitle())
+                    .year(parser.firstYear(tmdbItem.getSubtitle()))
+                    .fromCache(request.getTmdbItem() == null);
+        }
+        if (tmdbEpisode != null) {
+            builder.tmdbEpisodeId(tmdbEpisode.getTmdbId())
+                    .episodeTitle(tmdbEpisode.getTitle())
+                    .seasonNumber(tmdbEpisode.getSeasonNumber())
+                    .episodeNumber(tmdbEpisode.getNumber())
+                    .fromBoundEpisode(true);
+        }
+
+        if (tmdbItem == null) {
+            String canonical = parser.cleanTitle(request.getVodName());
+            int year = parser.firstYear(request.getVodYear());
+            if (year <= 0) year = parser.firstYear(request.getVodName());
+            if (year <= 0) year = parser.firstYear(request.getVodRemarks());
+            int seasonNumber = request.getSeasonNumber() > 0 ? request.getSeasonNumber() : parser.seasonNumber(request.getVodName());
+            if (seasonNumber <= 0) seasonNumber = parser.seasonNumber(request.getEpisodeName());
+            int episodeNumber = request.getEpisodeNumber() > 0 ? request.getEpisodeNumber() : parser.episodeNumber(request.getEpisodeName());
+            String mediaType = seasonNumber > 0 || episodeNumber > 0 ? "tv" : "movie";
+            builder.mediaType(mediaType)
+                    .canonicalTitle(canonical)
+                    .year(year)
+                    .seasonNumber(seasonNumber)
+                    .episodeNumber(episodeNumber)
+                    .episodeTitle(parser.cleanTitle(request.getEpisodeName()));
+        }
+
+        return builder.build();
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleUriFactory.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/SubtitleUriFactory.java
@@ -1,0 +1,31 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.App;
+import com.fongmi.android.tv.server.Server;
+
+import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public final class SubtitleUriFactory {
+
+    public String fromDirectUrl(String url) {
+        return url == null ? "" : url;
+    }
+
+    public String fromLocalFile(File file) {
+        return file == null ? "" : file.getAbsolutePath();
+    }
+
+    public String fromWebResource(String url, Map<String, String> headers, boolean includeCredentials) {
+        StringBuilder builder = new StringBuilder(Server.get().getAddress("/webResource?url=")).append(encode(url));
+        if (headers != null && !headers.isEmpty()) builder.append("&headers=").append(encode(App.gson().toJson(headers)));
+        if (includeCredentials) builder.append("&credentials=include");
+        return builder.toString();
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value == null ? "" : value, StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/cache/SubtitleAssetStore.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/cache/SubtitleAssetStore.java
@@ -1,0 +1,79 @@
+package com.fongmi.android.tv.subtitle.cache;
+
+import androidx.media3.common.C;
+
+import com.fongmi.android.tv.player.PlayerHelper;
+import com.fongmi.android.tv.subtitle.SubtitleUriFactory;
+import com.fongmi.android.tv.subtitle.model.SubtitleAsset;
+import com.fongmi.android.tv.utils.FileUtil;
+import com.github.catvod.utils.Path;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public final class SubtitleAssetStore {
+
+    private final SubtitleUriFactory uriFactory;
+
+    public SubtitleAssetStore() {
+        this(new SubtitleUriFactory());
+    }
+
+    public SubtitleAssetStore(SubtitleUriFactory uriFactory) {
+        this.uriFactory = uriFactory;
+    }
+
+    public File root() {
+        File dir = Path.cache("subtitle_asset");
+        if (!dir.exists()) dir.mkdirs();
+        return dir;
+    }
+
+    public File file(String provider, String candidateId, String suffix) {
+        String safeSuffix = suffix == null || suffix.isEmpty() ? ".sub" : suffix;
+        return new File(root(), provider + "_" + com.github.catvod.utils.Util.md5(candidateId == null ? "" : candidateId) + safeSuffix);
+    }
+
+    public File unzipAndPick(File archive, String provider, String candidateId) {
+        File folder = new File(root(), provider + "_" + com.github.catvod.utils.Util.md5(candidateId == null ? "" : candidateId) + "_zip");
+        if (!folder.exists()) folder.mkdirs();
+        FileUtil.zipDecompress(archive, folder);
+        return pickSubtitleFile(folder);
+    }
+
+    public File pickSubtitleFile(File folder) {
+        List<File> matches = new ArrayList<>();
+        collect(folder, matches);
+        matches.sort(Comparator.comparingInt(this::formatWeight).thenComparing(File::getName));
+        return matches.isEmpty() ? null : matches.get(0);
+    }
+
+    public SubtitleAsset toAsset(File file, String displayName, String language, boolean fromCache) {
+        if (file == null) return null;
+        String name = displayName == null || displayName.isEmpty() ? file.getName() : displayName;
+        return new SubtitleAsset(uriFactory.fromLocalFile(file), file.getAbsolutePath(), name, language, PlayerHelper.getSubtitleMimeType(file.getName()), C.SELECTION_FLAG_DEFAULT, fromCache, 0L);
+    }
+
+    private void collect(File file, List<File> matches) {
+        if (file == null || !file.exists()) return;
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children == null) return;
+            for (File child : children) collect(child, matches);
+            return;
+        }
+        String name = file.getName().toLowerCase();
+        if (name.endsWith(".ass") || name.endsWith(".ssa") || name.endsWith(".srt") || name.endsWith(".vtt")) matches.add(file);
+    }
+
+    private int formatWeight(File file) {
+        String name = file.getName().toLowerCase();
+        if (name.endsWith(".ass")) return 0;
+        if (name.endsWith(".ssa")) return 1;
+        if (name.endsWith(".srt")) return 2;
+        if (name.endsWith(".vtt")) return 3;
+        return 4;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/ResolvedMediaIdentity.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/ResolvedMediaIdentity.java
@@ -1,0 +1,168 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public final class ResolvedMediaIdentity {
+
+    private final int tmdbId;
+    private final int tmdbEpisodeId;
+    private final String mediaType;
+    private final String canonicalTitle;
+    private final String originalTitle;
+    private final int year;
+    private final int seasonNumber;
+    private final int episodeNumber;
+    private final String episodeTitle;
+    private final boolean fromCache;
+    private final boolean fromBoundEpisode;
+    private final boolean fromRemoteResolve;
+
+    private ResolvedMediaIdentity(Builder builder) {
+        this.tmdbId = builder.tmdbId;
+        this.tmdbEpisodeId = builder.tmdbEpisodeId;
+        this.mediaType = builder.mediaType;
+        this.canonicalTitle = builder.canonicalTitle;
+        this.originalTitle = builder.originalTitle;
+        this.year = builder.year;
+        this.seasonNumber = builder.seasonNumber;
+        this.episodeNumber = builder.episodeNumber;
+        this.episodeTitle = builder.episodeTitle;
+        this.fromCache = builder.fromCache;
+        this.fromBoundEpisode = builder.fromBoundEpisode;
+        this.fromRemoteResolve = builder.fromRemoteResolve;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public int getTmdbId() {
+        return tmdbId;
+    }
+
+    public int getTmdbEpisodeId() {
+        return tmdbEpisodeId;
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public String getCanonicalTitle() {
+        return canonicalTitle;
+    }
+
+    public String getOriginalTitle() {
+        return originalTitle;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getSeasonNumber() {
+        return seasonNumber;
+    }
+
+    public int getEpisodeNumber() {
+        return episodeNumber;
+    }
+
+    public String getEpisodeTitle() {
+        return episodeTitle;
+    }
+
+    public boolean isFromCache() {
+        return fromCache;
+    }
+
+    public boolean isFromBoundEpisode() {
+        return fromBoundEpisode;
+    }
+
+    public boolean isFromRemoteResolve() {
+        return fromRemoteResolve;
+    }
+
+    public boolean hasTmdbIdentity() {
+        return tmdbId > 0 || tmdbEpisodeId > 0;
+    }
+
+    public static final class Builder {
+
+        private int tmdbId;
+        private int tmdbEpisodeId;
+        private String mediaType = "";
+        private String canonicalTitle = "";
+        private String originalTitle = "";
+        private int year;
+        private int seasonNumber = -1;
+        private int episodeNumber = -1;
+        private String episodeTitle = "";
+        private boolean fromCache;
+        private boolean fromBoundEpisode;
+        private boolean fromRemoteResolve;
+
+        public Builder tmdbId(int tmdbId) {
+            this.tmdbId = tmdbId;
+            return this;
+        }
+
+        public Builder tmdbEpisodeId(int tmdbEpisodeId) {
+            this.tmdbEpisodeId = tmdbEpisodeId;
+            return this;
+        }
+
+        public Builder mediaType(String mediaType) {
+            this.mediaType = mediaType == null ? "" : mediaType;
+            return this;
+        }
+
+        public Builder canonicalTitle(String canonicalTitle) {
+            this.canonicalTitle = canonicalTitle == null ? "" : canonicalTitle;
+            return this;
+        }
+
+        public Builder originalTitle(String originalTitle) {
+            this.originalTitle = originalTitle == null ? "" : originalTitle;
+            return this;
+        }
+
+        public Builder year(int year) {
+            this.year = year;
+            return this;
+        }
+
+        public Builder seasonNumber(int seasonNumber) {
+            this.seasonNumber = seasonNumber;
+            return this;
+        }
+
+        public Builder episodeNumber(int episodeNumber) {
+            this.episodeNumber = episodeNumber;
+            return this;
+        }
+
+        public Builder episodeTitle(String episodeTitle) {
+            this.episodeTitle = episodeTitle == null ? "" : episodeTitle;
+            return this;
+        }
+
+        public Builder fromCache(boolean fromCache) {
+            this.fromCache = fromCache;
+            return this;
+        }
+
+        public Builder fromBoundEpisode(boolean fromBoundEpisode) {
+            this.fromBoundEpisode = fromBoundEpisode;
+            return this;
+        }
+
+        public Builder fromRemoteResolve(boolean fromRemoteResolve) {
+            this.fromRemoteResolve = fromRemoteResolve;
+            return this;
+        }
+
+        public ResolvedMediaIdentity build() {
+            return new ResolvedMediaIdentity(this);
+        }
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleAsset.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleAsset.java
@@ -1,0 +1,56 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public final class SubtitleAsset {
+
+    private final String uri;
+    private final String localPath;
+    private final String displayName;
+    private final String language;
+    private final String mimeType;
+    private final int selectionFlag;
+    private final boolean fromCache;
+    private final long expireAt;
+
+    public SubtitleAsset(String uri, String localPath, String displayName, String language, String mimeType, int selectionFlag, boolean fromCache, long expireAt) {
+        this.uri = uri == null ? "" : uri;
+        this.localPath = localPath == null ? "" : localPath;
+        this.displayName = displayName == null ? "" : displayName;
+        this.language = language == null ? "" : language;
+        this.mimeType = mimeType == null ? "" : mimeType;
+        this.selectionFlag = selectionFlag;
+        this.fromCache = fromCache;
+        this.expireAt = expireAt;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getLocalPath() {
+        return localPath;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public int getSelectionFlag() {
+        return selectionFlag;
+    }
+
+    public boolean isFromCache() {
+        return fromCache;
+    }
+
+    public long getExpireAt() {
+        return expireAt;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleCandidate.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleCandidate.java
@@ -1,0 +1,96 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public final class SubtitleCandidate {
+
+    private final String provider;
+    private final String candidateId;
+    private final String displayName;
+    private final String language;
+    private final String format;
+    private final String releaseInfo;
+    private final int score;
+    private final int year;
+    private final int seasonNumber;
+    private final int episodeNumber;
+    private final SubtitleMatchType matchType;
+    private final String queryKey;
+    private final boolean requiresResolve;
+    private final String providerPayload;
+
+    public SubtitleCandidate(String provider, String candidateId, String displayName, String language, String format, String releaseInfo, int score, int year, int seasonNumber, int episodeNumber, SubtitleMatchType matchType, String queryKey, boolean requiresResolve, String providerPayload) {
+        this.provider = provider == null ? "" : provider;
+        this.candidateId = candidateId == null ? "" : candidateId;
+        this.displayName = displayName == null ? "" : displayName;
+        this.language = language == null ? "" : language;
+        this.format = format == null ? "" : format;
+        this.releaseInfo = releaseInfo == null ? "" : releaseInfo;
+        this.score = score;
+        this.year = year;
+        this.seasonNumber = seasonNumber;
+        this.episodeNumber = episodeNumber;
+        this.matchType = matchType == null ? SubtitleMatchType.METADATA_FUZZY : matchType;
+        this.queryKey = queryKey == null ? "" : queryKey;
+        this.requiresResolve = requiresResolve;
+        this.providerPayload = providerPayload == null ? "" : providerPayload;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public String getCandidateId() {
+        return candidateId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public String getReleaseInfo() {
+        return releaseInfo;
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getSeasonNumber() {
+        return seasonNumber;
+    }
+
+    public int getEpisodeNumber() {
+        return episodeNumber;
+    }
+
+    public SubtitleMatchType getMatchType() {
+        return matchType;
+    }
+
+    public String getQueryKey() {
+        return queryKey;
+    }
+
+    public boolean isRequiresResolve() {
+        return requiresResolve;
+    }
+
+    public String getProviderPayload() {
+        return providerPayload;
+    }
+
+    public SubtitleCandidate withScore(int score, SubtitleMatchType matchType) {
+        return new SubtitleCandidate(provider, candidateId, displayName, language, format, releaseInfo, score, year, seasonNumber, episodeNumber, matchType, queryKey, requiresResolve, providerPayload);
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleContext.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleContext.java
@@ -1,0 +1,226 @@
+package com.fongmi.android.tv.subtitle.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class SubtitleContext {
+
+    private final String playbackKey;
+    private final String siteKey;
+    private final String vodId;
+    private final String mediaType;
+    private final String canonicalTitle;
+    private final String originalTitle;
+    private final List<String> aliases;
+    private final int year;
+    private final int seasonNumber;
+    private final int episodeNumber;
+    private final String episodeTitle;
+    private final String preferredLanguage;
+    private final String originalLanguage;
+    private final String originCountry;
+    private final boolean networkStream;
+    private final ResolvedMediaIdentity identity;
+
+    private SubtitleContext(Builder builder) {
+        this.playbackKey = builder.playbackKey;
+        this.siteKey = builder.siteKey;
+        this.vodId = builder.vodId;
+        this.mediaType = builder.mediaType;
+        this.canonicalTitle = builder.canonicalTitle;
+        this.originalTitle = builder.originalTitle;
+        this.aliases = Collections.unmodifiableList(new ArrayList<>(builder.aliases));
+        this.year = builder.year;
+        this.seasonNumber = builder.seasonNumber;
+        this.episodeNumber = builder.episodeNumber;
+        this.episodeTitle = builder.episodeTitle;
+        this.preferredLanguage = builder.preferredLanguage;
+        this.originalLanguage = builder.originalLanguage;
+        this.originCountry = builder.originCountry;
+        this.networkStream = builder.networkStream;
+        this.identity = builder.identity;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getPlaybackKey() {
+        return playbackKey;
+    }
+
+    public String getSiteKey() {
+        return siteKey;
+    }
+
+    public String getVodId() {
+        return vodId;
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public String getCanonicalTitle() {
+        return canonicalTitle;
+    }
+
+    public String getOriginalTitle() {
+        return originalTitle;
+    }
+
+    public List<String> getAliases() {
+        return aliases;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getSeasonNumber() {
+        return seasonNumber;
+    }
+
+    public int getEpisodeNumber() {
+        return episodeNumber;
+    }
+
+    public String getEpisodeTitle() {
+        return episodeTitle;
+    }
+
+    public String getPreferredLanguage() {
+        return preferredLanguage;
+    }
+
+    public String getOriginalLanguage() {
+        return originalLanguage;
+    }
+
+    public String getOriginCountry() {
+        return originCountry;
+    }
+
+    public boolean isNetworkStream() {
+        return networkStream;
+    }
+
+    public ResolvedMediaIdentity getIdentity() {
+        return identity;
+    }
+
+    public boolean hasTmdbIdentity() {
+        return identity != null && identity.hasTmdbIdentity();
+    }
+
+    public static final class Builder {
+
+        private String playbackKey = "";
+        private String siteKey = "";
+        private String vodId = "";
+        private String mediaType = "";
+        private String canonicalTitle = "";
+        private String originalTitle = "";
+        private final List<String> aliases = new ArrayList<>();
+        private int year;
+        private int seasonNumber = -1;
+        private int episodeNumber = -1;
+        private String episodeTitle = "";
+        private String preferredLanguage = "zh";
+        private String originalLanguage = "";
+        private String originCountry = "";
+        private boolean networkStream = true;
+        private ResolvedMediaIdentity identity;
+
+        public Builder playbackKey(String playbackKey) {
+            this.playbackKey = playbackKey == null ? "" : playbackKey;
+            return this;
+        }
+
+        public Builder siteKey(String siteKey) {
+            this.siteKey = siteKey == null ? "" : siteKey;
+            return this;
+        }
+
+        public Builder vodId(String vodId) {
+            this.vodId = vodId == null ? "" : vodId;
+            return this;
+        }
+
+        public Builder mediaType(String mediaType) {
+            this.mediaType = mediaType == null ? "" : mediaType;
+            return this;
+        }
+
+        public Builder canonicalTitle(String canonicalTitle) {
+            this.canonicalTitle = canonicalTitle == null ? "" : canonicalTitle;
+            return this;
+        }
+
+        public Builder originalTitle(String originalTitle) {
+            this.originalTitle = originalTitle == null ? "" : originalTitle;
+            return this;
+        }
+
+        public Builder addAlias(String alias) {
+            if (alias != null && !alias.isEmpty() && !aliases.contains(alias)) aliases.add(alias);
+            return this;
+        }
+
+        public Builder aliases(List<String> aliases) {
+            this.aliases.clear();
+            if (aliases != null) for (String alias : aliases) addAlias(alias);
+            return this;
+        }
+
+        public Builder year(int year) {
+            this.year = year;
+            return this;
+        }
+
+        public Builder seasonNumber(int seasonNumber) {
+            this.seasonNumber = seasonNumber;
+            return this;
+        }
+
+        public Builder episodeNumber(int episodeNumber) {
+            this.episodeNumber = episodeNumber;
+            return this;
+        }
+
+        public Builder episodeTitle(String episodeTitle) {
+            this.episodeTitle = episodeTitle == null ? "" : episodeTitle;
+            return this;
+        }
+
+        public Builder preferredLanguage(String preferredLanguage) {
+            this.preferredLanguage = preferredLanguage == null ? "zh" : preferredLanguage;
+            return this;
+        }
+
+        public Builder originalLanguage(String originalLanguage) {
+            this.originalLanguage = originalLanguage == null ? "" : originalLanguage;
+            return this;
+        }
+
+        public Builder originCountry(String originCountry) {
+            this.originCountry = originCountry == null ? "" : originCountry;
+            return this;
+        }
+
+        public Builder networkStream(boolean networkStream) {
+            this.networkStream = networkStream;
+            return this;
+        }
+
+        public Builder identity(ResolvedMediaIdentity identity) {
+            this.identity = identity;
+            return this;
+        }
+
+        public SubtitleContext build() {
+            return new SubtitleContext(this);
+        }
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleMatchResult.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleMatchResult.java
@@ -1,0 +1,68 @@
+package com.fongmi.android.tv.subtitle.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class SubtitleMatchResult {
+
+    private final SubtitleMatchStatus status;
+    private final SubtitleCandidate selected;
+    private final SubtitleAsset asset;
+    private final List<SubtitleCandidate> candidates;
+    private final String reason;
+    private final boolean cacheHit;
+
+    public SubtitleMatchResult(SubtitleMatchStatus status, SubtitleCandidate selected, SubtitleAsset asset, List<SubtitleCandidate> candidates, String reason, boolean cacheHit) {
+        this.status = status == null ? SubtitleMatchStatus.NO_MATCH : status;
+        this.selected = selected;
+        this.asset = asset;
+        this.candidates = candidates == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(candidates));
+        this.reason = reason == null ? "" : reason;
+        this.cacheHit = cacheHit;
+    }
+
+    public static SubtitleMatchResult matched(SubtitleCandidate selected, SubtitleAsset asset, List<SubtitleCandidate> candidates) {
+        return new SubtitleMatchResult(SubtitleMatchStatus.MATCHED, selected, asset, candidates, "", false);
+    }
+
+    public static SubtitleMatchResult noMatch(List<SubtitleCandidate> candidates, String reason) {
+        return new SubtitleMatchResult(SubtitleMatchStatus.NO_MATCH, null, null, candidates, reason, false);
+    }
+
+    public static SubtitleMatchResult skipped(String reason) {
+        return new SubtitleMatchResult(SubtitleMatchStatus.SKIPPED, null, null, Collections.emptyList(), reason, false);
+    }
+
+    public static SubtitleMatchResult error(String reason) {
+        return new SubtitleMatchResult(SubtitleMatchStatus.ERROR, null, null, Collections.emptyList(), reason, false);
+    }
+
+    public static SubtitleMatchResult canceled() {
+        return new SubtitleMatchResult(SubtitleMatchStatus.CANCELED, null, null, Collections.emptyList(), "canceled", false);
+    }
+
+    public SubtitleMatchStatus getStatus() {
+        return status;
+    }
+
+    public SubtitleCandidate getSelected() {
+        return selected;
+    }
+
+    public SubtitleAsset getAsset() {
+        return asset;
+    }
+
+    public List<SubtitleCandidate> getCandidates() {
+        return candidates;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public boolean isCacheHit() {
+        return cacheHit;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleMatchStatus.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleMatchStatus.java
@@ -1,0 +1,9 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public enum SubtitleMatchStatus {
+    MATCHED,
+    NO_MATCH,
+    SKIPPED,
+    ERROR,
+    CANCELED
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleMatchType.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleMatchType.java
@@ -1,0 +1,8 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public enum SubtitleMatchType {
+    TMDB_EXACT,
+    METADATA_STRICT,
+    METADATA_FUZZY,
+    MANUAL
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleQuery.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleQuery.java
@@ -1,0 +1,56 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public final class SubtitleQuery {
+
+    private final String key;
+    private final String text;
+    private final String language;
+    private final SubtitleQuerySource source;
+    private final SubtitleStrictness strictness;
+    private final int year;
+    private final int seasonNumber;
+    private final int episodeNumber;
+
+    public SubtitleQuery(String key, String text, String language, SubtitleQuerySource source, SubtitleStrictness strictness, int year, int seasonNumber, int episodeNumber) {
+        this.key = key == null ? "" : key;
+        this.text = text == null ? "" : text;
+        this.language = language == null ? "" : language;
+        this.source = source == null ? SubtitleQuerySource.SOURCE_TITLE : source;
+        this.strictness = strictness == null ? SubtitleStrictness.NORMAL : strictness;
+        this.year = year;
+        this.seasonNumber = seasonNumber;
+        this.episodeNumber = episodeNumber;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public SubtitleQuerySource getSource() {
+        return source;
+    }
+
+    public SubtitleStrictness getStrictness() {
+        return strictness;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getSeasonNumber() {
+        return seasonNumber;
+    }
+
+    public int getEpisodeNumber() {
+        return episodeNumber;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleQuerySource.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleQuerySource.java
@@ -1,0 +1,10 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public enum SubtitleQuerySource {
+    TMDB_TITLE,
+    TMDB_ORIGINAL_TITLE,
+    EPISODE_CODE,
+    EPISODE_TITLE,
+    MANUAL,
+    SOURCE_TITLE
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleRequest.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleRequest.java
@@ -1,0 +1,247 @@
+package com.fongmi.android.tv.subtitle.model;
+
+import androidx.annotation.Nullable;
+
+import com.fongmi.android.tv.bean.TmdbEpisode;
+import com.fongmi.android.tv.bean.TmdbItem;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SubtitleRequest {
+
+    private final String playbackKey;
+    private final String siteKey;
+    private final String siteName;
+    private final String vodId;
+    private final String vodName;
+    private final String vodRemarks;
+    private final String vodYear;
+    private final String episodeName;
+    private final String playUrl;
+    private final Map<String, String> playHeaders;
+    private final String preferredLanguage;
+    private final SubtitleTrigger trigger;
+    private final boolean allowTmdbLookup;
+    private final boolean manualOnly;
+    private final TmdbItem tmdbItem;
+    private final TmdbEpisode tmdbEpisode;
+    private final int seasonNumber;
+    private final int episodeNumber;
+
+    private SubtitleRequest(Builder builder) {
+        this.playbackKey = builder.playbackKey;
+        this.siteKey = builder.siteKey;
+        this.siteName = builder.siteName;
+        this.vodId = builder.vodId;
+        this.vodName = builder.vodName;
+        this.vodRemarks = builder.vodRemarks;
+        this.vodYear = builder.vodYear;
+        this.episodeName = builder.episodeName;
+        this.playUrl = builder.playUrl;
+        this.playHeaders = Collections.unmodifiableMap(new HashMap<>(builder.playHeaders));
+        this.preferredLanguage = builder.preferredLanguage;
+        this.trigger = builder.trigger;
+        this.allowTmdbLookup = builder.allowTmdbLookup;
+        this.manualOnly = builder.manualOnly;
+        this.tmdbItem = builder.tmdbItem;
+        this.tmdbEpisode = builder.tmdbEpisode;
+        this.seasonNumber = builder.seasonNumber;
+        this.episodeNumber = builder.episodeNumber;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getPlaybackKey() {
+        return playbackKey;
+    }
+
+    public String getSiteKey() {
+        return siteKey;
+    }
+
+    public String getSiteName() {
+        return siteName;
+    }
+
+    public String getVodId() {
+        return vodId;
+    }
+
+    public String getVodName() {
+        return vodName;
+    }
+
+    public String getVodRemarks() {
+        return vodRemarks;
+    }
+
+    public String getVodYear() {
+        return vodYear;
+    }
+
+    public String getEpisodeName() {
+        return episodeName;
+    }
+
+    public String getPlayUrl() {
+        return playUrl;
+    }
+
+    public Map<String, String> getPlayHeaders() {
+        return playHeaders;
+    }
+
+    public String getPreferredLanguage() {
+        return preferredLanguage;
+    }
+
+    public SubtitleTrigger getTrigger() {
+        return trigger;
+    }
+
+    public boolean isAllowTmdbLookup() {
+        return allowTmdbLookup;
+    }
+
+    public boolean isManualOnly() {
+        return manualOnly;
+    }
+
+    @Nullable
+    public TmdbItem getTmdbItem() {
+        return tmdbItem;
+    }
+
+    @Nullable
+    public TmdbEpisode getTmdbEpisode() {
+        return tmdbEpisode;
+    }
+
+    public int getSeasonNumber() {
+        return seasonNumber;
+    }
+
+    public int getEpisodeNumber() {
+        return episodeNumber;
+    }
+
+    public static final class Builder {
+
+        private String playbackKey = "";
+        private String siteKey = "";
+        private String siteName = "";
+        private String vodId = "";
+        private String vodName = "";
+        private String vodRemarks = "";
+        private String vodYear = "";
+        private String episodeName = "";
+        private String playUrl = "";
+        private Map<String, String> playHeaders = new HashMap<>();
+        private String preferredLanguage = "zh";
+        private SubtitleTrigger trigger = SubtitleTrigger.AUTO_PLAY;
+        private boolean allowTmdbLookup = true;
+        private boolean manualOnly = false;
+        private TmdbItem tmdbItem;
+        private TmdbEpisode tmdbEpisode;
+        private int seasonNumber = -1;
+        private int episodeNumber = -1;
+
+        public Builder playbackKey(String playbackKey) {
+            this.playbackKey = playbackKey == null ? "" : playbackKey;
+            return this;
+        }
+
+        public Builder siteKey(String siteKey) {
+            this.siteKey = siteKey == null ? "" : siteKey;
+            return this;
+        }
+
+        public Builder siteName(String siteName) {
+            this.siteName = siteName == null ? "" : siteName;
+            return this;
+        }
+
+        public Builder vodId(String vodId) {
+            this.vodId = vodId == null ? "" : vodId;
+            return this;
+        }
+
+        public Builder vodName(String vodName) {
+            this.vodName = vodName == null ? "" : vodName;
+            return this;
+        }
+
+        public Builder vodRemarks(String vodRemarks) {
+            this.vodRemarks = vodRemarks == null ? "" : vodRemarks;
+            return this;
+        }
+
+        public Builder vodYear(String vodYear) {
+            this.vodYear = vodYear == null ? "" : vodYear;
+            return this;
+        }
+
+        public Builder episodeName(String episodeName) {
+            this.episodeName = episodeName == null ? "" : episodeName;
+            return this;
+        }
+
+        public Builder playUrl(String playUrl) {
+            this.playUrl = playUrl == null ? "" : playUrl;
+            return this;
+        }
+
+        public Builder playHeaders(Map<String, String> playHeaders) {
+            this.playHeaders = playHeaders == null ? new HashMap<>() : new HashMap<>(playHeaders);
+            return this;
+        }
+
+        public Builder preferredLanguage(String preferredLanguage) {
+            this.preferredLanguage = preferredLanguage == null ? "zh" : preferredLanguage;
+            return this;
+        }
+
+        public Builder trigger(SubtitleTrigger trigger) {
+            this.trigger = trigger == null ? SubtitleTrigger.AUTO_PLAY : trigger;
+            return this;
+        }
+
+        public Builder allowTmdbLookup(boolean allowTmdbLookup) {
+            this.allowTmdbLookup = allowTmdbLookup;
+            return this;
+        }
+
+        public Builder manualOnly(boolean manualOnly) {
+            this.manualOnly = manualOnly;
+            return this;
+        }
+
+        public Builder tmdbItem(TmdbItem tmdbItem) {
+            this.tmdbItem = tmdbItem;
+            return this;
+        }
+
+        public Builder tmdbEpisode(TmdbEpisode tmdbEpisode) {
+            this.tmdbEpisode = tmdbEpisode;
+            return this;
+        }
+
+        public Builder seasonNumber(int seasonNumber) {
+            this.seasonNumber = seasonNumber;
+            return this;
+        }
+
+        public Builder episodeNumber(int episodeNumber) {
+            this.episodeNumber = episodeNumber;
+            return this;
+        }
+
+        public SubtitleRequest build() {
+            return new SubtitleRequest(this);
+        }
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleStrictness.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleStrictness.java
@@ -1,0 +1,7 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public enum SubtitleStrictness {
+    STRICT,
+    NORMAL,
+    FALLBACK
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleTrigger.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/model/SubtitleTrigger.java
@@ -1,0 +1,8 @@
+package com.fongmi.android.tv.subtitle.model;
+
+public enum SubtitleTrigger {
+    AUTO_PLAY,
+    EPISODE_SWITCH,
+    SOURCE_SWITCH,
+    MANUAL_SEARCH
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/provider/AssrtSubtitleProvider.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/provider/AssrtSubtitleProvider.java
@@ -1,0 +1,244 @@
+package com.fongmi.android.tv.subtitle.provider;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.fongmi.android.tv.App;
+import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.subtitle.SubtitleTitleParser;
+import com.fongmi.android.tv.subtitle.cache.SubtitleAssetStore;
+import com.fongmi.android.tv.subtitle.model.SubtitleAsset;
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchType;
+import com.fongmi.android.tv.subtitle.model.SubtitleQuery;
+import com.github.catvod.net.OkHttp;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public final class AssrtSubtitleProvider implements SubtitleProvider {
+
+    private static final String TAG = "SubtitleMatch";
+    private static final String NAME = "assrt";
+    private static final String API_BASE = "https://api.assrt.net/v1";
+    private static final String REFERER = "https://assrt.net/";
+    private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+    private final SubtitleTitleParser parser;
+    private final SubtitleAssetStore assetStore;
+
+    public AssrtSubtitleProvider() {
+        this.parser = new SubtitleTitleParser();
+        this.assetStore = new SubtitleAssetStore();
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        boolean enabled = !TextUtils.isEmpty(Setting.getSubtitleAssrtToken());
+        if (!enabled) Log.w(TAG, "assrt disabled reason=empty_token");
+        return enabled;
+    }
+
+    @Override
+    public List<SubtitleCandidate> search(SubtitleQuery query, SubtitleContext context) throws Exception {
+        List<SubtitleCandidate> items = new ArrayList<>();
+        if (!isEnabled() || query == null || TextUtils.isEmpty(query.getText())) return items;
+        Log.i(TAG, "assrt search request q=" + query.getText());
+        String url = API_BASE + "/sub/search?token=" + encode(Setting.getSubtitleAssrtToken()) + "&q=" + encode(query.getText()) + "&is_file=1&cnt=15";
+        try (Response response = OkHttp.client().newCall(new Request.Builder().url(url).get().build()).execute()) {
+            if (!response.isSuccessful() || response.body() == null) {
+                Log.w(TAG, "assrt search http_failed code=" + response.code() + " q=" + query.getText());
+                return items;
+            }
+            String body = response.body().string();
+            JsonObject root = JsonParser.parseString(body).getAsJsonObject();
+            int status = safeInt(root, "status");
+            if (status != 0) {
+                Log.w(TAG, "assrt search api_failed status=" + status + " q=" + query.getText());
+                return items;
+            }
+            JsonArray subs = safeArray(safeObject(root, "sub"), "subs");
+            Log.i(TAG, "assrt search response q=" + query.getText() + " count=" + subs.size());
+            for (JsonElement element : subs) {
+                if (!element.isJsonObject()) continue;
+                JsonObject item = element.getAsJsonObject();
+                String id = firstString(item, "id", "fileid");
+                if (TextUtils.isEmpty(id)) continue;
+                String name = firstString(item, "name", "sub_name", "m_version", "m_title");
+                String videoName = firstString(item, "videoname", "m_videoname", "video_chinese_name", "m_video_chinese_name");
+                String format = detectFormat(firstString(item, "subtype", "m_subtype"), name);
+                String language = firstString(safeObject(item, "lang"), "desc");
+                if (TextUtils.isEmpty(language)) language = firstString(item, "m_lang");
+                int season = parser.seasonNumber(name + " " + videoName);
+                int episode = parser.episodeNumber(name + " " + videoName);
+                int year = parser.firstYear(videoName);
+                JsonObject payload = new JsonObject();
+                payload.addProperty("id", id);
+                payload.addProperty("format", format);
+                items.add(new SubtitleCandidate(NAME, id, name, language, format, videoName, 0, year, season, episode, SubtitleMatchType.METADATA_FUZZY, query.getKey(), true, App.gson().toJson(payload)));
+            }
+        }
+        Log.i(TAG, "assrt search candidates q=" + query.getText() + " count=" + items.size());
+        return items;
+    }
+
+    @Override
+    public SubtitleAsset resolve(SubtitleCandidate candidate, SubtitleContext context) throws Exception {
+        if (candidate == null) return null;
+        JsonObject payload = JsonParser.parseString(candidate.getProviderPayload()).getAsJsonObject();
+        String id = safeString(payload, "id");
+        if (TextUtils.isEmpty(id)) id = candidate.getCandidateId();
+        Log.i(TAG, "assrt detail request id=" + id);
+        String url = API_BASE + "/sub/detail?token=" + encode(Setting.getSubtitleAssrtToken()) + "&id=" + encode(id);
+        try (Response response = OkHttp.client().newCall(new Request.Builder().url(url).get().build()).execute()) {
+            if (!response.isSuccessful() || response.body() == null) {
+                Log.w(TAG, "assrt detail http_failed code=" + response.code() + " id=" + id);
+                return null;
+            }
+            String body = response.body().string();
+            JsonObject root = JsonParser.parseString(body).getAsJsonObject();
+            int status = safeInt(root, "status");
+            if (status != 0) {
+                Log.w(TAG, "assrt detail api_failed status=" + status + " id=" + id);
+                return null;
+            }
+            JsonArray subs = safeArray(safeObject(root, "sub"), "subs");
+            JsonObject first = firstObject(subs);
+            if (first == null) {
+                Log.w(TAG, "assrt detail empty_subs id=" + id);
+                return null;
+            }
+            String downloadUrl = safeString(first, "url");
+            if (TextUtils.isEmpty(downloadUrl)) {
+                Log.w(TAG, "assrt detail empty_url id=" + id);
+                return null;
+            }
+            String filename = safeString(first, "filename");
+            File archive = download(downloadUrl, candidate, filename);
+            File target = isZip(archive, filename) ? assetStore.unzipAndPick(archive, NAME, id) : archive;
+            Log.i(TAG, "assrt detail resolved id=" + id + " file=" + target.getName());
+            return assetStore.toAsset(target, candidate.getDisplayName(), candidate.getLanguage(), false);
+        }
+    }
+
+    private File download(String url, SubtitleCandidate candidate, String filename) throws Exception {
+        String suffix = suffix(filename, candidate.getFormat());
+        File target = assetStore.file(NAME, candidate.getCandidateId(), suffix);
+        try (Response response = executeRedirects(url)) {
+            if (!response.isSuccessful() || response.body() == null) {
+                Log.w(TAG, "assrt download failed code=" + response.code() + " id=" + candidate.getCandidateId());
+                throw new IllegalStateException("download_failed");
+            }
+            try (InputStream input = response.body().byteStream(); FileOutputStream output = new FileOutputStream(target)) {
+                byte[] buffer = new byte[16384];
+                int read;
+                while ((read = input.read(buffer)) != -1) output.write(buffer, 0, read);
+            }
+        }
+        return target;
+    }
+
+    private Response executeRedirects(String url) throws Exception {
+        String current = url;
+        for (int i = 0; i < 5; i++) {
+            Request request = new Request.Builder().url(current).header("User-Agent", USER_AGENT).header("Referer", REFERER).header("Connection", "close").get().build();
+            Response response = OkHttp.noRedirect().newCall(request).execute();
+            if (!isRedirect(response.code())) return response;
+            String location = response.header("Location");
+            HttpUrl resolved = response.request().url().resolve(location == null ? "" : location);
+            response.close();
+            if (resolved == null) throw new IllegalStateException("redirect_failed");
+            current = resolved.toString();
+        }
+        throw new IllegalStateException("redirect_overflow");
+    }
+
+    private boolean isRedirect(int code) {
+        return code == 301 || code == 302 || code == 303 || code == 307 || code == 308;
+    }
+
+    private boolean isZip(File file, String filename) {
+        if (!TextUtils.isEmpty(filename) && filename.toLowerCase(Locale.ROOT).endsWith(".zip")) return true;
+        try (FileInputStream input = new FileInputStream(file)) {
+            byte[] header = new byte[4];
+            if (input.read(header) == 4) return header[0] == 0x50 && header[1] == 0x4B && header[2] == 0x03 && header[3] == 0x04;
+        } catch (Exception ignored) {
+        }
+        return false;
+    }
+
+    private String suffix(String filename, String format) {
+        if (!TextUtils.isEmpty(filename) && filename.contains(".")) return filename.substring(filename.lastIndexOf('.'));
+        if (!TextUtils.isEmpty(format)) return "." + format.toLowerCase(Locale.ROOT);
+        return ".sub";
+    }
+
+    private String detectFormat(String subtype, String name) {
+        String text = (subtype + " " + name).toLowerCase(Locale.ROOT);
+        if (text.contains(".ass") || text.contains(" ass")) return "ass";
+        if (text.contains(".ssa") || text.contains(" ssa")) return "ssa";
+        if (text.contains(".vtt") || text.contains(" vtt")) return "vtt";
+        return "srt";
+    }
+
+    private JsonObject firstObject(JsonArray array) {
+        for (JsonElement element : array) if (element.isJsonObject()) return element.getAsJsonObject();
+        return null;
+    }
+
+    private JsonObject safeObject(JsonObject object, String key) {
+        return object != null && object.has(key) && object.get(key).isJsonObject() ? object.getAsJsonObject(key) : new JsonObject();
+    }
+
+    private JsonArray safeArray(JsonObject object, String key) {
+        return object != null && object.has(key) && object.get(key).isJsonArray() ? object.getAsJsonArray(key) : new JsonArray();
+    }
+
+    private String safeString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) return "";
+        return object.get(key).getAsString();
+    }
+
+    private String firstString(JsonObject object, String... keys) {
+        if (object == null || keys == null) return "";
+        for (String key : keys) {
+            String value = safeString(object, key);
+            if (!TextUtils.isEmpty(value)) return value;
+        }
+        return "";
+    }
+
+    private int safeInt(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) return 0;
+        try {
+            return object.get(key).getAsInt();
+        } catch (Exception ignored) {
+            return 0;
+        }
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value == null ? "" : value, StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/provider/SubtitleProvider.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/provider/SubtitleProvider.java
@@ -1,0 +1,19 @@
+package com.fongmi.android.tv.subtitle.provider;
+
+import com.fongmi.android.tv.subtitle.model.SubtitleAsset;
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleQuery;
+
+import java.util.List;
+
+public interface SubtitleProvider {
+
+    String getName();
+
+    boolean isEnabled();
+
+    List<SubtitleCandidate> search(SubtitleQuery query, SubtitleContext context) throws Exception;
+
+    SubtitleAsset resolve(SubtitleCandidate candidate, SubtitleContext context) throws Exception;
+}

--- a/app/src/main/java/com/fongmi/android/tv/subtitle/provider/SubtitleProviderRegistry.java
+++ b/app/src/main/java/com/fongmi/android/tv/subtitle/provider/SubtitleProviderRegistry.java
@@ -1,0 +1,69 @@
+package com.fongmi.android.tv.subtitle.provider;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.fongmi.android.tv.subtitle.model.SubtitleAsset;
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleQuery;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class SubtitleProviderRegistry {
+
+    private static final String TAG = "SubtitleMatch";
+
+    private final Map<String, SubtitleProvider> providers;
+
+    public SubtitleProviderRegistry() {
+        this.providers = new LinkedHashMap<>();
+        register(new AssrtSubtitleProvider());
+    }
+
+    public void register(SubtitleProvider provider) {
+        if (provider == null || TextUtils.isEmpty(provider.getName())) return;
+        providers.put(provider.getName(), provider);
+    }
+
+    public List<SubtitleProvider> enabledProviders() {
+        List<SubtitleProvider> items = new ArrayList<>();
+        for (SubtitleProvider provider : providers.values()) if (provider.isEnabled()) items.add(provider);
+        return items;
+    }
+
+    public List<SubtitleCandidate> search(List<SubtitleQuery> queries, SubtitleContext context) {
+        List<SubtitleCandidate> items = new ArrayList<>();
+        Set<String> dedupe = new LinkedHashSet<>();
+        for (SubtitleProvider provider : enabledProviders()) {
+            int before = items.size();
+            for (SubtitleQuery query : queries) {
+                try {
+                    int queryBefore = items.size();
+                    Log.i(TAG, "provider search start provider=" + provider.getName() + " query=" + query.getText() + " source=" + query.getSource());
+                    for (SubtitleCandidate candidate : provider.search(query, context)) {
+                        if (candidate == null) continue;
+                        String key = candidate.getProvider() + "|" + candidate.getCandidateId();
+                        if (dedupe.add(key)) items.add(candidate);
+                    }
+                    Log.i(TAG, "provider search done provider=" + provider.getName() + " query=" + query.getText() + " added=" + (items.size() - queryBefore));
+                } catch (Throwable ignored) {
+                    Log.w(TAG, "provider search failed provider=" + provider.getName() + " query=" + query.getText() + " error=" + ignored.getMessage(), ignored);
+                }
+            }
+            Log.i(TAG, "provider summary provider=" + provider.getName() + " totalAdded=" + (items.size() - before));
+        }
+        return items;
+    }
+
+    public SubtitleAsset resolve(SubtitleCandidate candidate, SubtitleContext context) throws Exception {
+        if (candidate == null) return null;
+        SubtitleProvider provider = providers.get(candidate.getProvider());
+        return provider == null ? null : provider.resolve(candidate, context);
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -72,6 +72,7 @@ import com.fongmi.android.tv.databinding.DialogTmdbEpisodeBinding;
 import com.fongmi.android.tv.db.AppDatabase;
 import com.fongmi.android.tv.event.RefreshEvent;
 import com.fongmi.android.tv.player.IntroSkipPlayback;
+import com.fongmi.android.tv.player.PlayerManager;
 import com.fongmi.android.tv.player.PlayerHelper;
 import com.fongmi.android.tv.service.AiRecommendationService;
 import com.fongmi.android.tv.service.PersonalRecommendationService;
@@ -81,6 +82,7 @@ import com.fongmi.android.tv.service.TmdbService;
 import com.fongmi.android.tv.setting.DanmakuSetting;
 import com.fongmi.android.tv.setting.PlayerSetting;
 import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.subtitle.SubtitlePlaybackSession;
 import com.fongmi.android.tv.ui.adapter.EpisodeAdapter;
 import com.fongmi.android.tv.ui.adapter.InlineEpisodeAdapter;
 import com.fongmi.android.tv.ui.adapter.TmdbEpisodeAdapter;
@@ -94,6 +96,7 @@ import com.fongmi.android.tv.ui.custom.PlayerGesture;
 import com.fongmi.android.tv.ui.dialog.DanmakuDialog;
 import com.fongmi.android.tv.ui.dialog.DisplayDialog;
 import com.fongmi.android.tv.ui.dialog.SubtitleDialog;
+import com.fongmi.android.tv.ui.dialog.SubtitleManualSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TitleDialog;
 import com.fongmi.android.tv.ui.dialog.TmdbSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TrackDialog;
@@ -157,7 +160,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.Listener, Clock.Callback, PlayerGesture.Listener {
+public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.Listener, Clock.Callback, PlayerGesture.Listener, SubtitlePlaybackSession.Host {
 
     private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss", Locale.getDefault());
     private static final int FOCUS_STROKE = 0xFFFFD166;
@@ -177,6 +180,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     private final TmdbService tmdbService = new TmdbService();
     private final IntroSkipPlayback introSkipPlayback = new IntroSkipPlayback();
+    private final SubtitlePlaybackSession subtitlePlaybackSession = new SubtitlePlaybackSession(this);
     private final List<TmdbPerson> detailCastItems = new ArrayList<>();
     private final List<TmdbPerson> castItems = new ArrayList<>();
     private final List<TmdbPerson> creatorItems = new ArrayList<>();
@@ -445,6 +449,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         personalDoubanItems.clear();
         personalAiItems.clear();
         if (service() != null) {
+            subtitlePlaybackSession.stop(this);
             player().stop();
             player().clear();
         }
@@ -3627,6 +3632,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     private void stopInlinePlayerForReload() {
+        subtitlePlaybackSession.stop(this);
         inlineStartPosition = C.TIME_UNSET;
         inlineStartPositionApplied = false;
         pendingInlineResult = null;
@@ -3671,6 +3677,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         Site site = getCurrentSite();
         ensureInlineDanmakuController();
         startPlayer(getHistoryKey(), result, useParse, site == null ? 0 : site.getTimeout(), buildMetadata());
+        subtitlePlaybackSession.onPlaybackStarted(this, result);
         searchInlineDanmaku(result);
         binding.playerPanel.requestFocus();
     }
@@ -4266,7 +4273,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void showInlineQuality() {
         if (!canChangeInlineQuality()) return;
         if (!hasInlineUrlQuality()) {
-            TrackDialog.create().type(C.TRACK_TYPE_VIDEO).player(player()).show(this);
+            TrackDialog.create().type(C.TRACK_TYPE_VIDEO).player(player()).search(this::showSubtitleSearch).show(this);
             return;
         }
         int count = currentInlineResult.getUrl().getValues().size();
@@ -4406,7 +4413,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     private void showInlineTrack(View view) {
         if (service() == null || player().isEmpty()) return;
-        TrackDialog.create().type(Integer.parseInt(view.getTag().toString())).player(player()).show(this);
+        TrackDialog.create().type(Integer.parseInt(view.getTag().toString())).player(player()).search(this::showSubtitleSearch).show(this);
     }
 
     private boolean showInlineSubtitle() {
@@ -5288,6 +5295,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         inlinePlaybackGeneration++;
         inlinePlaybackLoading = false;
         introSkipPlayback.reset();
+        subtitlePlaybackSession.stop(this);
         hideInlineControls();
         if (service() != null) {
             player().stop();
@@ -5596,7 +5604,11 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     @Override
     public void onSubtitleClick() {
-        SubtitleDialog.create().view(binding.exo.getSubtitleView()).show(this);
+        SubtitleDialog.create().view(binding.exo.getSubtitleView()).search(this::showSubtitleSearch).show(this);
+    }
+
+    private void showSubtitleSearch() {
+        SubtitleManualSearchDialog.show(this, subtitlePlaybackSession, this);
     }
 
     @Override
@@ -5630,6 +5642,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     @Override
     protected void onDestroy() {
+        subtitlePlaybackSession.stop(this);
         if (inlinePiPLayout) exitInlinePiPLayout();
         if (inlineFullscreen) exitInlineFullscreen();
         cancelBackdropSlideRequest();
@@ -5640,6 +5653,46 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         if (inlineClock != null) inlineClock.release();
         DanmakuApi.cancel();
         super.onDestroy();
+    }
+
+    @Override
+    public String getSubtitlePlaybackKey() {
+        return getHistoryKey();
+    }
+
+    @Override
+    public Site getSubtitleSite() {
+        return getCurrentSite();
+    }
+
+    @Override
+    public Vod getSubtitleVod() {
+        return vod;
+    }
+
+    @Override
+    public Episode getSubtitleEpisode() {
+        return selectedEpisode;
+    }
+
+    @Override
+    public TmdbItem getSubtitleTmdbItem() {
+        return matchedTmdbItem == null ? initialTmdbItem : matchedTmdbItem;
+    }
+
+    @Override
+    public TmdbEpisode getSubtitleTmdbEpisode() {
+        return selectedEpisode == null ? null : selectedEpisode.getTmdbEpisode();
+    }
+
+    @Override
+    public PlayerManager getSubtitlePlayer() {
+        return player();
+    }
+
+    @Override
+    public boolean isSubtitleHostActive() {
+        return !isFinishing() && !isDestroyed() && service() != null && player() != null && !player().isReleased() && inlineStarted && currentInlineResult != null && isOwner();
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerOsdController.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerOsdController.java
@@ -108,6 +108,13 @@ public class PlayerOsdController {
         return diagnosticsVisible;
     }
 
+    public void setDiagnosticsVisible(boolean visible) {
+        boolean next = visible && PlayerSetting.isOsdDiagnostics();
+        if (diagnosticsVisible == next) return;
+        diagnosticsVisible = next;
+        if (started) render();
+    }
+
     public void toggleDiagnostics() {
         if (!PlayerSetting.isOsdDiagnostics()) return;
         diagnosticsVisible = !diagnosticsVisible;

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/PlayerButtonConfigDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/PlayerButtonConfigDialog.java
@@ -157,8 +157,7 @@ public class PlayerButtonConfigDialog extends BaseAlertDialog {
         public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
             PlayerButtonSetting.Item item = items.get(position);
             holder.binding.name.setText(item.name());
-            holder.binding.visible.setText(null);
-            holder.binding.visible.setIconResource(item.visible() ? R.drawable.ic_player_button_visible : R.drawable.ic_player_button_hidden);
+            holder.binding.visible.setImageResource(item.visible() ? R.drawable.ic_player_button_visible : R.drawable.ic_player_button_hidden);
             holder.binding.visible.setContentDescription(getString(item.visible() ? R.string.setting_show : R.string.setting_hide));
             holder.binding.visible.setSelected(item.visible());
             holder.binding.visible.setActivated(item.visible());
@@ -168,7 +167,8 @@ public class PlayerButtonConfigDialog extends BaseAlertDialog {
             holder.binding.up.setFocusable(position > 0);
             holder.binding.down.setEnabled(position < items.size() - 1);
             holder.binding.down.setFocusable(position < items.size() - 1);
-            holder.binding.root.setAlpha(item.visible() ? 1f : 0.55f);
+            holder.binding.root.setAlpha(1f);
+            holder.binding.name.setAlpha(item.visible() ? 1f : 0.55f);
             holder.binding.root.setOnClickListener(view -> toggle(holder.getBindingAdapterPosition(), R.id.visible));
             holder.binding.visible.setOnClickListener(view -> toggle(holder.getBindingAdapterPosition(), view.getId()));
             holder.binding.up.setOnClickListener(view -> move(-1, holder.getBindingAdapterPosition(), view.getId()));

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/SubtitleDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/SubtitleDialog.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.media3.ui.SubtitleView;
 import androidx.viewbinding.ViewBinding;
 
+import com.fongmi.android.tv.App;
 import com.fongmi.android.tv.databinding.DialogSubtitleBinding;
 import com.fongmi.android.tv.setting.PlayerSetting;
 import com.fongmi.android.tv.utils.ResUtil;
@@ -22,6 +23,7 @@ public final class SubtitleDialog extends BaseBottomSheetDialog {
 
     private DialogSubtitleBinding binding;
     private SubtitleView subtitleView;
+    private Runnable searchAction;
 
     public static SubtitleDialog create() {
         return new SubtitleDialog();
@@ -29,6 +31,11 @@ public final class SubtitleDialog extends BaseBottomSheetDialog {
 
     public SubtitleDialog view(SubtitleView subtitleView) {
         this.subtitleView = subtitleView;
+        return this;
+    }
+
+    public SubtitleDialog search(Runnable searchAction) {
+        this.searchAction = searchAction;
         return this;
     }
 
@@ -55,6 +62,7 @@ public final class SubtitleDialog extends BaseBottomSheetDialog {
     protected void initView() {
         int count = binding.getRoot().getChildCount();
         if (isFull()) for (int i = 0; i < count; i++) ((ImageView) binding.getRoot().getChildAt(i)).getDrawable().setTint(MDColor.WHITE);
+        binding.search.setVisibility(searchAction == null ? View.GONE : View.VISIBLE);
     }
 
     @Override
@@ -64,6 +72,7 @@ public final class SubtitleDialog extends BaseBottomSheetDialog {
         binding.large.setOnClickListener(this::onLarge);
         binding.small.setOnClickListener(this::onSmall);
         binding.reset.setOnClickListener(this::onReset);
+        binding.search.setOnClickListener(this::onSearch);
     }
 
     private void onUp(View view) {
@@ -90,6 +99,12 @@ public final class SubtitleDialog extends BaseBottomSheetDialog {
         PlayerSetting.putSubtitleTextSize(0.0f);
         PlayerSetting.putSubtitlePosition(0.0f);
         subtitleView.reset();
+    }
+
+    private void onSearch(View view) {
+        if (searchAction == null) return;
+        dismiss();
+        App.post(searchAction::run, 100);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/SubtitleManualSearchDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/SubtitleManualSearchDialog.java
@@ -1,0 +1,164 @@
+package com.fongmi.android.tv.ui.dialog;
+
+import android.text.TextUtils;
+import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.widget.Button;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.FragmentActivity;
+
+import com.fongmi.android.tv.R;
+import com.fongmi.android.tv.subtitle.SubtitlePlaybackSession;
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchResult;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchStatus;
+import com.fongmi.android.tv.utils.Notify;
+import com.fongmi.android.tv.utils.ResUtil;
+import com.fongmi.android.tv.utils.Util;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
+
+import java.util.List;
+import java.util.Locale;
+
+public final class SubtitleManualSearchDialog {
+
+    private SubtitleManualSearchDialog() {
+    }
+
+    public static void show(FragmentActivity activity, SubtitlePlaybackSession session, SubtitlePlaybackSession.Host host) {
+        if (activity == null || session == null || host == null) return;
+        showKeywordDialog(activity, session, host, session.getManualSearchKeyword(host));
+    }
+
+    private static void showKeywordDialog(FragmentActivity activity, SubtitlePlaybackSession session, SubtitlePlaybackSession.Host host, String defaultKeyword) {
+        TextInputEditText input = new TextInputEditText(activity);
+        input.setSingleLine(true);
+        input.setHint(R.string.search_keyword);
+        input.setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+        input.setMaxLines(1);
+        input.setText(defaultKeyword);
+        input.setSelectAllOnFocus(false);
+        input.setSelection(input.getText() == null ? 0 : input.getText().length());
+
+        AlertDialog dialog = new MaterialAlertDialogBuilder(activity, R.style.Theme_WebHTV_LightDialog)
+                .setTitle(R.string.subtitle_manual_search)
+                .setView(input)
+                .setNegativeButton(R.string.dialog_negative, null)
+                .setPositiveButton(R.string.play_search, null)
+                .show();
+        LightDialog.apply(dialog);
+        Button positive = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+        positive.setOnClickListener(view -> {
+            String keyword = input.getText() == null ? "" : input.getText().toString().trim();
+            if (TextUtils.isEmpty(keyword)) return;
+            Util.hideKeyboard(input);
+            dialog.dismiss();
+            search(activity, session, host, keyword);
+        });
+        input.setOnEditorActionListener((textView, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) positive.performClick();
+            return true;
+        });
+        input.setOnKeyListener((view, keyCode, event) -> {
+            if (keyCode != KeyEvent.KEYCODE_DPAD_DOWN || event.getAction() != KeyEvent.ACTION_DOWN) return false;
+            return positive.requestFocus();
+        });
+        Util.showKeyboard(input);
+    }
+
+    private static void search(FragmentActivity activity, SubtitlePlaybackSession session, SubtitlePlaybackSession.Host host, String keyword) {
+        Notify.show(R.string.subtitle_manual_searching);
+        session.manualSearch(host, keyword, (request, result, applied) -> {
+            if (!isAlive(activity)) return;
+            if (!canShowCandidates(result)) {
+                notifySearchResult(result);
+                return;
+            }
+            showCandidates(activity, session, host, result.getCandidates());
+        });
+    }
+
+    private static void showCandidates(FragmentActivity activity, SubtitlePlaybackSession session, SubtitlePlaybackSession.Host host, List<SubtitleCandidate> candidates) {
+        String[] labels = new String[candidates.size()];
+        for (int i = 0; i < candidates.size(); i++) labels[i] = label(candidates.get(i));
+        AlertDialog dialog = new MaterialAlertDialogBuilder(activity, R.style.Theme_WebHTV_LightDialog)
+                .setTitle(ResUtil.getString(R.string.subtitle_manual_select_title, candidates.size()))
+                .setNegativeButton(R.string.dialog_negative, null)
+                .setItems(labels, (d, which) -> resolve(activity, session, host, candidates.get(which)))
+                .show();
+        LightDialog.apply(dialog);
+    }
+
+    private static void resolve(FragmentActivity activity, SubtitlePlaybackSession session, SubtitlePlaybackSession.Host host, SubtitleCandidate candidate) {
+        Notify.show(R.string.subtitle_manual_resolving);
+        session.resolveManual(host, candidate, (request, result, applied) -> {
+            if (!isAlive(activity)) return;
+            if (result != null && result.getStatus() == SubtitleMatchStatus.MATCHED && applied) {
+                Notify.show(ResUtil.getString(R.string.subtitle_manual_applied, displayName(candidate)));
+            } else if (result != null && result.getStatus() == SubtitleMatchStatus.MATCHED) {
+                Notify.show(R.string.subtitle_manual_apply_failed);
+            } else {
+                notifySearchResult(result);
+            }
+        });
+    }
+
+    private static boolean canShowCandidates(SubtitleMatchResult result) {
+        return result != null && result.getCandidates() != null && !result.getCandidates().isEmpty();
+    }
+
+    private static void notifySearchResult(SubtitleMatchResult result) {
+        if (result == null) {
+            Notify.show(R.string.subtitle_manual_search_failed);
+            return;
+        }
+        if (result.getStatus() == SubtitleMatchStatus.SKIPPED && "provider_unavailable".equals(result.getReason())) {
+            Notify.show(R.string.subtitle_auto_match_provider_unavailable);
+        } else if (result.getStatus() == SubtitleMatchStatus.ERROR && "inactive".equals(result.getReason())) {
+            Notify.show(R.string.subtitle_manual_inactive);
+        } else if (result.getStatus() == SubtitleMatchStatus.ERROR) {
+            Notify.show(ResUtil.getString(R.string.subtitle_auto_match_failed, readableReason(result.getReason())));
+        } else {
+            Notify.show(R.string.subtitle_manual_search_empty);
+        }
+    }
+
+    private static String label(SubtitleCandidate candidate) {
+        StringBuilder builder = new StringBuilder(displayName(candidate));
+        String meta = meta(candidate);
+        if (!TextUtils.isEmpty(meta)) builder.append('\n').append(meta);
+        return builder.toString();
+    }
+
+    private static String meta(SubtitleCandidate candidate) {
+        if (candidate == null) return "";
+        StringBuilder builder = new StringBuilder();
+        append(builder, candidate.getProvider());
+        append(builder, candidate.getLanguage());
+        append(builder, candidate.getFormat());
+        if (candidate.getScore() > 0) append(builder, String.format(Locale.US, "%d", candidate.getScore()));
+        return builder.toString();
+    }
+
+    private static void append(StringBuilder builder, String value) {
+        if (TextUtils.isEmpty(value)) return;
+        if (builder.length() > 0) builder.append(" · ");
+        builder.append(value);
+    }
+
+    private static String displayName(SubtitleCandidate candidate) {
+        if (candidate == null) return "";
+        if (!TextUtils.isEmpty(candidate.getDisplayName())) return candidate.getDisplayName();
+        return TextUtils.isEmpty(candidate.getCandidateId()) ? candidate.getProvider() : candidate.getCandidateId();
+    }
+
+    private static String readableReason(String reason) {
+        return TextUtils.isEmpty(reason) ? ResUtil.getString(R.string.subtitle_auto_match_unknown_reason) : reason;
+    }
+
+    private static boolean isAlive(FragmentActivity activity) {
+        return activity != null && !activity.isFinishing() && !activity.isDestroyed();
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/SubtitleSettingsDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/SubtitleSettingsDialog.java
@@ -1,0 +1,77 @@
+package com.fongmi.android.tv.ui.dialog;
+
+import android.text.InputType;
+import android.text.TextUtils;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.FragmentActivity;
+
+import com.fongmi.android.tv.R;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
+
+public final class SubtitleSettingsDialog {
+
+    public interface ValueCallback {
+        void onValue(String value);
+    }
+
+    private SubtitleSettingsDialog() {
+    }
+
+    public static void showPreferredLanguage(FragmentActivity activity, String[] labels, String[] values, String currentValue, ValueCallback callback) {
+        if (activity == null || labels == null || values == null || labels.length == 0 || values.length == 0) return;
+        int checked = indexOf(values, currentValue);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(activity, R.style.Theme_WebHTV_LightDialog)
+                .setTitle(R.string.player_subtitle_language)
+                .setNegativeButton(R.string.dialog_negative, null)
+                .setSingleChoiceItems(labels, checked, (d, which) -> {
+                    if (which >= 0 && which < values.length && callback != null) callback.onValue(values[which]);
+                    d.dismiss();
+                })
+                .show();
+        LightDialog.apply(dialog);
+    }
+
+    public static void showAssrtToken(FragmentActivity activity, String currentToken, ValueCallback callback) {
+        if (activity == null) return;
+        TextInputEditText input = new TextInputEditText(activity);
+        input.setSingleLine(true);
+        input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+        input.setText(TextUtils.isEmpty(currentToken) ? "" : currentToken);
+        if (input.getText() != null) input.setSelection(input.length());
+
+        TextInputLayout layout = new TextInputLayout(activity);
+        layout.setHint(activity.getString(R.string.player_subtitle_assrt_token));
+        layout.setBoxBackgroundMode(TextInputLayout.BOX_BACKGROUND_OUTLINE);
+        layout.addView(input, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        LinearLayout container = new LinearLayout(activity);
+        container.setOrientation(LinearLayout.VERTICAL);
+        int horizontal = dp(activity, 20);
+        container.setPadding(horizontal, dp(activity, 8), horizontal, 0);
+        container.addView(layout, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        AlertDialog dialog = new MaterialAlertDialogBuilder(activity, R.style.Theme_WebHTV_LightDialog)
+                .setTitle(R.string.player_subtitle_assrt_token)
+                .setView(container)
+                .setNegativeButton(R.string.dialog_negative, null)
+                .setPositiveButton(R.string.dialog_positive, (d, which) -> {
+                    if (callback != null) callback.onValue(input.getText() == null ? "" : input.getText().toString().trim());
+                })
+                .show();
+        LightDialog.apply(dialog);
+    }
+
+    private static int indexOf(String[] values, String currentValue) {
+        for (int i = 0; i < values.length; i++) if (TextUtils.equals(values[i], currentValue)) return i;
+        return 0;
+    }
+
+    private static int dp(FragmentActivity activity, int value) {
+        return Math.round(activity.getResources().getDisplayMetrics().density * value);
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/TrackDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/TrackDialog.java
@@ -43,6 +43,7 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
     private final TrackAdapter adapter;
     private DialogTrackBinding binding;
     private PlayerManager player;
+    private Runnable searchAction;
     private int type;
 
     public static TrackDialog create() {
@@ -64,6 +65,11 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
         return this;
     }
 
+    public TrackDialog search(Runnable searchAction) {
+        this.searchAction = searchAction;
+        return this;
+    }
+
     public void show(FragmentActivity activity) {
         for (Fragment f : activity.getSupportFragmentManager().getFragments()) if (f instanceof TrackDialog) return;
         show(activity.getSupportFragmentManager(), null);
@@ -79,6 +85,10 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
 
     private boolean hasAudio() {
         return type == C.TRACK_TYPE_AUDIO && player.haveTrack(type);
+    }
+
+    private boolean hasSearch() {
+        return type == C.TRACK_TYPE_TEXT && searchAction != null;
     }
 
     @Override
@@ -97,6 +107,7 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
         binding.recycler.setVisibility(adapter.getItemCount() == 0 ? View.GONE : View.VISIBLE);
         binding.offset.setVisibility(hasText() || hasAudio() ? View.VISIBLE : View.GONE);
         binding.choose.setVisibility(hasChoose() ? View.VISIBLE : View.GONE);
+        binding.search.setVisibility(hasSearch() ? View.VISIBLE : View.GONE);
         binding.subtitle.setVisibility(hasText() ? View.VISIBLE : View.GONE);
     }
 
@@ -104,6 +115,7 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
     protected void initEvent() {
         binding.offset.setOnClickListener(this::onOffset);
         binding.choose.setOnClickListener(this::onChoose);
+        binding.search.setOnClickListener(this::onSearch);
         binding.subtitle.setOnClickListener(this::onSubtitle);
     }
 
@@ -114,6 +126,12 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
     private void onChoose(View view) {
         FileChooser.from(launcher).show(new String[]{MimeTypes.APPLICATION_SUBRIP, MimeTypes.TEXT_SSA, MimeTypes.TEXT_VTT, MimeTypes.APPLICATION_TTML, "audio/*", "text/*", "application/octet-stream"});
         player.pause();
+    }
+
+    private void onSearch(View view) {
+        if (searchAction == null) return;
+        App.post(searchAction::run, 100);
+        dismiss();
     }
 
     private void onSubtitle(View view) {

--- a/app/src/main/res/layout/adapter_player_button_config.xml
+++ b/app/src/main/res/layout/adapter_player_button_config.xml
@@ -25,22 +25,17 @@
         android:textSize="15sp"
         tools:text="倍速" />
 
-    <com.google.android.material.button.MaterialButton
+    <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/visible"
-        style="@style/Widget.Material3.Button.TextButton"
         android:layout_width="40dp"
         android:layout_height="36dp"
+        android:background="@drawable/selector_dialog_switch"
         android:contentDescription="@string/setting_show"
         android:focusable="true"
-        android:minWidth="0dp"
-        android:paddingStart="0dp"
-        android:paddingEnd="0dp"
-        android:textColor="@color/dialog_tonal_button_text"
-        app:icon="@drawable/ic_player_button_visible"
-        app:iconGravity="textStart"
-        app:iconPadding="0dp"
-        app:iconSize="18dp"
-        app:iconTint="@color/dialog_tonal_button_text" />
+        android:padding="8dp"
+        android:scaleType="center"
+        android:src="@drawable/ic_player_button_visible"
+        app:tint="@color/dialog_tonal_button_text" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/up"

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -52,7 +52,7 @@
         android:layout_marginTop="6dp"
         android:textColor="#5F6368"
         android:textSize="13sp"
-        tools:text="版本 5.5.2 (552) · mobile/arm64" />
+        tools:text="版本 5.5.4 (554) · mobile/arm64" />
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -136,6 +136,7 @@
     <string name="setting_builtin_wall">内置壁纸</string>
     <string name="setting_player">播放设置</string>
     <string name="setting_danmaku">弹幕设置</string>
+    <string name="setting_subtitle">字幕设置</string>
     <string name="setting_enhance">增强功能</string>
     <string name="setting_personal">个性设置</string>
     <string name="setting_home_vod_auto_load">默认加载点播</string>
@@ -825,6 +826,24 @@
     <string name="player_speed">长按倍速</string>
     <string name="player_ua">User-Agent</string>
     <string name="player_osd">屏显设置</string>
+    <string name="player_subtitle_auto_match">自动匹配字幕</string>
+    <string name="player_subtitle_language">字幕偏好语言</string>
+    <string name="player_subtitle_assrt_token">ASSRT Token</string>
+    <string name="subtitle_auto_match_hit">已自动匹配字幕：%1$s</string>
+    <string name="subtitle_auto_match_hit_not_applied">已找到字幕但未应用：%1$s</string>
+    <string name="subtitle_auto_match_empty">未找到匹配字幕</string>
+    <string name="subtitle_auto_match_provider_unavailable">请先配置字幕源</string>
+    <string name="subtitle_auto_match_failed">字幕匹配失败：%1$s</string>
+    <string name="subtitle_auto_match_unknown_reason">未知错误</string>
+    <string name="subtitle_manual_search">搜索字幕</string>
+    <string name="subtitle_manual_searching">正在搜索字幕...</string>
+    <string name="subtitle_manual_select_title">选择字幕（%1$d）</string>
+    <string name="subtitle_manual_search_empty">未搜索到字幕</string>
+    <string name="subtitle_manual_search_failed">字幕搜索失败</string>
+    <string name="subtitle_manual_resolving">正在加载字幕...</string>
+    <string name="subtitle_manual_applied">已应用字幕：%1$s</string>
+    <string name="subtitle_manual_apply_failed">已找到字幕但无法应用</string>
+    <string name="subtitle_manual_inactive">请先开始播放再搜索字幕</string>
     <string name="lut_original">原色</string>
     <string name="lut_missing">预设不存在</string>
     <string name="lut_summary">%1$s · %2$d%%</string>
@@ -1084,6 +1103,26 @@
     <string-array name="select_caption">
         <item>预设</item>
         <item>系统</item>
+    </string-array>
+
+    <string-array name="select_subtitle_language">
+        <item>中文优先</item>
+        <item>简体中文</item>
+        <item>繁体中文</item>
+        <item>英语</item>
+        <item>日语</item>
+        <item>韩语</item>
+        <item>不限制</item>
+    </string-array>
+
+    <string-array name="select_subtitle_language_value">
+        <item>zh</item>
+        <item>zh-Hans</item>
+        <item>zh-Hant</item>
+        <item>en</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>any</item>
     </string-array>
 
     <string-array name="select_player_osd">

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -136,6 +136,7 @@
     <string name="setting_builtin_wall">內置壁紙</string>
     <string name="setting_player">播放設定</string>
     <string name="setting_danmaku">彈幕設定</string>
+    <string name="setting_subtitle">字幕設定</string>
     <string name="setting_enhance">增強功能</string>
     <string name="setting_search_thread">搜尋線程</string>
     <string name="setting_personal">個性設定</string>
@@ -804,6 +805,24 @@
     <string name="player_speed">長按倍速</string>
     <string name="player_ua">User-Agent</string>
     <string name="player_osd">屏顯設定</string>
+    <string name="player_subtitle_auto_match">自動匹配字幕</string>
+    <string name="player_subtitle_language">字幕偏好語言</string>
+    <string name="player_subtitle_assrt_token">ASSRT Token</string>
+    <string name="subtitle_auto_match_hit">已自動匹配字幕：%1$s</string>
+    <string name="subtitle_auto_match_hit_not_applied">已找到字幕但未套用：%1$s</string>
+    <string name="subtitle_auto_match_empty">未找到匹配字幕</string>
+    <string name="subtitle_auto_match_provider_unavailable">請先配置字幕源</string>
+    <string name="subtitle_auto_match_failed">字幕匹配失敗：%1$s</string>
+    <string name="subtitle_auto_match_unknown_reason">未知錯誤</string>
+    <string name="subtitle_manual_search">搜尋字幕</string>
+    <string name="subtitle_manual_searching">正在搜尋字幕...</string>
+    <string name="subtitle_manual_select_title">選擇字幕（%1$d）</string>
+    <string name="subtitle_manual_search_empty">未搜尋到字幕</string>
+    <string name="subtitle_manual_search_failed">字幕搜尋失敗</string>
+    <string name="subtitle_manual_resolving">正在載入字幕...</string>
+    <string name="subtitle_manual_applied">已套用字幕：%1$s</string>
+    <string name="subtitle_manual_apply_failed">已找到字幕但無法套用</string>
+    <string name="subtitle_manual_inactive">請先開始播放再搜尋字幕</string>
     <string name="lut_original">原色</string>
     <string name="lut_missing">預設不存在</string>
     <string name="lut_summary">%1$s · %2$d%%</string>
@@ -1012,6 +1031,26 @@
     <string-array name="select_caption">
         <item>預設</item>
         <item>系統</item>
+    </string-array>
+
+    <string-array name="select_subtitle_language">
+        <item>中文優先</item>
+        <item>簡體中文</item>
+        <item>繁體中文</item>
+        <item>英語</item>
+        <item>日語</item>
+        <item>韓語</item>
+        <item>不限制</item>
+    </string-array>
+
+    <string-array name="select_subtitle_language_value">
+        <item>zh</item>
+        <item>zh-Hans</item>
+        <item>zh-Hant</item>
+        <item>en</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>any</item>
     </string-array>
 
     <string-array name="select_player_osd">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="setting_builtin_wall">Built-in wallpapers</string>
     <string name="setting_player">Player setting</string>
     <string name="setting_danmaku">Danmaku setting</string>
+    <string name="setting_subtitle">Subtitle setting</string>
     <string name="setting_enhance">Enhancements</string>
     <string name="setting_personal">Personal</string>
     <string name="setting_home_vod_auto_load">Auto-load VOD</string>
@@ -827,6 +828,24 @@
     <string name="player_speed">Press speed</string>
     <string name="player_ua">User-Agent</string>
     <string name="player_osd">On-screen display</string>
+    <string name="player_subtitle_auto_match">Auto subtitle match</string>
+    <string name="player_subtitle_language">Preferred subtitle language</string>
+    <string name="player_subtitle_assrt_token">ASSRT token</string>
+    <string name="subtitle_auto_match_hit">Subtitle matched: %1$s</string>
+    <string name="subtitle_auto_match_hit_not_applied">Subtitle found but not applied: %1$s</string>
+    <string name="subtitle_auto_match_empty">No matching subtitle found</string>
+    <string name="subtitle_auto_match_provider_unavailable">Configure a subtitle source first</string>
+    <string name="subtitle_auto_match_failed">Subtitle match failed: %1$s</string>
+    <string name="subtitle_auto_match_unknown_reason">unknown error</string>
+    <string name="subtitle_manual_search">Search subtitles</string>
+    <string name="subtitle_manual_searching">Searching subtitles...</string>
+    <string name="subtitle_manual_select_title">Select subtitle (%1$d)</string>
+    <string name="subtitle_manual_search_empty">No subtitles found</string>
+    <string name="subtitle_manual_search_failed">Subtitle search failed</string>
+    <string name="subtitle_manual_resolving">Loading subtitle...</string>
+    <string name="subtitle_manual_applied">Subtitle applied: %1$s</string>
+    <string name="subtitle_manual_apply_failed">Subtitle found but could not be applied</string>
+    <string name="subtitle_manual_inactive">Start playback before searching subtitles</string>
     <string name="lut_original">Original</string>
     <string name="lut_missing">Preset missing</string>
     <string name="lut_summary">%1$s · %2$d%%</string>
@@ -1101,6 +1120,26 @@
     <string-array name="select_caption">
         <item>Default</item>
         <item>System</item>
+    </string-array>
+
+    <string-array name="select_subtitle_language">
+        <item>Chinese first</item>
+        <item>Simplified Chinese</item>
+        <item>Traditional Chinese</item>
+        <item>English</item>
+        <item>Japanese</item>
+        <item>Korean</item>
+        <item>No preference</item>
+    </string-array>
+
+    <string-array name="select_subtitle_language_value">
+        <item>zh</item>
+        <item>zh-Hans</item>
+        <item>zh-Hant</item>
+        <item>en</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>any</item>
     </string-array>
 
     <string-array name="select_player_osd">

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/HomeActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/HomeActivity.java
@@ -42,6 +42,7 @@ import com.fongmi.android.tv.ui.fragment.SettingDanmakuFragment;
 import com.fongmi.android.tv.ui.fragment.SettingFragment;
 import com.fongmi.android.tv.ui.fragment.SettingPersonalFragment;
 import com.fongmi.android.tv.ui.fragment.SettingPlayerFragment;
+import com.fongmi.android.tv.ui.fragment.SettingSubtitleFragment;
 import com.fongmi.android.tv.ui.fragment.VodFragment;
 import com.fongmi.android.tv.utils.FileChooser;
 import com.fongmi.android.tv.utils.Notify;
@@ -143,6 +144,7 @@ public class HomeActivity extends BaseActivity implements NavigationBarView.OnIt
             case 3 -> SettingEnhanceFragment.newInstance();
             case 4 -> SettingDanmakuFragment.newInstance();
             case 5 -> SettingPersonalFragment.newInstance();
+            case 6 -> SettingSubtitleFragment.newInstance();
             default -> null;
         });
         if (savedInstanceState == null) change(0);
@@ -284,7 +286,7 @@ public class HomeActivity extends BaseActivity implements NavigationBarView.OnIt
     }
 
     private boolean isSettingSubPageVisible() {
-        return mManager.isVisible(2) || mManager.isVisible(3) || mManager.isVisible(4) || mManager.isVisible(5);
+        return mManager.isVisible(2) || mManager.isVisible(3) || mManager.isVisible(4) || mManager.isVisible(5) || mManager.isVisible(6);
     }
 
     private void refreshWebHomeChromeLayout() {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -91,6 +91,7 @@ import com.fongmi.android.tv.setting.PlayerButtonSetting;
 import com.fongmi.android.tv.setting.PlayerSetting;
 import com.fongmi.android.tv.setting.Setting;
 import com.fongmi.android.tv.setting.SiteHealthStore;
+import com.fongmi.android.tv.subtitle.SubtitlePlaybackSession;
 import com.fongmi.android.tv.ui.adapter.EpisodeAdapter;
 import com.fongmi.android.tv.ui.adapter.EpisodeGroupAdapter;
 import com.fongmi.android.tv.ui.adapter.FlagAdapter;
@@ -115,6 +116,7 @@ import com.fongmi.android.tv.ui.dialog.LutPanelDialog;
 import com.fongmi.android.tv.ui.dialog.QuickSearchDialog;
 import com.fongmi.android.tv.ui.dialog.ReceiveDialog;
 import com.fongmi.android.tv.ui.dialog.SubtitleDialog;
+import com.fongmi.android.tv.ui.dialog.SubtitleManualSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TmdbSearchDialog;
 import com.fongmi.android.tv.ui.dialog.TitleDialog;
 import com.fongmi.android.tv.ui.dialog.TrackDialog;
@@ -153,7 +155,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class VideoActivity extends PlaybackActivity implements Clock.Callback, CustomKeyDown.Listener, TrackDialog.Listener, ControlDialog.Listener, FlagAdapter.OnClickListener, EpisodeAdapter.OnClickListener, EpisodeGroupAdapter.OnClickListener, QualityAdapter.OnClickListener, QuickAdapter.OnClickListener, ParseAdapter.OnClickListener, CastDialog.Listener, InfoDialog.Listener {
+public class VideoActivity extends PlaybackActivity implements Clock.Callback, CustomKeyDown.Listener, TrackDialog.Listener, ControlDialog.Listener, FlagAdapter.OnClickListener, EpisodeAdapter.OnClickListener, EpisodeGroupAdapter.OnClickListener, QualityAdapter.OnClickListener, QuickAdapter.OnClickListener, ParseAdapter.OnClickListener, CastDialog.Listener, InfoDialog.Listener, SubtitlePlaybackSession.Host {
 
     private static final int SHORT_DRAMA_SCALE = 4;
     private static final int SHORT_DRAMA_EDGE_MARGIN_DP = 12;
@@ -198,6 +200,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     private FlagAdapter mFlagAdapter;
     private PlayerOsdController mOsd;
     private final IntroSkipPlayback mIntroSkipPlayback = new IntroSkipPlayback();
+    private final SubtitlePlaybackSession subtitlePlaybackSession = new SubtitlePlaybackSession(this);
     private ValueAnimator mAnimator;
     private CustomKeyDown mKeyDown;
     private List<String> mBroken;
@@ -1058,6 +1061,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mBinding.scroll.scrollTo(0, 0);
         mClock.setCallback(null);
         updateNavigationKey();
+        subtitlePlaybackSession.stop(this);
         player().reset();
         player().stop();
         saveHistory();
@@ -1376,6 +1380,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mBinding.control.parse.setVisibility(isUseParse() ? View.VISIBLE : View.GONE);
         if (redirectToAudioIfNeeded(result)) return;
         startPlayer(getHistoryKey(), result, isUseParse(), getSite().getTimeout(), buildMetadata());
+        subtitlePlaybackSession.onPlaybackStarted(this, result);
         if (DanmakuApi.canSearch()) DanmakuApi.search(mHistory.getVodName(), getEpisode().getName(), danmaku -> {
             if (DanmakuSetting.isSpiderFirst() && !result.getDanmaku().isEmpty()) player().addDanmaku(danmaku);
             else player().setDanmaku(danmaku);
@@ -1445,6 +1450,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         updateActionQuality(result);
         beginPlayHealth();
         startPlayer(getHistoryKey(), result, isUseParse(), getSite().getTimeout(), buildMetadata());
+        subtitlePlaybackSession.onPlaybackStarted(this, result);
     }
 
     @Override
@@ -1872,13 +1878,13 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     }
 
     private void onTrack(View view) {
-        TrackDialog.create().type(Integer.parseInt(view.getTag().toString())).player(player()).show(this);
+        TrackDialog.create().type(Integer.parseInt(view.getTag().toString())).player(player()).search(this::showSubtitleSearch).show(this);
         hideControl();
     }
 
     @Override
     public void onTrackPanel(int type) {
-        TrackDialog.create().type(type).player(player()).show(this);
+        TrackDialog.create().type(type).player(player()).search(this::showSubtitleSearch).show(this);
     }
 
     private void onTitle() {
@@ -2024,6 +2030,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     private void onRefresh() {
         saveHistory();
+        subtitlePlaybackSession.stop(this);
         player().stop();
         player().clear();
         mClock.setCallback(null);
@@ -2709,6 +2716,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     @Override
     protected void onError(String msg) {
         recordPlayHealth(false, msg);
+        subtitlePlaybackSession.stop(this);
         mBinding.swipeLayout.setEnabled(true);
         Track.delete(player().getKey());
         mClock.setCallback(null);
@@ -2786,8 +2794,12 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     @Override
     public void onSubtitleClick() {
-        SubtitleDialog.create().view(mBinding.exo.getSubtitleView()).show(this);
+        SubtitleDialog.create().view(mBinding.exo.getSubtitleView()).search(() -> SubtitleManualSearchDialog.show(this, subtitlePlaybackSession, this)).show(this);
         hideControl();
+    }
+
+    private void showSubtitleSearch() {
+        SubtitleManualSearchDialog.show(this, subtitlePlaybackSession, this);
     }
 
     @Override
@@ -3784,6 +3796,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     @Override
     public void onCasted() {
+        subtitlePlaybackSession.stop(this);
         player().stop();
     }
 
@@ -4031,6 +4044,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     @Override
     protected void onDestroy() {
+        subtitlePlaybackSession.stop(this);
         mClock.release();
         saveHistory(true);
         Timer.get().reset();
@@ -4043,6 +4057,48 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mViewModel.getSearch().removeObserver(mObserveSearch);
         SiteHealthStore.flush();
         super.onDestroy();
+    }
+
+    @Override
+    public String getSubtitlePlaybackKey() {
+        return getHistoryKey();
+    }
+
+    @Override
+    public Site getSubtitleSite() {
+        return getSite();
+    }
+
+    @Override
+    public Vod getSubtitleVod() {
+        return mVod;
+    }
+
+    @Override
+    public Episode getSubtitleEpisode() {
+        return getEpisode();
+    }
+
+    @Override
+    public TmdbItem getSubtitleTmdbItem() {
+        TmdbItem item = mTmdbUIAdapter == null ? null : mTmdbUIAdapter.getTmdbItem();
+        return item == null ? getTmdbItem() : item;
+    }
+
+    @Override
+    public TmdbEpisode getSubtitleTmdbEpisode() {
+        Episode episode = getEpisode();
+        return episode == null ? null : episode.getTmdbEpisode();
+    }
+
+    @Override
+    public PlayerManager getSubtitlePlayer() {
+        return player();
+    }
+
+    @Override
+    public boolean isSubtitleHostActive() {
+        return !isFinishing() && !isDestroyed() && service() != null && player() != null && !player().isReleased() && !player().isEmpty() && isOwner();
     }
 
     private static class ShortDramaControlItem {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/SettingFragment.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/SettingFragment.java
@@ -132,6 +132,7 @@ public class SettingFragment extends BaseFragment implements ConfigListener, Sit
         mBinding.personal.setOnClickListener(this::onPersonal);
         mBinding.player.setOnClickListener(this::onPlayer);
         mBinding.danmaku.setOnClickListener(this::onDanmaku);
+        mBinding.subtitle.setOnClickListener(this::onSubtitle);
         mBinding.restore.setOnClickListener(this::onRestore);
         mBinding.version.setOnClickListener(this::onVersion);
         mBinding.vod.setOnLongClickListener(this::onVodEdit);
@@ -258,6 +259,10 @@ public class SettingFragment extends BaseFragment implements ConfigListener, Sit
 
     private void onDanmaku(View view) {
         getRoot().change(4);
+    }
+
+    private void onSubtitle(View view) {
+        getRoot().change(6);
     }
 
     private void onEnhance(View view) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/SettingSubtitleFragment.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/SettingSubtitleFragment.java
@@ -1,0 +1,92 @@
+package com.fongmi.android.tv.ui.fragment;
+
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.viewbinding.ViewBinding;
+
+import com.fongmi.android.tv.R;
+import com.fongmi.android.tv.databinding.FragmentSettingSubtitleBinding;
+import com.fongmi.android.tv.setting.Setting;
+import com.fongmi.android.tv.ui.base.BaseFragment;
+import com.fongmi.android.tv.ui.dialog.SubtitleSettingsDialog;
+import com.fongmi.android.tv.utils.ResUtil;
+
+public class SettingSubtitleFragment extends BaseFragment {
+
+    private FragmentSettingSubtitleBinding mBinding;
+    private String[] subtitleLanguageLabels;
+    private String[] subtitleLanguageValues;
+
+    public static SettingSubtitleFragment newInstance() {
+        return new SettingSubtitleFragment();
+    }
+
+    private String getSwitch(boolean value) {
+        return getString(value ? R.string.setting_on : R.string.setting_off);
+    }
+
+    @Override
+    protected ViewBinding getBinding(@NonNull LayoutInflater inflater, @Nullable ViewGroup container) {
+        return mBinding = FragmentSettingSubtitleBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected void initView() {
+        subtitleLanguageLabels = ResUtil.getStringArray(R.array.select_subtitle_language);
+        subtitleLanguageValues = ResUtil.getStringArray(R.array.select_subtitle_language_value);
+        mBinding.subtitleAutoMatchText.setText(getSwitch(Setting.isSubtitleAutoMatchEnabled()));
+        mBinding.subtitleLanguageText.setText(getSubtitleLanguageText());
+        mBinding.subtitleAssrtTokenText.setText(getSubtitleAssrtTokenText());
+    }
+
+    @Override
+    protected void initEvent() {
+        mBinding.subtitleAutoMatch.setOnClickListener(this::setSubtitleAutoMatch);
+        mBinding.subtitleLanguage.setOnClickListener(this::onSubtitleLanguage);
+        mBinding.subtitleAssrtToken.setOnClickListener(this::onSubtitleAssrtToken);
+    }
+
+    private void setSubtitleAutoMatch(View view) {
+        Setting.putSubtitleAutoMatchEnabled(!Setting.isSubtitleAutoMatchEnabled());
+        mBinding.subtitleAutoMatchText.setText(getSwitch(Setting.isSubtitleAutoMatchEnabled()));
+    }
+
+    private void onSubtitleLanguage(View view) {
+        SubtitleSettingsDialog.showPreferredLanguage(requireActivity(), subtitleLanguageLabels, subtitleLanguageValues, Setting.getSubtitlePreferredLanguage(), value -> {
+            Setting.putSubtitlePreferredLanguage(value);
+            mBinding.subtitleLanguageText.setText(getSubtitleLanguageText());
+        });
+    }
+
+    private void onSubtitleAssrtToken(View view) {
+        SubtitleSettingsDialog.showAssrtToken(requireActivity(), Setting.getSubtitleAssrtToken(), value -> {
+            Setting.putSubtitleAssrtToken(value);
+            mBinding.subtitleAssrtTokenText.setText(getSubtitleAssrtTokenText());
+        });
+    }
+
+    private String getSubtitleLanguageText() {
+        int index = getSubtitleLanguageIndex();
+        return subtitleLanguageLabels != null && index >= 0 && index < subtitleLanguageLabels.length ? subtitleLanguageLabels[index] : Setting.getSubtitlePreferredLanguage();
+    }
+
+    private int getSubtitleLanguageIndex() {
+        if (subtitleLanguageValues == null) return 0;
+        for (int i = 0; i < subtitleLanguageValues.length; i++) if (TextUtils.equals(subtitleLanguageValues[i], Setting.getSubtitlePreferredLanguage())) return i;
+        return 0;
+    }
+
+    private String getSubtitleAssrtTokenText() {
+        return getString(TextUtils.isEmpty(Setting.getSubtitleAssrtToken()) ? R.string.setting_unconfigured : R.string.setting_configured);
+    }
+
+    @Override
+    public void onHiddenChanged(boolean hidden) {
+        if (!hidden) initView();
+    }
+}

--- a/app/src/mobile/res/layout/dialog_subtitle.xml
+++ b/app/src/mobile/res/layout/dialog_subtitle.xml
@@ -46,4 +46,13 @@
         android:padding="8dp"
         android:src="@drawable/ic_subtitle_reset" />
 
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/search"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/subtitle_manual_search"
+        android:padding="8dp"
+        android:src="@drawable/ic_action_search" />
+
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/mobile/res/layout/dialog_track.xml
+++ b/app/src/mobile/res/layout/dialog_track.xml
@@ -36,6 +36,18 @@
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/search"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/subtitle_manual_search"
+            android:src="@drawable/ic_action_search"
+            app:tint="@color/white_90"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/subtitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/mobile/res/layout/fragment_setting.xml
+++ b/app/src/mobile/res/layout/fragment_setting.xml
@@ -263,6 +263,23 @@
             </androidx.appcompat.widget.LinearLayoutCompat>
 
             <androidx.appcompat.widget.LinearLayoutCompat
+                android:id="@+id/subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/shape_item"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setting_subtitle"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
+            <androidx.appcompat.widget.LinearLayoutCompat
                 android:id="@+id/uiScale"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/mobile/res/layout/fragment_setting_subtitle.xml
+++ b/app/src/mobile/res/layout/fragment_setting_subtitle.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:navigationIconTint="@android:color/white"
+        app:title="@string/setting_subtitle"
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:overScrollMode="never">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="16dp">
+
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:id="@+id/subtitleAutoMatch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/shape_item"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:text="@string/player_subtitle_auto_match"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/subtitleAutoMatchText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="end"
+                    android:textColor="@color/white"
+                    android:textSize="16sp"
+                    tools:text="开" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:id="@+id/subtitleLanguage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/shape_item"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:text="@string/player_subtitle_language"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/subtitleLanguageText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:gravity="end"
+                    android:singleLine="true"
+                    android:textColor="@color/white"
+                    android:textSize="16sp"
+                    tools:text="中文优先" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:id="@+id/subtitleAssrtToken"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/shape_item"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:text="@string/player_subtitle_assrt_token"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/subtitleAssrtTokenText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:gravity="end"
+                    android:singleLine="true"
+                    android:textColor="@color/white"
+                    android:textSize="16sp"
+                    tools:text="已配置" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+        </androidx.appcompat.widget.LinearLayoutCompat>
+    </androidx.core.widget.NestedScrollView>
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/test/java/com/fongmi/android/tv/player/exo/ExoUtilTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/player/exo/ExoUtilTest.java
@@ -16,7 +16,7 @@ public class ExoUtilTest {
     }
 
     @Test
-    public void getRenderMode_keepsPlatformRendererFirstForSoftDecode() {
-        assertEquals(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON, ExoUtil.getRenderMode(PlayerEngine.SOFT));
+    public void getRenderMode_prefersExtensionRendererForSoftDecode() {
+        assertEquals(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER, ExoUtil.getRenderMode(PlayerEngine.SOFT));
     }
 }

--- a/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitleContextBuilderTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitleContextBuilderTest.java
@@ -1,0 +1,60 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SubtitleContextBuilderTest {
+
+    @Test
+    public void buildWithoutTmdb_usesSourceMetadataFallbackForMovie() {
+        SubtitleRequest request = SubtitleRequest.builder()
+                .siteKey("test")
+                .vodId("movie-1")
+                .vodName("想见你 (2019) 1080P")
+                .vodYear("2019")
+                .allowTmdbLookup(false)
+                .build();
+
+        SubtitleContext context = new SubtitleContextBuilder().build(request);
+        assertEquals("movie", context.getMediaType());
+        assertEquals("想见你", context.getCanonicalTitle());
+        assertEquals(2019, context.getYear());
+        assertFalse(context.hasTmdbIdentity());
+    }
+
+    @Test
+    public void buildWithoutTmdb_usesEpisodeMetadataFallbackForTv() {
+        SubtitleRequest request = SubtitleRequest.builder()
+                .siteKey("test")
+                .vodId("tv-1")
+                .vodName("最后生还者 第二季")
+                .episodeName("S02E03 漫长漫长时光")
+                .allowTmdbLookup(false)
+                .build();
+
+        SubtitleContext context = new SubtitleContextBuilder().build(request);
+        assertEquals("tv", context.getMediaType());
+        assertEquals("最后生还者", context.getCanonicalTitle());
+        assertEquals(2, context.getSeasonNumber());
+        assertEquals(3, context.getEpisodeNumber());
+    }
+
+    @Test
+    public void build_carriesPreferredLanguageThroughToContext() {
+        SubtitleRequest request = SubtitleRequest.builder()
+                .siteKey("test")
+                .vodId("movie-1")
+                .vodName("想见你")
+                .preferredLanguage("en")
+                .allowTmdbLookup(false)
+                .build();
+
+        SubtitleContext context = new SubtitleContextBuilder().build(request);
+        assertEquals("en", context.getPreferredLanguage());
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitlePlannerTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitlePlannerTest.java
@@ -1,0 +1,62 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.subtitle.model.ResolvedMediaIdentity;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleQuery;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SubtitlePlannerTest {
+
+    @Test
+    public void buildMovieQueries_prefersTitleWithYearThenFallbackTitle() {
+        SubtitleContext context = SubtitleContext.builder()
+                .mediaType("movie")
+                .canonicalTitle("想见你")
+                .year(2019)
+                .identity(ResolvedMediaIdentity.builder().canonicalTitle("想见你").year(2019).build())
+                .build();
+
+        List<SubtitleQuery> queries = new SubtitleQueryPlanner().build(context);
+        assertEquals("想见你 2019", queries.get(0).getText());
+        assertTrue(queries.stream().anyMatch(query -> "想见你".equals(query.getText())));
+    }
+
+    @Test
+    public void buildEpisodeQueries_prefersSxeAndEpisodeTitle() {
+        SubtitleContext context = SubtitleContext.builder()
+                .mediaType("tv")
+                .canonicalTitle("最后生还者")
+                .seasonNumber(2)
+                .episodeNumber(3)
+                .episodeTitle("漫长漫长时光")
+                .identity(ResolvedMediaIdentity.builder().canonicalTitle("最后生还者").seasonNumber(2).episodeNumber(3).episodeTitle("漫长漫长时光").build())
+                .build();
+
+        List<SubtitleQuery> queries = new SubtitleQueryPlanner().build(context);
+        assertEquals("最后生还者 S02E03", queries.get(0).getText());
+        assertTrue(queries.stream().anyMatch(query -> query.getText().contains("第3集")));
+        assertTrue(queries.stream().anyMatch(query -> query.getText().contains("漫长漫长时光")));
+    }
+
+    @Test
+    public void buildManual_usesEditableKeywordAsSingleQuery() {
+        SubtitleContext context = SubtitleContext.builder()
+                .mediaType("movie")
+                .canonicalTitle("镖人：风起大漠")
+                .year(2026)
+                .preferredLanguage("zh-Hans")
+                .build();
+
+        List<SubtitleQuery> queries = new SubtitleQueryPlanner().buildManual(context, " 镖人：风起大漠 2026 ");
+        assertEquals(1, queries.size());
+        assertEquals("镖人：风起大漠 2026", queries.get(0).getText());
+        assertEquals("zh-Hans", queries.get(0).getLanguage());
+        assertEquals(2026, queries.get(0).getYear());
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitlePlaybackSessionTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitlePlaybackSessionTest.java
@@ -1,0 +1,346 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.bean.Episode;
+import com.fongmi.android.tv.bean.Result;
+import com.fongmi.android.tv.bean.Site;
+import com.fongmi.android.tv.bean.Sub;
+import com.fongmi.android.tv.bean.TmdbEpisode;
+import com.fongmi.android.tv.bean.TmdbItem;
+import com.fongmi.android.tv.bean.Vod;
+import com.fongmi.android.tv.subtitle.model.SubtitleAsset;
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchResult;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchStatus;
+import com.fongmi.android.tv.subtitle.model.SubtitleRequest;
+import com.fongmi.android.tv.subtitle.model.SubtitleTrigger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SubtitlePlaybackSessionTest {
+
+    @Test
+    public void onPlaybackStarted_resolvesAutoPlaySourceSwitchAndEpisodeSwitch() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        FakeResultApplier applier = new FakeResultApplier();
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), applier);
+
+        session.onPlaybackStarted(host, result("https://play/1.m3u8"));
+        host.episode = Episode.create("第1集", "ep1", "https://episode/1");
+        session.onPlaybackStarted(host, result("https://play/1b.m3u8"));
+        host.episode = Episode.create("第2集", "ep2", "https://episode/2");
+        session.onPlaybackStarted(host, result("https://play/2.m3u8"));
+
+        assertEquals(List.of(SubtitleTrigger.AUTO_PLAY, SubtitleTrigger.SOURCE_SWITCH, SubtitleTrigger.EPISODE_SWITCH), requestFactory.triggers);
+        assertEquals(1, controller.playbackStarted.size());
+        assertEquals(1, controller.sourceChanged.size());
+        assertEquals(1, controller.episodeChanged.size());
+        assertTrue(applier.applied.isEmpty());
+    }
+
+    @Test
+    public void onPlaybackStarted_withProvidedSubtitleStopsMatching() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), new FakeResultApplier());
+
+        Result result = result("https://play/1.m3u8");
+        result.setSubs(Collections.singletonList(Sub.create("外挂字幕", "https://sub/1.srt", "zh", "application/x-subrip")));
+        session.onPlaybackStarted(host, result);
+
+        assertTrue(requestFactory.triggers.isEmpty());
+        assertEquals(List.of("playback-1"), controller.stoppedKeys);
+    }
+
+    @Test
+    public void onSubtitleResult_appliesOnlyForCurrentActiveRequest() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        FakeResultApplier applier = new FakeResultApplier();
+        FakeResultNotifier notifier = new FakeResultNotifier();
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), applier, notifier);
+
+        session.onPlaybackStarted(host, result("https://play/1.m3u8"));
+        SubtitleRequest current = controller.playbackStarted.get(0);
+        SubtitleAsset asset = new SubtitleAsset("file:///subtitle.srt", "/tmp/subtitle.srt", "匹配字幕", "zh", "application/x-subrip", 0, false, 0L);
+        controller.emit(current, SubtitleMatchResult.matched(null, asset, Collections.emptyList()));
+
+        assertEquals(1, applier.applied.size());
+        assertEquals("file:///subtitle.srt", applier.applied.get(0).getUrl());
+        assertEquals(List.of(SubtitleMatchStatus.MATCHED), notifier.statuses);
+        assertEquals(List.of(true), notifier.applied);
+
+        session.stop(host);
+        controller.emit(current, SubtitleMatchResult.matched(null, asset, Collections.emptyList()));
+        assertEquals(1, applier.applied.size());
+        assertEquals(1, notifier.statuses.size());
+    }
+
+    @Test
+    public void onSubtitleResult_notifiesFailureWithoutApplyingSubtitle() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        FakeResultApplier applier = new FakeResultApplier();
+        FakeResultNotifier notifier = new FakeResultNotifier();
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), applier, notifier);
+
+        session.onPlaybackStarted(host, result("https://play/1.m3u8"));
+        SubtitleRequest current = controller.playbackStarted.get(0);
+        controller.emit(current, SubtitleMatchResult.noMatch(Collections.emptyList(), "empty_result"));
+
+        assertTrue(applier.applied.isEmpty());
+        assertEquals(List.of(SubtitleMatchStatus.NO_MATCH), notifier.statuses);
+        assertEquals(List.of(false), notifier.applied);
+    }
+
+    @Test
+    public void manualSearch_returnsCandidatesForCurrentActiveRequest() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        FakeResultApplier applier = new FakeResultApplier();
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), applier);
+        SubtitleCandidate candidate = new SubtitleCandidate("assrt", "sub-1", "匹配字幕", "zh", "srt", "", 88, 2024, 1, 1, null, "query", true, "payload");
+        controller.manualResult = SubtitleMatchResult.noMatch(List.of(candidate), "manual_candidates");
+        List<SubtitleMatchResult> results = new ArrayList<>();
+        List<Boolean> applied = new ArrayList<>();
+
+        session.onPlaybackStarted(host, result("https://play/1.m3u8"));
+        session.manualSearch(host, (request, result, didApply) -> {
+            results.add(result);
+            applied.add(didApply);
+        });
+
+        assertEquals(1, controller.manualSearches.size());
+        assertEquals(List.of(candidate), results.get(0).getCandidates());
+        assertEquals(List.of(false), applied);
+        assertTrue(applier.applied.isEmpty());
+    }
+
+    @Test
+    public void manualSearch_withKeywordPassesEditableTextToController() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), new FakeResultApplier());
+        controller.manualResult = SubtitleMatchResult.noMatch(Collections.emptyList(), "empty_result");
+
+        session.onPlaybackStarted(host, result("https://play/1.m3u8"));
+        session.manualSearch(host, "镖人：风起大漠 2026", (request, result, didApply) -> {
+        });
+
+        assertEquals(List.of("镖人：风起大漠 2026"), controller.manualKeywords);
+    }
+
+    @Test
+    public void getManualSearchKeyword_prefersTmdbTitleAndYear() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        requestFactory.tmdbTitle = "镖人：风起大漠";
+        requestFactory.vodYear = "2026";
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), new FakeResultApplier());
+
+        session.onPlaybackStarted(host, result("https://play/1.m3u8"));
+
+        assertEquals("镖人：风起大漠 2026", session.getManualSearchKeyword(host));
+    }
+
+    @Test
+    public void resolveManual_appliesSelectedSubtitle() {
+        FakeController controller = new FakeController();
+        FakeRequestFactory requestFactory = new FakeRequestFactory();
+        FakeResultApplier applier = new FakeResultApplier();
+        FakeHost host = new FakeHost();
+        SubtitlePlaybackSession session = new SubtitlePlaybackSession(host, controller, requestFactory, new SubtitleInjector(), applier);
+        SubtitleCandidate candidate = new SubtitleCandidate("assrt", "sub-1", "匹配字幕", "zh", "srt", "", 88, 2024, 1, 1, null, "query", true, "payload");
+        SubtitleAsset asset = new SubtitleAsset("file:///manual.srt", "/tmp/manual.srt", "手动字幕", "zh", "application/x-subrip", 0, false, 0L);
+        controller.resolveResult = SubtitleMatchResult.matched(candidate, asset, List.of(candidate));
+        List<Boolean> applied = new ArrayList<>();
+
+        session.onPlaybackStarted(host, result("https://play/1.m3u8"));
+        session.resolveManual(host, candidate, (request, result, didApply) -> applied.add(didApply));
+
+        assertEquals(List.of(candidate), controller.resolveCandidates);
+        assertEquals(1, applier.applied.size());
+        assertEquals("file:///manual.srt", applier.applied.get(0).getUrl());
+        assertEquals(List.of(true), applied);
+    }
+
+    private Result result(String playUrl) {
+        Result result = new Result();
+        result.setPlayUrl(playUrl);
+        return result;
+    }
+
+    private static final class FakeController implements SubtitlePlaybackSession.Controller {
+
+        private final List<SubtitleRequest> playbackStarted = new ArrayList<>();
+        private final List<SubtitleRequest> episodeChanged = new ArrayList<>();
+        private final List<SubtitleRequest> sourceChanged = new ArrayList<>();
+        private final List<SubtitleRequest> manualSearches = new ArrayList<>();
+        private final List<String> manualKeywords = new ArrayList<>();
+        private final List<SubtitleCandidate> resolveCandidates = new ArrayList<>();
+        private final List<String> stoppedKeys = new ArrayList<>();
+        private SubtitleMatchResult manualResult;
+        private SubtitleMatchResult resolveResult;
+        private Callback callback;
+
+        @Override
+        public void bind(Callback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void onPlaybackStarted(SubtitleRequest request) {
+            playbackStarted.add(request);
+        }
+
+        @Override
+        public void onEpisodeChanged(SubtitleRequest request) {
+            episodeChanged.add(request);
+        }
+
+        @Override
+        public void onSourceChanged(SubtitleRequest request) {
+            sourceChanged.add(request);
+        }
+
+        @Override
+        public void onStop(String playbackKey) {
+            stoppedKeys.add(playbackKey);
+        }
+
+        @Override
+        public void manualSearch(SubtitleRequest request, Callback callback) {
+            manualSearch(request, "", callback);
+        }
+
+        @Override
+        public void manualSearch(SubtitleRequest request, String keyword, Callback callback) {
+            manualSearches.add(request);
+            manualKeywords.add(keyword);
+            if (callback != null && manualResult != null) callback.onSubtitleResult(request, manualResult);
+        }
+
+        @Override
+        public void resolve(SubtitleRequest request, SubtitleCandidate candidate, Callback callback) {
+            resolveCandidates.add(candidate);
+            if (callback != null && resolveResult != null) callback.onSubtitleResult(request, resolveResult);
+        }
+
+        private void emit(SubtitleRequest request, SubtitleMatchResult result) {
+            if (callback != null) callback.onSubtitleResult(request, result);
+        }
+    }
+
+    private static final class FakeRequestFactory extends SubtitleRequestFactory {
+
+        private final List<SubtitleTrigger> triggers = new ArrayList<>();
+        private String tmdbTitle = "";
+        private String vodYear = "";
+
+        @Override
+        public SubtitleRequest create(String playbackKey, Site site, Vod vod, Episode episode, Result result, TmdbItem tmdbItem, TmdbEpisode tmdbEpisode, SubtitleTrigger trigger) {
+            triggers.add(trigger);
+            return SubtitleRequest.builder()
+                    .playbackKey(playbackKey)
+                    .siteKey(site == null ? "" : "test")
+                    .vodId(vod == null ? "" : "vod-1")
+                    .vodName(vod == null ? "" : "想见你")
+                    .vodYear(vodYear)
+                    .episodeName(episode == null ? "" : "第1集")
+                    .playUrl(result == null ? "" : "https://play/test.m3u8")
+                    .playHeaders(Map.of())
+                    .preferredLanguage("zh")
+                    .trigger(trigger)
+                    .allowTmdbLookup(false)
+                    .tmdbItem(tmdbTitle.isEmpty() ? null : new TmdbItem(1, "movie", tmdbTitle, "", "", "", ""))
+                    .build();
+        }
+    }
+
+    private static final class FakeResultApplier implements SubtitlePlaybackSession.ResultApplier {
+
+        private final List<Sub> applied = new ArrayList<>();
+        private boolean applyResult = true;
+
+        @Override
+        public boolean apply(SubtitlePlaybackSession.Host host, Sub sub) {
+            applied.add(sub);
+            return applyResult;
+        }
+    }
+
+    private static final class FakeResultNotifier implements SubtitlePlaybackSession.ResultNotifier {
+
+        private final List<SubtitleMatchStatus> statuses = new ArrayList<>();
+        private final List<Boolean> applied = new ArrayList<>();
+
+        @Override
+        public void notify(SubtitlePlaybackSession.Host host, SubtitleRequest request, SubtitleMatchResult result, boolean applied) {
+            statuses.add(result.getStatus());
+            this.applied.add(applied);
+        }
+    }
+
+    private static final class FakeHost implements SubtitlePlaybackSession.Host {
+
+        private Episode episode = Episode.create("第1集", "ep1", "https://episode/1");
+
+        @Override
+        public String getSubtitlePlaybackKey() {
+            return "playback-1";
+        }
+
+        @Override
+        public Site getSubtitleSite() {
+            return Site.get("test", "Test");
+        }
+
+        @Override
+        public Vod getSubtitleVod() {
+            Vod vod = new Vod();
+            vod.setId("vod-1");
+            vod.setName("想见你");
+            return vod;
+        }
+
+        @Override
+        public Episode getSubtitleEpisode() {
+            return episode;
+        }
+
+        @Override
+        public TmdbItem getSubtitleTmdbItem() {
+            return null;
+        }
+
+        @Override
+        public TmdbEpisode getSubtitleTmdbEpisode() {
+            return null;
+        }
+
+        @Override
+        public com.fongmi.android.tv.player.PlayerManager getSubtitlePlayer() {
+            return null;
+        }
+
+        @Override
+        public boolean isSubtitleHostActive() {
+            return true;
+        }
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitleRankerTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitleRankerTest.java
@@ -1,0 +1,29 @@
+package com.fongmi.android.tv.subtitle;
+
+import com.fongmi.android.tv.subtitle.model.SubtitleCandidate;
+import com.fongmi.android.tv.subtitle.model.SubtitleContext;
+import com.fongmi.android.tv.subtitle.model.SubtitleMatchType;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SubtitleRankerTest {
+
+    @Test
+    public void rank_prefersConfiguredLanguageOverDefaultChineseBias() {
+        SubtitleContext context = SubtitleContext.builder()
+                .mediaType("movie")
+                .canonicalTitle("The Last of Us")
+                .preferredLanguage("en")
+                .build();
+
+        SubtitleCandidate chinese = new SubtitleCandidate("assrt", "1", "The Last of Us 中文字幕", "中文字幕", "srt", "The Last of Us", 60, 0, 0, 0, SubtitleMatchType.METADATA_FUZZY, "query", false, "{}");
+        SubtitleCandidate english = new SubtitleCandidate("assrt", "2", "The Last of Us English", "English", "srt", "The Last of Us", 60, 0, 0, 0, SubtitleMatchType.METADATA_FUZZY, "query", false, "{}");
+
+        List<SubtitleCandidate> ranked = new SubtitleRanker().rank(List.of(chinese, english), context);
+        assertEquals("2", ranked.get(0).getCandidateId());
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitleTitleParserTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/subtitle/SubtitleTitleParserTest.java
@@ -1,0 +1,38 @@
+package com.fongmi.android.tv.subtitle;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SubtitleTitleParserTest {
+
+    @Test
+    public void cleanTitle_removesCommonNoise() {
+        SubtitleTitleParser parser = new SubtitleTitleParser();
+        assertEquals("想见你", parser.cleanTitle("想见你 2019 1080P 国语版"));
+    }
+
+    @Test
+    public void firstYear_extractsFirstYear() {
+        SubtitleTitleParser parser = new SubtitleTitleParser();
+        assertEquals(2019, parser.firstYear("想见你 (2019)"));
+    }
+
+    @Test
+    public void seasonAndEpisodeNumber_parseStructuredEpisodeTokens() {
+        SubtitleTitleParser parser = new SubtitleTitleParser();
+        assertEquals(2, parser.seasonNumber("最后生还者 S02E03"));
+        assertEquals(3, parser.episodeNumber("最后生还者 S02E03"));
+        assertEquals(12, parser.episodeNumber("第12集"));
+    }
+
+    @Test
+    public void aliases_includeCleanAndYearTrimmedVariants() {
+        SubtitleTitleParser parser = new SubtitleTitleParser();
+        List<String> aliases = parser.aliases("想见你 (2019)", "想见你 国语版");
+        assertTrue(aliases.contains("想见你"));
+    }
+}


### PR DESCRIPTION
## Summary
- Sync fish2018 upstream changes into dev.
- Add automatic/manual subtitle matching for network playback with ASSRT provider support.
- Add standalone subtitle settings pages for TV/mobile and player-side match notifications.
- Keep subtitle loading on the reload path and reset selected text track so matched subtitles are enabled by default.

## Verification
- .\\gradlew.bat :app:testLeanbackArm64_v8aDebugUnitTest :app:testMobileArm64_v8aDebugUnitTest