### PR TITLE
fix: 修复安卓重置应用无响应

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingPersonalActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/SettingPersonalActivity.java
@@ -25,7 +25,6 @@ import com.fongmi.android.tv.ui.dialog.SpeedSettingDialog;
 import com.fongmi.android.tv.ui.dialog.SliderNumberDialog;
 import com.fongmi.android.tv.utils.Notify;
 import com.fongmi.android.tv.utils.PermissionUtil;
-import com.fongmi.android.tv.utils.Task;
 import com.fongmi.android.tv.utils.Util;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -85,7 +84,7 @@ public class SettingPersonalActivity extends BaseActivity {
         mBinding.searchUi.setOnClickListener(this::setSearchUi);
         mBinding.searchResultSort.setOnClickListener(this::setSearchResultSort);
         // mBinding.searchColumn.setOnClickListener(this::setSearchColumn); // 在搜索页面切换更方便
-        mBinding.resetApp.setOnClickListener(this::resetApp);
+        mBinding.resetApp.setOnClickListener(this::showResetAppDialog);
     }
 
     @Override
@@ -269,13 +268,17 @@ public class SettingPersonalActivity extends BaseActivity {
         setText();
     }
 
-    private void resetApp(View view) {
+    private void showResetAppDialog(View view) {
         new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.dialog_reset_app)
                 .setMessage(R.string.dialog_reset_app_data)
                 .setNegativeButton(R.string.dialog_negative, null)
-                .setPositiveButton(R.string.dialog_positive, (dialog, which) -> Task.execute(() -> Util.resetApp()))
+                .setPositiveButton(R.string.dialog_positive, (dialog, which) -> resetApp())
                 .show();
+    }
+
+    private void resetApp() {
+        if (!Util.resetApp()) Notify.show(R.string.reset_app_failed);
     }
 
     // 在搜索页面切换更方便，此处不再提供设置入口

--- a/app/src/main/java/com/fongmi/android/tv/utils/Util.java
+++ b/app/src/main/java/com/fongmi/android/tv/utils/Util.java
@@ -1,6 +1,7 @@
 package com.fongmi.android.tv.utils;
 
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -52,8 +53,14 @@ public class Util {
         }
     }
 
