### PR TITLE
feat(TmdbDetailActivity): 添加移动设备融合播放器按钮设置和停靠功能

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -81,6 +81,7 @@ import com.fongmi.android.tv.service.IntroSkipService;
 import com.fongmi.android.tv.service.PlaybackService;
 import com.fongmi.android.tv.service.TmdbService;
 import com.fongmi.android.tv.setting.DanmakuSetting;
+import com.fongmi.android.tv.setting.PlayerButtonSetting;
 import com.fongmi.android.tv.setting.PlayerSetting;
 import com.fongmi.android.tv.setting.Setting;
 import com.fongmi.android.tv.subtitle.SubtitlePlaybackSession;
@@ -251,6 +252,9 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private ViewGroup.LayoutParams inlinePiPLayoutParams;
     private View detailControlRoot;
     private View detailActionRoot;
+    private ViewGroup detailActionParent;
+    private ViewGroup.LayoutParams detailActionLayoutParams;
+    private int detailActionIndex;
     private View inlineControlFocus;
     private long lastInlineControlInteraction;
     private long inlineDisplaySuppressUntil;
@@ -747,6 +751,9 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.detailControlHost.removeAllViews();
         binding.detailControlHost.addView(detailControlRoot);
         detailActionRoot = detailControlRoot.findViewById(R.id.action);
