### PR TITLE
fix(mobile): 播放页启用 CustomWallView 底层壁纸

### DIFF
--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -317,6 +317,11 @@ public class VideoActivity extends PlaybackActivity implements Clock.Callback, C
 
     @Override
     protected boolean customWall() {
+        return true;
+    }
+
+    @Override
+    protected boolean customWallMotion() {
         return false;
     }
 


### PR DESCRIPTION
## 问题
播放界面简介区域背景在禁用剧照时显示主题灰色而非用户配置的壁纸。

## 根因
VideoActivity 是唯一将 `customWall()` 返回 false 的界面，导致没有 CustomWallView 壁纸底层。剧照禁用时 contextWall 隐藏后，半透明遮罩直接露出主题灰色 windowBackground。

## 改动
- `customWall()` 返回 true，让 CustomWallView 作为底层渲染所有类型的用户壁纸（纯色/设计/文件/GIF/视频）
- `customWallMotion()` 返回 false，关闭动态壁纸播放器，避免与播放器抢资源
- contextWall 剧照层浮于壁纸层之上，剧照逻辑不变

## 测试
- ✅ 禁用剧照时简介区域露出用户配置的壁纸
- ✅ 启用剧照时显示剧照（行为不变）