-    public static void resetApp() {
-        Shell.exec("pm clear " + App.get().getPackageName());
+    public static boolean resetApp() {
+        try {
+            ActivityManager manager = App.get().getSystemService(ActivityManager.class);
+            return manager != null && manager.clearApplicationUserData();
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
     public static void hideSystemUI(Activity activity) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1365,6 +1365,7 @@
     <string name="setting_reset_app">重置APP</string>
     <string name="dialog_reset_app">重置App?</string>
     <string name="dialog_reset_app_data">所有数据将会被重置，App即将被关闭.</string>
+    <string name="reset_app_failed">重置失败，请重试。</string>
 
     <string name="dialog_audio_site_rules">音频源规则:关联站源或关键词,用 ; 分隔。默认:[音];[听]</string>
     <string name="dialog_audio_site_manage">选择音频源</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1325,6 +1325,7 @@
     <string name="setting_reset_app">重置APP</string>
     <string name="dialog_reset_app">重置App?</string>
     <string name="dialog_reset_app_data">所有數據將會被重置，App即將被關閉.</string>
+    <string name="reset_app_failed">重置失敗，請重試。</string>
 
     <string name="dialog_audio_site_rules">音訊源規則:關聯站源或關鍵詞,用 ; 分隔。預設:[音];[听]</string>
     <string name="dialog_audio_site_manage">選擇音訊源</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1369,6 +1369,7 @@
     <string name="setting_reset_app">Reset app</string>
     <string name="dialog_reset_app">Reset app?</string>
     <string name="dialog_reset_app_data">All app data will be reset, and app will be shutdown.</string>
+    <string name="reset_app_failed">Unable to reset app data. Please try again.</string>
 
     <string name="dialog_audio_site_rules">Audio source rules: enabled sources or keywords, separated by ;. Default: [音];[听]</string>
     <string name="dialog_audio_site_manage">Select audio sources</string>

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/SettingPersonalFragment.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/SettingPersonalFragment.java
@@ -23,7 +23,6 @@ import com.fongmi.android.tv.ui.dialog.SpeedSettingDialog;
 import com.fongmi.android.tv.ui.dialog.SliderNumberDialog;
 import com.fongmi.android.tv.utils.Notify;
 import com.fongmi.android.tv.utils.PermissionUtil;
-import com.fongmi.android.tv.utils.Task;
 import com.fongmi.android.tv.utils.Util;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -75,7 +74,7 @@ public class SettingPersonalFragment extends BaseFragment {
         mBinding.searchColumn.setOnClickListener(this::setSearchColumn);
         mBinding.siteColumn.setOnClickListener(this::setSiteColumn);
         mBinding.searchResultSort.setOnClickListener(this::setSearchResultSort);
-        mBinding.resetApp.setOnClickListener(this::resetApp);
+        mBinding.resetApp.setOnClickListener(this::showResetAppDialog);
     }
 
     private void setText() {
@@ -227,13 +226,17 @@ public class SettingPersonalFragment extends BaseFragment {
         setText();
     }
 
-    private void resetApp(View view) {
+    private void showResetAppDialog(View view) {
         new MaterialAlertDialogBuilder(requireActivity())
                 .setTitle(R.string.dialog_reset_app)
                 .setMessage(R.string.dialog_reset_app_data)
                 .setNegativeButton(R.string.dialog_negative, null)
-                .setPositiveButton(R.string.dialog_positive, (dialog, which) -> Task.execute(() -> Util.resetApp()))
+                .setPositiveButton(R.string.dialog_positive, (dialog, which) -> resetApp())
                 .show();
+    }
+
+    private void resetApp() {
+        if (!Util.resetApp()) Notify.show(R.string.reset_app_failed);
     }
 
     @Override

--- a/app/src/test/java/com/fongmi/android/tv/setting/SettingPlaybackDefaultsTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/setting/SettingPlaybackDefaultsTest.java
@@ -73,18 +73,23 @@ public class SettingPlaybackDefaultsTest {
         assertTrue(leanbackLayout.contains("@+id/resetApp"));
         assertTrue(mobileLayout.contains("@string/setting_reset_app"));
         assertTrue(leanbackLayout.contains("@string/setting_reset_app"));
-        assertTrue(mobileSource.contains("mBinding.resetApp.setOnClickListener(this::resetApp)"));
-        assertTrue(leanbackSource.contains("mBinding.resetApp.setOnClickListener(this::resetApp)"));
-        String confirmedReset = ".setPositiveButton(R.string.dialog_positive, (dialog, which) -> Task.execute(() -> Util.resetApp()))";
+        assertTrue(mobileSource.contains("mBinding.resetApp.setOnClickListener(this::showResetAppDialog)"));
+        assertTrue(leanbackSource.contains("mBinding.resetApp.setOnClickListener(this::showResetAppDialog)"));
+        String confirmedReset = ".setPositiveButton(R.string.dialog_positive, (dialog, which) -> resetApp())";
         assertTrue(mobileSource.contains(confirmedReset));
         assertTrue(leanbackSource.contains(confirmedReset));
-        assertTrue(utilSource.contains("Shell.exec(\"pm clear \" + App.get().getPackageName())"));
-
+        assertTrue(mobileSource.contains("if (!Util.resetApp()) Notify.show(R.string.reset_app_failed)"));
+        assertTrue(leanbackSource.contains("if (!Util.resetApp()) Notify.show(R.string.reset_app_failed)"));
+        assertTrue(utilSource.contains("ActivityManager manager = App.get().getSystemService(ActivityManager.class)"));
+        assertTrue(utilSource.contains("manager.clearApplicationUserData()"));
+        assertTrue(utilSource.contains("catch (RuntimeException e)"));
+        assertFalse(utilSource.contains("pm clear"));
         for (String values : new String[]{"values", "values-zh-rCN", "values-zh-rTW"}) {
             String strings = read(root.resolve(Path.of("src", "main", "res", values, "strings.xml")));
             assertTrue(strings.contains("<string name=\"setting_reset_app\">"));
             assertTrue(strings.contains("<string name=\"dialog_reset_app\">"));
             assertTrue(strings.contains("<string name=\"dialog_reset_app_data\">"));
+            assertTrue(strings.contains("<string name=\"reset_app_failed\">"));
         }
     }
 


### PR DESCRIPTION
改用 ActivityManager 清除应用数据，补充失败提示与移动端、电视端回归测试。