+        detailActionParent = (ViewGroup) detailActionRoot.getParent();
+        detailActionLayoutParams = detailActionRoot.getLayoutParams();
+        detailActionIndex = detailActionParent.indexOfChild(detailActionRoot);
     }
 
     private <T extends View> T detailControlView(int id, Class<T> type) {
@@ -3990,7 +3997,56 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.playerRepeat.setSelected(hasPlayer && player().isRepeatOne());
         setInlineFullscreenIcon();
         updateMobileInlineButtons(playing, hasPlayer, hasPrev, hasNext, hasTitle);
+        applyInlinePlayerButtonSettings();
         updateInlineDisplayPanel();
+    }
+
+    private void applyInlinePlayerButtonSettings() {
+        PlayerButtonSetting.applyOrder((ViewGroup) binding.playerActionRow.getChildAt(0), inlinePlayerButtonMap());
+        if (!Util.isMobile() || detailActionRoot == null) return;
+        PlayerButtonSetting.applyOrder(detailActionRoot.findViewById(R.id.container), mobileInlinePlayerButtonMap());
+    }
+
+    private Map<String, View> inlinePlayerButtonMap() {
+        Map<String, View> buttons = new LinkedHashMap<>();
+        buttons.put(PlayerButtonSetting.FULLSCREEN, binding.playerFullscreenAction);
+        buttons.put(PlayerButtonSetting.NEXT, binding.playerNext);
+        buttons.put(PlayerButtonSetting.PREV, binding.playerPrev);
+        buttons.put(PlayerButtonSetting.EPISODES, binding.playerEpisodes);
+        buttons.put(PlayerButtonSetting.RESET, binding.playerRefresh);
+        buttons.put(PlayerButtonSetting.CHANGE, binding.playerChangeSource);
+        buttons.put(PlayerButtonSetting.PLAYER, binding.playerExternal);
+        buttons.put(PlayerButtonSetting.DECODE, binding.playerDecode);
+        buttons.put(PlayerButtonSetting.SPEED, binding.playerSpeed);
+        buttons.put(PlayerButtonSetting.SCALE, binding.playerScale);
+        buttons.put(PlayerButtonSetting.TEXT, binding.playerTextTrack);
+        buttons.put(PlayerButtonSetting.AUDIO, binding.playerAudioTrack);
+        buttons.put(PlayerButtonSetting.VIDEO, binding.playerVideoTrack);
+        buttons.put(PlayerButtonSetting.OPENING, binding.playerOpening);
+        buttons.put(PlayerButtonSetting.ENDING, binding.playerEnding);
+        buttons.put(PlayerButtonSetting.DANMAKU, binding.playerDanmaku);
+        buttons.put(PlayerButtonSetting.TITLE, binding.playerChapter);
+        buttons.put(PlayerButtonSetting.REPEAT, binding.playerRepeat);
+        return buttons;
+    }
+
+    private Map<String, View> mobileInlinePlayerButtonMap() {
+        Map<String, View> buttons = new LinkedHashMap<>();
+        buttons.put(PlayerButtonSetting.PLAYER, detailActionView(R.id.player, View.class));
+        buttons.put(PlayerButtonSetting.DECODE, detailActionView(R.id.decode, View.class));
+        buttons.put(PlayerButtonSetting.SPEED, detailActionView(R.id.speed, View.class));
+        buttons.put(PlayerButtonSetting.SCALE, detailActionView(R.id.scale, View.class));
+        buttons.put(PlayerButtonSetting.RESET, detailActionView(R.id.reset, View.class));
+        buttons.put(PlayerButtonSetting.REPEAT, detailActionView(R.id.repeat, View.class));
+        buttons.put(PlayerButtonSetting.TEXT, detailActionView(R.id.text, View.class));
+        buttons.put(PlayerButtonSetting.AUDIO, detailActionView(R.id.audio, View.class));
+        buttons.put(PlayerButtonSetting.VIDEO, detailActionView(R.id.video, View.class));
+        buttons.put(PlayerButtonSetting.OPENING, detailActionView(R.id.opening, View.class));
+        buttons.put(PlayerButtonSetting.ENDING, detailActionView(R.id.ending, View.class));
+        buttons.put(PlayerButtonSetting.DANMAKU, detailActionView(R.id.danmaku, View.class));
+        buttons.put(PlayerButtonSetting.TITLE, detailActionView(R.id.chapter, View.class));
+        buttons.put(PlayerButtonSetting.EPISODES, detailActionView(R.id.episodes, View.class));
+        return buttons;
     }
 
     private void updateMobileInlineButtons(boolean playing, boolean hasPlayer, boolean hasPrev, boolean hasNext, boolean hasTitle) {
@@ -4063,8 +4119,33 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         detailActionView(R.id.chapter, View.class).setVisibility(hasTitle ? View.VISIBLE : View.GONE);
         detailActionView(R.id.actionQuality, View.class).setVisibility(inlineQuality ? View.VISIBLE : View.GONE);
         detailActionView(R.id.repeat, View.class).setSelected(hasPlayer && player().isRepeatOne());
-        action.setVisibility(inlineFullscreen && !locked ? View.VISIBLE : View.GONE);
+        boolean docked = updateMobileFusionPlayerActionDock(hasPlayer && !locked);
+        if (!docked) action.setVisibility(inlineFullscreen && !locked ? View.VISIBLE : View.GONE);
         inlineControlController.updateDanmakuState();
+    }
+
+    private boolean updateMobileFusionPlayerActionDock(boolean show) {
+        if (!Util.isMobile() || detailActionRoot == null || binding.mobileFusionPlayerActionDock == null) return false;
+        if (!isFusionMode() || inlineFullscreen || inlinePiPLayout || !show) {
+            restoreMobileInlinePlayerAction();
+            binding.mobileFusionPlayerActionDock.setVisibility(View.GONE);
+            return false;
+        }
+        if (detailActionRoot.getParent() != binding.mobileFusionPlayerActionDock) {
+            if (detailActionRoot.getParent() instanceof ViewGroup parent) parent.removeView(detailActionRoot);
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            binding.mobileFusionPlayerActionDock.addView(detailActionRoot, params);
+        }
+        binding.mobileFusionPlayerActionDock.setVisibility(View.VISIBLE);
+        detailActionRoot.setVisibility(View.VISIBLE);
+        return true;
+    }
+
+    private void restoreMobileInlinePlayerAction() {
+        if (detailActionRoot == null || detailActionParent == null || detailActionRoot.getParent() == detailActionParent) return;
+        if (detailActionRoot.getParent() instanceof ViewGroup parent) parent.removeView(detailActionRoot);
+        int index = Math.min(Math.max(detailActionIndex, 0), detailActionParent.getChildCount());
+        detailActionParent.addView(detailActionRoot, index, detailActionLayoutParams);
     }
 
     private CharSequence inlineDecodeText(boolean hasPlayer) {

--- a/app/src/main/res/layout/activity_tmdb_detail.xml
+++ b/app/src/main/res/layout/activity_tmdb_detail.xml
@@ -667,6 +667,15 @@
                     android:visibility="gone" />
             </com.google.android.material.card.MaterialCardView>
 
+            <FrameLayout
+                android:id="@+id/mobileFusionPlayerActionDock"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="12dp"
+                android:visibility="gone" />
+
             <com.google.android.flexbox.FlexboxLayout
                 android:id="@+id/fusionActions"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_control_vod_action_tmdb.xml
+++ b/app/src/main/res/layout/view_control_vod_action_tmdb.xml
@@ -9,6 +9,7 @@
     android:scrollbars="none">
 
     <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal">

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -994,7 +994,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         addActionButton(PlayerButtonSetting.PREV, mBinding.control.action.prev);
         addActionButton(PlayerButtonSetting.NEXT, mBinding.control.action.next);
         addActionButton(PlayerButtonSetting.EPISODES, mBinding.control.action.episodes);
-        PlayerButtonSetting.applyOrder(mBinding.control.action.container, mActionButtons);
+        applyActionButtonSettings();
     }
 
     private void addActionButton(String id, View view) {
@@ -1003,6 +1003,10 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     private void applyActionButtonVisibility() {
         if (mActionButtons != null) PlayerButtonSetting.applyVisibility(mActionButtons);
+    }
+
+    private void applyActionButtonSettings() {
+        if (mActionButtons != null) PlayerButtonSetting.applyOrder(mBinding.control.action.container, mActionButtons);
     }
 
     private void setVideoView(boolean isInPictureInPictureMode) {
@@ -1409,6 +1413,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         if (DanmakuApi.canSearch()) DanmakuApi.search(mHistory.getVodName(), getEpisode().getName(), danmaku -> {
             if (DanmakuSetting.isSpiderFirst() && !result.getDanmaku().isEmpty()) player().addDanmaku(danmaku);
             else player().setDanmaku(danmaku);
+            refreshDanmakuControls();
         });
     }
 
@@ -2256,6 +2261,12 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         player().setDanmakuEnabled(false);
     }
 
