### PR TITLE
feat(ui): 实现TMDB详情页面的壁纸背景支持

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -1011,13 +1011,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void applyDetailTheme() {
         lightTheme = resolveLightTheme();
         applyDetailEdgeToEdge();
-        ThemeColors colors = lightTheme ? ThemeColors.light() : ThemeColors.dark();
-        if (isCinemaMode()) colors = ThemeColors.cinema(lightTheme);
-        int backdropBackground = backdropFallbackBackground(colors);
-        binding.root.setBackgroundColor(backdropBackground);
-        binding.hero.setBackgroundColor(backdropBackground);
-        binding.backdropFill.setBackgroundColor(backdropBackground);
-        binding.backdrop.setBackgroundColor(backdropBackground);
+        ThemeColors colors = currentThemeColors();
+        applyBackdropSurface(colors);
         binding.backdropFill.setAlpha(backdropSlideAlpha());
         binding.backdrop.setAlpha(backdropSlideAlpha());
         binding.backdropShade.setBackground(isCinemaMode() ? cinemaBackdropShade() : colorDrawable(colors.backdropShade));
@@ -1952,7 +1947,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     private void bindBackdrop() {
-        bindBackdropImage(vod.getName(), tmdbBackdropUrl(), vod.getPic());
+        boolean wallpaperBackdrop = useAppWallpaperBackdrop();
+        bindBackdropImage(vod.getName(), wallpaperBackdrop ? "" : tmdbBackdropUrl(), wallpaperBackdrop ? "" : vod.getPic());
         episodeAdapter.setFallbackStillUrl(episodeFallbackStillUrl());
         ImgUtil.load(vod.getName(), tmdbPosterUrl(), binding.poster);
     }
@@ -1969,7 +1965,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void bindBackdropImage(String title, String backdrop, String fallback) {
         boolean hasBackdrop = !TextUtils.isEmpty(backdrop) && !TextUtils.equals(backdrop, fallback);
         String image = hasBackdrop ? backdrop : fallback;
-        binding.hero.setVisibility(TextUtils.isEmpty(image) ? View.GONE : View.VISIBLE);
+        refreshBackdropSurface();
+        binding.hero.setVisibility(TextUtils.isEmpty(image) && !useAppWallpaperBackdrop() ? View.GONE : View.VISIBLE);
         cancelBackdropSlideRequest();
         if (TextUtils.isEmpty(image)) {
             ImgUtil.clear(binding.backdropFill);
@@ -2198,6 +2195,27 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     private boolean shouldCropBackdrop() {
         return true;
+    }
+
+    private ThemeColors currentThemeColors() {
+        ThemeColors colors = lightTheme ? ThemeColors.light() : ThemeColors.dark();
+        return isCinemaMode() ? ThemeColors.cinema(lightTheme) : colors;
+    }
+
+    private void refreshBackdropSurface() {
+        applyBackdropSurface(currentThemeColors());
+    }
+
+    private void applyBackdropSurface(ThemeColors colors) {
+        int backdropBackground = useAppWallpaperBackdrop() ? Color.TRANSPARENT : backdropFallbackBackground(colors);
+        binding.root.setBackgroundColor(backdropBackground);
+        binding.hero.setBackgroundColor(backdropBackground);
+        binding.backdropFill.setBackgroundColor(backdropBackground);
+        binding.backdrop.setBackgroundColor(backdropBackground);
+    }
+
+    private boolean useAppWallpaperBackdrop() {
+        return vod != null && matchedTmdbDetail == null;
     }
 
     private int backdropFallbackBackground(ThemeColors colors) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -3351,7 +3351,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     private void applyFusionThemeSurface() {
         boolean light = isFusionLightTheme();
-        mBinding.getRoot().setBackgroundColor(light ? 0xFFF3F6F9 : 0xFF0F141A);
+        mBinding.getRoot().setBackgroundColor(mTmdbFallbackToNative ? Color.TRANSPARENT : light ? 0xFFF3F6F9 : 0xFF0F141A);
         mBinding.scroll.setBackgroundColor(Color.TRANSPARENT);
         mBinding.swipeLayout.setBackgroundColor(Color.TRANSPARENT);
         mBinding.progressLayout.setBackgroundColor(Color.TRANSPARENT);
@@ -3366,13 +3366,18 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     private void applyContextWallScrimTheme() {
         if (mBinding.videoContextScrim == null) return;
+        if (mTmdbFallbackToNative) {
+            mBinding.videoContextScrim.setBackgroundResource(R.drawable.shape_video_context_scrim);
+            mBinding.videoContextScrim.setVisibility(View.VISIBLE);
+            return;
+        }
         boolean light = Setting.isFusionDetailPage() && isFusionLightTheme();
         mBinding.videoContextScrim.setBackgroundResource(light ? R.drawable.shape_video_context_scrim_light : R.drawable.shape_video_context_scrim);
     }
 
     private void applyFusionNativeTextColors() {
-        if (!Setting.isFusionDetailPage() || mBinding.nativeContentContainer == null) return;
-        tintFusionNativeTextTree(mBinding.nativeContentContainer, isFusionLightTheme());
+        if ((!Setting.isFusionDetailPage() && !mTmdbFallbackToNative) || mBinding.nativeContentContainer == null) return;
+        tintFusionNativeTextTree(mBinding.nativeContentContainer, !mTmdbFallbackToNative && isFusionLightTheme());
     }
 
     private void tintFusionNativeTextTree(View view, boolean light) {
@@ -3474,6 +3479,7 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mTmdbFallbackToNative = true;
         mTmdbContentLoaded = true;
         hideTmdbHeader();
+        applyNativeFallbackWallpaperSurface();
         restoreFlagAndEpisodeFromTmdb();
         updateEpisodeGroupVisibility();
         restoreDefaultVideoLayout();
@@ -3485,6 +3491,15 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
         mBinding.progressLayout.showContent();
         loadNativePersonalRecommendations(item);
         hideProgress();
+    }
+
+    private void applyNativeFallbackWallpaperSurface() {
+        mBinding.getRoot().setBackgroundColor(Color.TRANSPARENT);
+        mBinding.scroll.setBackgroundColor(Color.TRANSPARENT);
+        mBinding.swipeLayout.setBackgroundColor(Color.TRANSPARENT);
+        mBinding.progressLayout.setBackgroundColor(Color.TRANSPARENT);
+        if (mBinding.nativeContentContainer != null) mBinding.nativeContentContainer.setBackgroundColor(Color.TRANSPARENT);
+        applyContextWallScrimTheme();
     }
 
     private void loadNativePersonalRecommendations(Vod item) {
@@ -3807,7 +3822,9 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
     }
 
     private void moveFusionPlayerActionsToTmdb(ViewGroup playbackControls) {
-        if (!Setting.isFusionDetailPage()) return;
+        if (!Setting.isFusionDetailPage()) {
+            return;
+        }
         View actions = mBinding.control.action.getRoot();
         rememberTmdbMovedView(actions);
         if (actions.getParent() instanceof ViewGroup parent) parent.removeView(actions);

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -105,6 +105,27 @@ public class TmdbDetailActivityLayoutTest {
     }
 
     @Test
+    public void unmatchedTmdbDetailUsesAppWallpaperBackdrop() throws Exception {
+        Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int bind = source.indexOf("private void bindBackdrop()");
+        int surface = source.indexOf("private void applyBackdropSurface(ThemeColors colors)");
+        int wallpaper = source.indexOf("private boolean useAppWallpaperBackdrop()");
+
+        assertTrue(sourcePath + " is missing bindBackdrop", bind >= 0);
+        assertTrue(sourcePath + " is missing applyBackdropSurface", surface >= 0);
+        assertTrue(sourcePath + " is missing useAppWallpaperBackdrop", wallpaper >= 0);
+        assertTrue("unmatched TMDB detail must not use the source poster as the large backdrop fallback",
+                source.indexOf("bindBackdropImage(vod.getName(), wallpaperBackdrop ? \"\" : tmdbBackdropUrl(), wallpaperBackdrop ? \"\" : vod.getPic());", bind) > bind);
+        assertTrue("unmatched TMDB detail must keep the hero layer visible so the wallpaper can be shaded",
+                source.indexOf("TextUtils.isEmpty(image) && !useAppWallpaperBackdrop() ? View.GONE : View.VISIBLE") > bind);
+        assertTrue("unmatched TMDB detail must make the detail background transparent over the app wallpaper",
+                source.indexOf("useAppWallpaperBackdrop() ? Color.TRANSPARENT : backdropFallbackBackground(colors)", surface) > surface);
+        assertTrue("wallpaper fallback must only apply after source detail has loaded and no TMDB detail matched",
+                source.indexOf("return vod != null && matchedTmdbDetail == null;", wallpaper) > wallpaper);
+    }
+
+    @Test
     public void detailLoadsPersonalAiCacheBeforeSlowMediaBlocksFinish() throws Exception {
         Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
@@ -444,6 +444,30 @@ public class VideoActivityLayoutTest {
     }
 
     @Test
+    public void mobileTmdbFallbackUsesAppWallpaperSurface() throws Exception {
+        Path sourcePath = findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int fallback = source.indexOf("private void showNativeDetailFallback(Vod item)");
+        int surface = source.indexOf("private void applyNativeFallbackWallpaperSurface()");
+        int theme = source.indexOf("private void applyFusionThemeSurface()");
+        int scrim = source.indexOf("private void applyContextWallScrimTheme()");
+
+        assertTrue(sourcePath + " is missing showNativeDetailFallback", fallback >= 0);
+        assertTrue(sourcePath + " is missing applyNativeFallbackWallpaperSurface", surface >= 0);
+        assertTrue("unmatched TMDB fallback must switch to the app wallpaper surface before native rows draw",
+                source.indexOf("applyNativeFallbackWallpaperSurface();", fallback) > fallback);
+        assertTrue("unmatched TMDB fallback must clear the opaque root background",
+                source.indexOf("mBinding.getRoot().setBackgroundColor(Color.TRANSPARENT);", surface) > surface);
+        assertTrue("unmatched TMDB fallback must clear the old TMDB scroll background",
+                source.indexOf("mBinding.scroll.setBackgroundColor(Color.TRANSPARENT);", surface) > surface);
+        assertTrue("unmatched TMDB fallback must keep a readable dark scrim over the app wallpaper",
+                source.indexOf("mBinding.videoContextScrim.setBackgroundResource(R.drawable.shape_video_context_scrim);", scrim) > scrim
+                        && source.indexOf("mBinding.videoContextScrim.setVisibility(View.VISIBLE);", scrim) > scrim);
+        assertTrue("fusion theme refresh must not cover unmatched fallback with a solid color",
+                source.indexOf("mBinding.getRoot().setBackgroundColor(mTmdbFallbackToNative ? Color.TRANSPARENT", theme) > theme);
+    }
+
+    @Test
     public void leanbackTmdbRecommendationPresenterReportsAlreadyFocusedAiCards() throws Exception {
         Path sourcePath = findLeanbackJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "presenter", "TmdbRecommendationPresenter.java"));
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);


### PR DESCRIPTION
- 在TMDB详情页面中添加应用壁纸作为背景的回退方案
- 当TMDB详情匹配失败时自动切换到应用壁纸背景
- 重构主题颜色应用逻辑，统一背景处理方法
- 添加透明背景支持以适配壁纸显示效果

fix(ui): 修复移动设备上TMDB回退时的背景显示问题

- 解决TMDB详情回退到原生界面时的背景不透明问题
- 优化融合主题下的背景颜色设置逻辑
- 添加上下文遮罩层的透明度处理
- 改进文本颜色主题的应用条件判断