### PR TITLE
修复媒体会话通知无法驻留

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/service/PlaybackService.java
+++ b/app/src/main/java/com/fongmi/android/tv/service/PlaybackService.java
@@ -153,6 +153,8 @@ private AudioHistory.Record audioHistoryRecord;
         EventBus.getDefault().register(this);
         Server.get().setService(this);
         setupNotification();
+        // Direct SessionToken controllers bypass MediaSessionService binding, so register the session for media notifications.
+        addSession(session);
         if (SpiderDebug.isEnabled()) SpiderDebug.log("playback-flow", "service onCreate end cost=%dms", System.currentTimeMillis() - start);
     }
 

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
@@ -1392,6 +1392,19 @@ public class VideoActivityLayoutTest {
     }
 
     @Test
+    public void playbackServiceRegistersDirectSessionForMediaNotificationLifecycle() throws Exception {
+        Path servicePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "service", "PlaybackService.java"));
+        String service = new String(Files.readAllBytes(servicePath), StandardCharsets.UTF_8);
+        String onCreate = methodBody(service, "public void onCreate()", "private PendingIntent buildDefaultIntent()");
+        int setupNotification = onCreate.indexOf("setupNotification();");
+        int addSession = onCreate.indexOf("addSession(session);");
+
+        assertTrue("the media notification provider must be configured before session registration", setupNotification >= 0);
+        assertTrue("direct SessionToken controllers bypass MediaSessionService binding, so the session must be registered explicitly",
+                addSession > setupNotification);
+    }
+
+    @Test
     public void playbackControllerConnectionDoesNotReplayStaleState() throws Exception {
         Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "PlaybackActivity.java"));
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);


### PR DESCRIPTION
直接 SessionToken 控制器绕过服务绑定时显式注册 MediaSession，恢复后台媒体通知和前台播放服务，并增加回归测试。