+    private void refreshDanmakuControls() {
+        mBinding.control.action.danmaku.setVisibility(DanmakuSetting.isLoad() ? View.VISIBLE : View.GONE);
+        applyActionButtonVisibility();
+        if (mBinding.control.getRoot().getVisibility() == View.VISIBLE) mBinding.control.danmaku.setVisibility(isLock() || !player().haveDanmaku() ? View.GONE : View.VISIBLE);
+    }
+
     private void showControl() {
         if (service() == null || isInPictureInPictureMode()) return;
         setOsdSuppressed(true);
@@ -2270,7 +2281,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mBinding.control.osdDiagnostics.setVisibility(PlayerSetting.isOsdDiagnostics() && !player().isEmpty() ? View.VISIBLE : View.GONE);
         mBinding.control.osdDiagnostics.setAlpha(mOsd != null && mOsd.isDiagnosticsVisible() ? 1f : 0.72f);
         mBinding.control.parse.setVisibility(isFullscreen() && isUseParse() ? View.VISIBLE : View.GONE);
-        mBinding.control.action.getRoot().setVisibility(isFullscreen() ? View.VISIBLE : View.GONE);
+        mBinding.control.action.getRoot().setVisibility(isFullscreen() || isFusionPlayerActionsDocked() ? View.VISIBLE : View.GONE);
         mBinding.control.right.lock.setVisibility(isFullscreen() ? View.VISIBLE : View.GONE);
         mBinding.control.info.setVisibility(player().isEmpty() ? View.GONE : View.VISIBLE);
         mBinding.control.cast.setVisibility(isFullscreen() && mHistory != null && !player().isEmpty() ? View.VISIBLE : View.GONE);
@@ -2878,7 +2889,10 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         else if (event.getType() == RefreshEvent.Type.VOD) updateVod(event.getVod());
         else if (event.getType() == RefreshEvent.Type.HISTORY) refreshPersonalRecommendationsForHistory();
         else if (event.getType() == RefreshEvent.Type.SUBTITLE) player().setSub(Sub.from(event.getPath()));
-        else if (event.getType() == RefreshEvent.Type.DANMAKU) player().setDanmaku(Danmaku.from(event.getPath()));
+        else if (event.getType() == RefreshEvent.Type.DANMAKU) {
+            player().setDanmaku(Danmaku.from(event.getPath()));
+            refreshDanmakuControls();
+        }
     }
 
     private void requestIntroSkipPlan() {
@@ -3359,6 +3373,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         tintFusionPlaybackIcon(mBinding.reverse, color);
         tintFusionPlaybackIcon(mBinding.episodeViewMode, color);
         tintFusionPlaybackIcon(mBinding.more, color);
+        tintFusionPlaybackTextTree(mBinding.control.action.getRoot(), color, light);
     }
 
     private boolean isTmdbPlaybackLightTheme() {
@@ -3699,6 +3714,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
             if (parent != null) parent.removeView(view);
             playbackControls.addView(view);
         }
