### PR TITLE
feat(adapter): 优化TMDB剧集适配器的原生增强模式显示

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapter.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapter.java
@@ -158,8 +158,9 @@ public class TmdbEpisodeAdapter extends RecyclerView.Adapter<TmdbEpisodeAdapter.
 
         applyCardSize(holder, compact);
         if (isNativeEnhanced()) {
-            holder.binding.index.setText(title);
-            holder.binding.index.setTextSize(isPhoneWidth(holder.itemView) ? 12f : 18f);
+            boolean phoneWidth = isPhoneWidth(holder.itemView);
+            holder.binding.index.setText(nativeEnhancedIndexTitle(title, cleanTitle, phoneWidth, mode));
+            holder.binding.index.setTextSize(nativeEnhancedIndexTextSize(phoneWidth, mode));
             holder.binding.fileSize.setVisibility(View.GONE);
             holder.binding.title.setVisibility(View.GONE);
             holder.binding.date.setText(nativeEnhancedMeta(tmdbEpisode));
@@ -329,6 +330,14 @@ public class TmdbEpisodeAdapter extends RecyclerView.Adapter<TmdbEpisodeAdapter.
 
     private boolean isNativeEnhanced() {
         return nativeEnhanced;
+    }
+
+    static String nativeEnhancedIndexTitle(String title, String cleanTitle, boolean phoneWidth, Mode mode) {
+        return phoneWidth && mode == Mode.GRID ? cleanTitle : title;
+    }
+
+    static float nativeEnhancedIndexTextSize(boolean phoneWidth, Mode mode) {
+        return phoneWidth && mode == Mode.GRID ? 14f : phoneWidth ? 12f : 18f;
     }
 
     public static String getTitle(Episode episode, int number, String tmdbTitle) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/holder/EpisodeGridHolder.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/holder/EpisodeGridHolder.java
@@ -115,7 +115,7 @@ public class EpisodeGridHolder extends BaseEpisodeHolder {
     }
 
     private void setMarquee(boolean focused) {
-        binding.text.setEllipsize(focused ? TextUtils.TruncateAt.MARQUEE : TextUtils.TruncateAt.START);
+        binding.text.setEllipsize(focused ? TextUtils.TruncateAt.MARQUEE : TextUtils.TruncateAt.END);
         binding.text.setSelected(focused);
     }
 

--- a/app/src/test/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapterTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapterTest.java
@@ -1,0 +1,14 @@
+package com.fongmi.android.tv.ui.adapter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TmdbEpisodeAdapterTest {
+
+    @Test
+    public void nativeEnhancedPhoneGridUsesReadableCleanTitle() {
+        assertEquals("2. 觉醒", TmdbEpisodeAdapter.nativeEnhancedIndexTitle("完美世界_02 2. 觉醒", "2. 觉醒", true, TmdbEpisodeAdapter.Mode.GRID));
+        assertEquals(14f, TmdbEpisodeAdapter.nativeEnhancedIndexTextSize(true, TmdbEpisodeAdapter.Mode.GRID), 0f);
+    }
+}


### PR DESCRIPTION
- 在原生增强模式下，根据设备宽度和网格模式动态调整剧集标题显示
- 为手机宽度的网格视图使用简洁标题并调整字体大小至14f
- 添加测试用例验证原生增强模式下的标题显示逻辑

fix(holder): 修正移动端剧集网格项的文本截断行为

- 将非焦点状态下的文本截断位置从START改为END
- 确保文本内容正确显示而非被截断开头部分