### PR TITLE
fix: 修复自定义壁纸渐变色带光晕

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/CustomWallView.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/CustomWallView.java
@@ -244,8 +244,8 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
             if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null;
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inSampleSize = getWallSampleSize(bounds);
-            options.inPreferredConfig = Bitmap.Config.RGB_565;
-            options.inDither = true;
+            // Blurred wallpapers are gradient-heavy; RGB_565 quantization creates visible bands and halos.
+            options.inPreferredConfig = Bitmap.Config.ARGB_8888;
             return BitmapFactory.decodeFile(file.getAbsolutePath(), options);
         } catch (OutOfMemoryError | RuntimeException e) {
             SpiderDebug.log("startup", "wall bitmap decode fallback file=%s error=%s", file.getName(), e.getClass().getSimpleName());

--- a/app/src/test/java/com/fongmi/android/tv/ui/custom/CustomWallViewSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/custom/CustomWallViewSourceTest.java
@@ -1,0 +1,29 @@
+package com.fongmi.android.tv.ui.custom;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CustomWallViewSourceTest {
+
+    @Test
+    public void customWallpaperDecodePreservesSmoothGradients() throws Exception {
+        String source = readMainSource("ui/custom/CustomWallView.java");
+
+        assertTrue("custom wallpapers must use 32-bit color to avoid visible RGB_565 banding",
+                source.contains("options.inPreferredConfig = Bitmap.Config.ARGB_8888;"));
+        assertFalse("custom wallpaper decoding must not quantize smooth gradients to RGB_565",
+                source.contains("options.inPreferredConfig = Bitmap.Config.RGB_565;"));
+    }
+
+    private static String readMainSource(String file) throws Exception {
+        Path app = Files.exists(Path.of("src", "main")) ? Path.of(".") : Path.of("app");
+        Path path = app.resolve(Path.of("src", "main", "java", "com", "fongmi", "android", "tv", file));
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
将自定义壁纸解码格式由 RGB_565 调整为 ARGB_8888，避免平滑渐变出现量化色阶，并增加回归测试。