+        moveFusionPlayerActionsToTmdb(playbackControls);
         mTmdbControlsMoved = true;
         updateEpisodeGroupVisibility();
         mTmdbHeaderView.refreshTheme();
@@ -3763,6 +3779,21 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         if (view == null) return;
         for (TmdbMovedView item : mTmdbMovedViews) if (item.view == view) return;
         if (view.getParent() instanceof ViewGroup) mTmdbMovedViews.add(new TmdbMovedView(view));
+    }
+
+    private void moveFusionPlayerActionsToTmdb(ViewGroup playbackControls) {
+        if (!Setting.isFusionDetailPage()) return;
+        View actions = mBinding.control.action.getRoot();
+        rememberTmdbMovedView(actions);
+        if (actions.getParent() instanceof ViewGroup parent) parent.removeView(actions);
+        actions.setLayoutParams(new LinearLayoutCompat.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        playbackControls.addView(actions);
+        actions.setVisibility(View.VISIBLE);
+        applyActionButtonSettings();
+    }
+
+    private boolean isFusionPlayerActionsDocked() {
+        return Setting.isFusionDetailPage() && mBinding.control.action.getRoot().getParent() != mBinding.control.bottom;
     }
 
     private View[] getTmdbMovableViews() {

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -34,6 +34,62 @@ public class TmdbDetailActivityLayoutTest {
     }
 
     @Test
+    public void fusionInlinePlayerButtonsUsePlayerButtonSettings() throws Exception {
+        Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int method = source.indexOf("private void applyInlinePlayerButtonSettings()");
+        int update = source.indexOf("private void updateInlineButtons(boolean playing)");
+        int call = source.indexOf("applyInlinePlayerButtonSettings();", update);
+
+        assertTrue(sourcePath + " is missing applyInlinePlayerButtonSettings", method >= 0);
+        assertTrue("inline player buttons must apply settings after dynamic visibility is recalculated", call > update);
+        assertTrue("wide fusion buttons must use PlayerButtonSetting order and visibility",
+                source.indexOf("PlayerButtonSetting.applyOrder((ViewGroup) binding.playerActionRow.getChildAt(0)", method) > method);
+        assertTrue("fusion fullscreen button must be mapped to player button settings",
+                source.indexOf("buttons.put(PlayerButtonSetting.FULLSCREEN, binding.playerFullscreenAction)", method) > method);
+        assertTrue("fusion refresh button must be mapped so hiding reset hides refresh",
+                source.indexOf("buttons.put(PlayerButtonSetting.RESET, binding.playerRefresh)", method) > method);
+        assertTrue("fusion source button must be mapped to the change setting",
+                source.indexOf("buttons.put(PlayerButtonSetting.CHANGE, binding.playerChangeSource)", method) > method);
+    }
+
+    @Test
+    public void mobileFusionInlinePlayerActionLayoutExposesConfigContainer() throws Exception {
+        Path layoutPath = findMainResPath().resolve(Path.of("layout", "view_control_vod_action_tmdb.xml"));
+        String layout = new String(Files.readAllBytes(layoutPath), StandardCharsets.UTF_8);
+
+        assertTrue("mobile fusion action row must expose @id/container for PlayerButtonSetting.applyOrder",
+                layout.contains("android:id=\"@+id/container\""));
+    }
+
+    @Test
+    public void mobileFusionDetailDocksInlinePlayerActionsBelowPlayer() throws Exception {
+        Path layoutPath = findMainResPath().resolve(Path.of("layout", "activity_tmdb_detail.xml"));
+        String layout = new String(Files.readAllBytes(layoutPath), StandardCharsets.UTF_8);
+        int player = layout.indexOf("android:id=\"@+id/playerPanel\"");
+        int dock = layout.indexOf("android:id=\"@+id/mobileFusionPlayerActionDock\"");
+        int fusionActions = layout.indexOf("android:id=\"@+id/fusionActions\"");
+
+        assertTrue("mobile fusion detail must expose a dock for the shared player action row", dock >= 0);
+        assertTrue("mobile fusion player action dock must sit between player and detail actions", player < dock && dock < fusionActions);
+
+        Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int update = source.indexOf("private void updateMobileInlineButtons(boolean playing");
+        int dockMethod = source.indexOf("private boolean updateMobileFusionPlayerActionDock(boolean show)");
+        int restoreMethod = source.indexOf("private void restoreMobileInlinePlayerAction()");
+
+        assertTrue(sourcePath + " is missing updateMobileFusionPlayerActionDock", dockMethod >= 0);
+        assertTrue(sourcePath + " is missing restoreMobileInlinePlayerAction", restoreMethod >= 0);
+        assertTrue("mobile inline buttons must dock the action row before falling back to fullscreen visibility",
+                source.indexOf("boolean docked = updateMobileFusionPlayerActionDock(hasPlayer && !locked);", update) > update);
+        assertTrue("non-fullscreen fusion detail must move the shared action row into the visible dock",
+                source.indexOf("binding.mobileFusionPlayerActionDock.addView(detailActionRoot", dockMethod) > dockMethod);
+        assertTrue("fullscreen and non-fusion modes must restore the action row to the control overlay",
+                source.indexOf("restoreMobileInlinePlayerAction();", dockMethod) > dockMethod);
+    }
+
+    @Test
     public void fusionDetailBackdropCropsToFillScreen() throws Exception {
         Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
@@ -101,6 +101,25 @@ public class VideoActivityLayoutTest {
     }
 
     @Test
+    public void mobileVideoRefreshesDanmakuControlsAfterLateDanmakuLoad() throws Exception {
+        Path sourcePath = findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int method = source.indexOf("private void refreshDanmakuControls()");
+        int action = source.indexOf("mBinding.control.action.danmaku.setVisibility", method);
+        int quick = source.indexOf("mBinding.control.danmaku.setVisibility", method);
+        int apiSearch = source.indexOf("DanmakuApi.search");
+        int apiRefresh = source.indexOf("refreshDanmakuControls();", apiSearch);
+        int event = source.indexOf("RefreshEvent.Type.DANMAKU");
+        int eventRefresh = source.indexOf("refreshDanmakuControls();", event);
+
+        assertTrue(sourcePath + " is missing refreshDanmakuControls", method >= 0);
+        assertTrue("late danmaku refresh must update the fullscreen action button", action > method);
+        assertTrue("late danmaku refresh must update the quick toggle button", quick > method);
+        assertTrue("auto danmaku search must refresh controls after loading", apiRefresh > apiSearch);
+        assertTrue("manual danmaku refresh event must refresh controls after loading", eventRefresh > event);
+    }
+
+    @Test
     public void mobileVideoTmdbMovableViewsKeepQualityBetweenFlagsAndEpisodes() throws Exception {
         Path sourcePath = findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"));
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
@@ -221,6 +240,25 @@ public class VideoActivityLayoutTest {
         assertTrue("fusion playback controls must update visibility before final theme sync", updateVisibility > method);
         assertTrue("fusion playback controls must refresh header theme after all source and episode views are moved", refreshHeader > updateVisibility);
         assertTrue("fusion playback surface must sync after header playback controls are re-themed", refreshSurface > refreshHeader);
+    }
+
+    @Test
+    public void mobileVideoFusionUsesNativePlayerActionButtons() throws Exception {
+        Path sourcePath = findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int move = source.indexOf("private void moveFusionPlayerActionsToTmdb");
+        int actionRoot = source.indexOf("mBinding.control.action.getRoot()", move);
+        int settings = source.indexOf("applyActionButtonSettings();", actionRoot);
+        int layoutParams = source.indexOf("new LinearLayoutCompat.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)", actionRoot);
+        int docked = source.indexOf("private boolean isFusionPlayerActionsDocked()");
+
+        assertTrue(sourcePath + " is missing moveFusionPlayerActionsToTmdb", move >= 0);
+        assertTrue("fusion must reuse the native player action root", actionRoot > move);
+        assertTrue("fusion reused player buttons must honor player button order and visibility settings", settings > actionRoot);
+        assertTrue("fusion reused player action row must fill the TMDB playback controls width on narrow screens", layoutParams > actionRoot);
+        assertTrue("showControl must keep docked fusion player buttons visible", docked > move);
+        assertTrue("fusion player button text should share the moved playback control theme",
+                source.indexOf("tintFusionPlaybackTextTree(mBinding.control.action.getRoot()", source.indexOf("private void applyTmdbPlaybackControlColors()")) > 0);
     }
 
     @Test


### PR DESCRIPTION
- 引入PlayerButtonSetting用于配置内联播放器按钮顺序
- 为移动设备添加融合播放器动作停靠区域布局
- 实现移动设备融合模式下的播放器动作停靠和恢复功能
- 添加内联播放器按钮映射配置方法
- 在VideoActivity中统一应用按钮设置并优化弹幕控制刷新
- 增加相关单元测试验证融合播放器功能实现