### PR TITLE
fix: 修复推送网页嗅探失败

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/api/SiteApi.java
+++ b/app/src/main/java/com/fongmi/android/tv/api/SiteApi.java
@@ -187,25 +187,47 @@ public class SiteApi {
         String requestId = PUSH.equals(key) ? resolvePushPlayerUrl(id) : id;
         if (PUSH.equals(key) && (site.isEmpty() || isLocalFileUrl(requestId))) return pushPlayer(flag, requestId, playerType);
         if (site.getType() == 3) {
-            String playerContent = site.recent().spider().playerContent(flag, requestId, VodConfig.get().getFlags());
-            SpiderDebug.log("player", playerContent);
-            Result result = Result.fromJson(playerContent);
-            if (result.getFlag().isEmpty()) result.setFlag(flag);
-            result.setUrl(Source.get().fetch(result, playerType));
-            result.setHeader(site.getHeader());
-            result.setKey(key);
-            return result;
+            String fallbackReason;
+            try {
+                String playerContent = site.recent().spider().playerContent(flag, requestId, VodConfig.get().getFlags());
+                SpiderDebug.log("player", playerContent);
+                Result result = Result.fromJson(playerContent);
+                if (shouldFallbackPushSiteResult(key, result)) {
+                    fallbackReason = result == null ? "" : result.getMsg();
+                } else {
+                    if (result.getFlag().isEmpty()) result.setFlag(flag);
+                    result.setUrl(Source.get().fetch(result, playerType));
+                    result.setHeader(site.getHeader());
+                    result.setKey(key);
+                    return result;
+                }
+            } catch (Exception e) {
+                if (PUSH.equals(key)) fallbackReason = e.getMessage();
+                else throw e;
+            }
+            return fallbackPushPlayer(flag, requestId, playerType, fallbackReason);
         } else if (site.getType() == 4) {
-            ArrayMap<String, String> params = new ArrayMap<>();
-            params.put("play", requestId);
-            params.put("flag", flag);
-            String playerContent = call(site, params);
-            SpiderDebug.log("player", playerContent);
-            Result result = Result.fromJson(playerContent);
-            if (result.getFlag().isEmpty()) result.setFlag(flag);
-            result.setUrl(Source.get().fetch(result, playerType));
-            result.setHeader(site.getHeader());
-            return result;
+            String fallbackReason;
+            try {
+                ArrayMap<String, String> params = new ArrayMap<>();
+                params.put("play", requestId);
+                params.put("flag", flag);
+                String playerContent = call(site, params);
+                SpiderDebug.log("player", playerContent);
+                Result result = Result.fromJson(playerContent);
+                if (shouldFallbackPushSiteResult(key, result)) {
+                    fallbackReason = result == null ? "" : result.getMsg();
+                } else {
+                    if (result.getFlag().isEmpty()) result.setFlag(flag);
+                    result.setUrl(Source.get().fetch(result, playerType));
+                    result.setHeader(site.getHeader());
+                    return result;
+                }
+            } catch (Exception e) {
+                if (PUSH.equals(key)) fallbackReason = e.getMessage();
+                else throw e;
+            }
+            return fallbackPushPlayer(flag, requestId, playerType, fallbackReason);
         } else {
             Result result = new Result();
             result.setUrl(requestId);
@@ -227,10 +249,30 @@ public class SiteApi {
         return url.regionMatches(true, 0, "file:", 0, 5);
     }
 
+    static boolean shouldSniffPushUrl(String url) {
+        if (!shouldSniffPushUrl(url, false)) return false;
+        return !Sniffer.isVideoFormat(url);
+    }
+
+    static boolean shouldSniffPushUrl(String url, boolean videoFormat) {
+        if (url == null || url.isEmpty() || isLocalFileUrl(url)) return false;
+        boolean webUrl = url.regionMatches(true, 0, "http://", 0, 7) || url.regionMatches(true, 0, "https://", 0, 8);
+        return webUrl && !videoFormat;
+    }
+
+    static boolean shouldFallbackPushSiteResult(String key, Result result) {
+        return PUSH.equals(key) && (result == null || result.hasMsg() || result.getUrl().isEmpty());
+    }
+
+    private static Result fallbackPushPlayer(String flag, String url, int playerType, String reason) throws Exception {
+        SpiderDebug.log("player", "push site fallback reason=%s", TextUtils.isEmpty(reason) ? "empty result" : reason);
+        return pushPlayer(flag, url, playerType);
+    }
+
     private static Result pushPlayer(String flag, String url, int playerType) throws Exception {
         Result result = new Result();
         result.setUrl(url);
-        result.setParse(0);
+        result.setParse(shouldSniffPushUrl(url) ? 1 : 0);
         result.setFlag(flag);
         result.setUrl(Source.get().fetch(result, playerType));
         SpiderDebug.log("player", result.toString());

--- a/app/src/main/java/com/fongmi/android/tv/web/HomeWebController.java
+++ b/app/src/main/java/com/fongmi/android/tv/web/HomeWebController.java
@@ -1183,7 +1183,6 @@ public class HomeWebController {
             inlineEvaluationCount = 0;
         }
         webView.onResume();
-        webView.resumeTimers();
         recoverAfterResume();
         consumeExtensionReload();
     }
@@ -1200,7 +1199,6 @@ public class HomeWebController {
         dispatchLifecycle("fmpause", "{time:" + pauseAt + "}");
         pausePageMedia();
         webView.onPause();
-        webView.pauseTimers();
     }
 
     public boolean beginInlineEvaluation() {
@@ -1213,7 +1211,6 @@ public class HomeWebController {
             if (!paused) return;
             SpiderDebug.log("webhome-inline", "resume WebView for inline evaluation url=%s", safeLogUrl(webView.getUrl()));
             webView.onResume();
-            webView.resumeTimers();
         });
         return true;
     }
@@ -1231,7 +1228,6 @@ public class HomeWebController {
             SpiderDebug.log("webhome-inline", "pause WebView after inline evaluation url=%s", safeLogUrl(webView.getUrl()));
             pausePageMedia();
             webView.onPause();
-            webView.pauseTimers();
         });
     }
 

