### PR TITLE
修复搜索线程池耗尽导致无结果

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/model/SiteViewModel.java
+++ b/app/src/main/java/com/fongmi/android/tv/model/SiteViewModel.java
@@ -49,6 +49,8 @@ public class SiteViewModel extends ViewModel {
     private final List<Future<?>> searchFuture;
     private final ListeningExecutorService playerExecutor;
     private final AtomicInteger searchEpoch;
+    private final Object searchLock;
+    private ListeningExecutorService searchExecutor;
     private KaraokeResult karaokeResult;
     private int karaokeResultAction;
 
@@ -60,6 +62,7 @@ public class SiteViewModel extends ViewModel {
         action = new MutableLiveData<>();
         searchEpoch = new AtomicInteger(0);
         searchFuture = new CopyOnWriteArrayList<>();
+        searchLock = new Object();
         // Player spiders can share a loopback proxy and may ignore interruption.
         // Keep resolutions serial so a canceled source fully exits before the next starts.
         playerExecutor = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
@@ -147,35 +150,40 @@ public class SiteViewModel extends ViewModel {
     }
 
     public void searchContent(List<Site> sites, String keyword, boolean quick) {
-        int epoch = stopSearch();
-        Task.applySearchThread(Setting.getSearchThread());
-        List<Site> tasks = new ArrayList<>();
-        for (Site site : sites) {
-            if (quick && !site.isQuickSearch()) continue;
-            tasks.add(site);
-        }
-        int total = tasks.size();
-        AtomicInteger completed = new AtomicInteger();
-        searchProgress.postValue(SearchProgress.start(total));
-        for (Site site : tasks) {
-            long start = System.currentTimeMillis();
-            FluentFuture<Result> future = FluentFuture.from(Task.searchPoolExecutor().submit(SearchTask.create(site, keyword, quick))).withTimeout(Constant.TIMEOUT_SEARCH, TimeUnit.MILLISECONDS, Task.scheduler());
-            searchFuture.add(future);
-            future.addCallback(Task.callback(
-                    result -> {
-                        if (searchEpoch.get() != epoch) return;
-                        SiteHealthStore.recordSearch(site, true, result.getList().size(), System.currentTimeMillis() - start, "");
-                        postSearchResult(epoch, result);
-                        postSearchProgress(epoch, completed, total);
-                    },
-                    error -> {
-                        if (searchEpoch.get() != epoch) return;
-                        if (error instanceof CancellationException) return;
-                        SiteHealthStore.recordSearch(site, false, 0, System.currentTimeMillis() - start, error.getMessage());
-                        postSearchProgress(epoch, completed, total);
-                        error.printStackTrace();
-                    }
-            ), MoreExecutors.directExecutor());
+        synchronized (searchLock) {
+            int epoch = stopSearchLocked();
+            List<Site> tasks = new ArrayList<>();
+            for (Site site : sites) {
+                if (quick && !site.isQuickSearch()) continue;
+                tasks.add(site);
+            }
+            int total = tasks.size();
+            AtomicInteger completed = new AtomicInteger();
+            searchProgress.postValue(SearchProgress.start(total));
+            // A site spider may ignore interruption after its timeout. Isolate every
+            // generation so an uncooperative old worker cannot starve the next search;
+            // shutdownNow() remains best-effort because the JVM cannot forcibly stop it.
+            ListeningExecutorService executor = searchExecutor = Task.newSearchExecutor(Setting.getSearchThread());
+            for (Site site : tasks) {
+                long start = System.currentTimeMillis();
+                FluentFuture<Result> future = FluentFuture.from(executor.submit(SearchTask.create(site, keyword, quick))).withTimeout(Constant.TIMEOUT_SEARCH, TimeUnit.MILLISECONDS, Task.scheduler());
+                searchFuture.add(future);
+                future.addCallback(Task.callback(
+                        result -> {
+                            if (searchEpoch.get() != epoch) return;
+                            SiteHealthStore.recordSearch(site, true, result.getList().size(), System.currentTimeMillis() - start, "");
+                            postSearchResult(epoch, result);
+                            postSearchProgress(epoch, completed, total);
+                        },
+                        error -> {
+                            if (searchEpoch.get() != epoch) return;
+                            if (error instanceof CancellationException) return;
+                            SiteHealthStore.recordSearch(site, false, 0, System.currentTimeMillis() - start, error.getMessage());
+                            postSearchProgress(epoch, completed, total);
+                            error.printStackTrace();
+                        }
+                ), MoreExecutors.directExecutor());
+            }
         }
     }
 
@@ -220,9 +228,19 @@ public class SiteViewModel extends ViewModel {
     }
 
     public int stopSearch() {
+        synchronized (searchLock) {
+            return stopSearchLocked();
+        }
+    }
+
+    private int stopSearchLocked() {
         int epoch = searchEpoch.incrementAndGet();
         searchFuture.forEach(future -> future.cancel(true));
         searchFuture.clear();
+        if (searchExecutor != null) {
+            searchExecutor.shutdownNow();
+            searchExecutor = null;
+        }
         return epoch;
     }
 

--- a/app/src/main/java/com/fongmi/android/tv/utils/Task.java
+++ b/app/src/main/java/com/fongmi/android/tv/utils/Task.java
@@ -33,7 +33,11 @@ public class Task {
     private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     private static ThreadPoolExecutor createSearchPool() {
-        ThreadPoolExecutor pool = new ThreadPoolExecutor(20, 20, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+        return createSearchPool(20);
+    }
+
+    private static ThreadPoolExecutor createSearchPool(int threads) {
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(threads, threads, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
         pool.allowCoreThreadTimeOut(true);
         return pool;
     }
@@ -60,6 +64,10 @@ public class Task {
 
     public static ListeningExecutorService searchPoolExecutor() {
         return searchExecutor;
+    }
+
+    public static ListeningExecutorService newSearchExecutor(int threads) {
+        return MoreExecutors.listeningDecorator(createSearchPool(Math.max(1, threads)));
     }
 
     public static void applySearchThread(int threads) {

--- a/app/src/test/java/com/fongmi/android/tv/model/SearchExecutorRecoveryTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/model/SearchExecutorRecoveryTest.java
@@ -1,0 +1,62 @@
+package com.fongmi.android.tv.model;
+
+import com.fongmi.android.tv.utils.Task;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SearchExecutorRecoveryTest {
+
+    @Test
+    public void aNewSearchExecutorRunsAfterThePreviousGenerationIsStopped() throws Exception {
+        ListeningExecutorService previous = newSearchExecutor(1);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        previous.submit(() -> {
+            started.countDown();
+            while (release.getCount() > 0) {
+                try {
+                    release.await();
+                } catch (InterruptedException ignored) {
+                    // Simulate a third-party site spider that ignores cancellation.
+                }
+            }
+            return null;
+        });
+        assertTrue(started.await(1, TimeUnit.SECONDS));
+        ListeningExecutorService current = null;
+        try {
+            previous.shutdownNow();
+            current = newSearchExecutor(1);
+            assertEquals("current", current.submit(() -> "current").get(1, TimeUnit.SECONDS));
+        } finally {
+            release.countDown();
+            previous.shutdownNow();
+            if (current != null) current.shutdownNow();
+        }
+    }
+
+    @Test
+    public void siteSearchUsesAReplaceableExecutorInsteadOfTheGlobalPool() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/fongmi/android/tv/model/SiteViewModel.java"));
+
+        assertTrue(source.contains("searchExecutor = Task.newSearchExecutor(Setting.getSearchThread())"));
+        assertTrue(source.contains("FluentFuture.from(executor.submit(SearchTask.create(site, keyword, quick)))"));
+        assertTrue(source.contains("searchExecutor.shutdownNow()"));
+        assertTrue(source.contains("synchronized (searchLock)"));
+        assertFalse(source.contains("Task.searchPoolExecutor().submit(SearchTask.create(site, keyword, quick))"));
+    }
+
+    private static ListeningExecutorService newSearchExecutor(int threads) {
+        return Task.newSearchExecutor(threads);
+    }
+}


### PR DESCRIPTION
为每轮页面搜索创建独立执行器，避免超时且不响应中断的旧站源阻塞后续搜索。同步增加并发停止保护和 TV/手机版共用的恢复回归测试。