--- a/app/src/test/java/com/fongmi/android/tv/api/SiteApiTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/api/SiteApiTest.java
@@ -1,5 +1,7 @@
 package com.fongmi.android.tv.api;
 
+import com.fongmi.android.tv.bean.Result;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -38,5 +40,50 @@ public class SiteApiTest {
     @Test
     public void isLocalFileUrlRejectsRemoteUrl() {
         assertFalse(SiteApi.isLocalFileUrl("https://cdn.test/movie.mp4"));
+    }
+
+    @Test
+    public void pushedWebPageRequiresSniffing() {
+        assertTrue(SiteApi.shouldSniffPushUrl("https://shdy2.com/play/50292-1-1.html", false));
+    }
+
+    @Test
+    public void pushedRemoteMediaStaysDirect() {
+        assertFalse(SiteApi.shouldSniffPushUrl("https://cdn.test/video/movie.m3u8?token=demo", true));
+    }
+
+    @Test
+    public void pushedLocalFileStaysDirect() {
+        assertFalse(SiteApi.shouldSniffPushUrl("file:///storage/emulated/0/Download/movie.mp4", false));
+    }
+
+    @Test
+    public void pushedNonHttpMediaStaysDirect() {
+        assertFalse(SiteApi.shouldSniffPushUrl("rtmp://stream.test/live/channel", false));
+    }
+
+    @Test
+    public void failedConfiguredPushFallsBackToBuiltInHandling() {
+        Result result = new Result();
+        result.setUrl("https://shdy2.com/play/50292-1-1.html");
+        result.setMsg("Request failed with status code 403");
+
+        assertTrue(SiteApi.shouldFallbackPushSiteResult(SiteApi.PUSH, result));
+    }
+
+    @Test
+    public void successfulConfiguredPushKeepsConfiguredResult() {
+        Result result = new Result();
+        result.setUrl("https://cdn.test/video/movie.m3u8");
+
+        assertFalse(SiteApi.shouldFallbackPushSiteResult(SiteApi.PUSH, result));
+    }
+
+    @Test
+    public void regularSiteErrorsNeverUsePushFallback() {
+        Result result = new Result();
+        result.setMsg("upstream error");
+
+        assertFalse(SiteApi.shouldFallbackPushSiteResult("regular_site", result));
     }
 }

--- a/app/src/test/java/com/fongmi/android/tv/web/WebThemeDetailWiringTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/web/WebThemeDetailWiringTest.java
@@ -148,7 +148,17 @@ public class WebThemeDetailWiringTest {
 
         assertTrue(remote.contains("!destroyed && !paused && bridgeReady"));
         assertTrue(v2.contains("!destroyed && !paused && bridgeReady"));
-        assertTrue(pause.contains("webView.pauseTimers();"));
+        assertTrue(pause.contains("webView.onPause();"));
+    }
+
+    @Test
+    public void pausingHomeWebViewDoesNotFreezeOtherWebViews() throws Exception {
+        String controller = read("src/main/java/com/fongmi/android/tv/web/HomeWebController.java");
+
+        assertTrue(controller.contains("webView.onPause();"));
+        assertTrue(controller.contains("webView.onResume();"));
+        assertFalse(controller.contains("webView.pauseTimers();"));
+        assertFalse(controller.contains("webView.resumeTimers();"));
     }
 
     @Test


### PR DESCRIPTION
推送解析接口异常或返回空结果时回退到内置处理。

移除会冻结进程内全部 WebView 的全局计时器暂停调用，并补充推送分流与生命周期回归测试。