### PR TITLE
修复：部分 ROM 因 TrafficStats 不可用导致网速不显示

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/CastActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/CastActivity.java
@@ -323,7 +323,7 @@ public class CastActivity extends PlaybackActivity implements CustomKeyDownVod.L
     }
 
     private void setTraffic() {
-        Traffic.setSpeed(mBinding.progress.traffic);
+        Traffic.setSpeed(mBinding.progress.traffic, service() == null ? null : player());
         App.post(mR2, 1000);
     }
 

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
@@ -707,7 +707,7 @@ public class LiveActivity extends PlaybackActivity implements GroupAdapter.OnCli
     }
 
     private void setTraffic() {
-        Traffic.setSpeed(mBinding.progress.traffic);
+        Traffic.setSpeed(mBinding.progress.traffic, service() == null ? null : player());
         App.post(mR2, 1000);
     }
 

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -8685,7 +8685,7 @@ private boolean onChooseLong() {
     }
 
 private void setTraffic() {
-        Traffic.setSpeed(mBinding.progress.traffic);
+        Traffic.setSpeed(mBinding.progress.traffic, service() == null ? null : player());
         App.post(mR3, 1000);
     }
 

--- a/app/src/main/java/com/fongmi/android/tv/player/PlaybackSpeedMeter.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlaybackSpeedMeter.java
@@ -1,0 +1,198 @@
+package com.fongmi.android.tv.player;
+
+import android.net.TrafficStats;
+
+import androidx.annotation.Nullable;
+
+import com.fongmi.android.tv.App;
+import com.fongmi.android.tv.player.engine.PlayerEngine;
+import com.fongmi.android.tv.player.exo.PlaybackAnalyticsListener;
+import com.github.catvod.net.OkTrafficCounter;
+
+import java.text.DecimalFormat;
+import java.util.function.LongSupplier;
+
+/**
+ * Download speed for the playback readouts, counted in-process rather than read from
+ * the platform.
+ *
+ * <p>Per-UID {@link TrafficStats} needs kernel support (xt_qtaguid or the netd eBPF
+ * path) that some vendor ROMs — TV boxes and projectors in particular — never
+ * compiled in.  There every reader gets {@code UNSUPPORTED} or a value frozen at a
+ * constant, so a readout built on it alone shows nothing at all.
+ *
+ * <p>Three sources are tried in order, so something usable is available at every stage
+ * of playback:
+ * <ol>
+ *   <li>the active playback kernel's own throughput, the most accurate view of the
+ *       stream actually being played;
+ *   <li>{@link OkTrafficCounter}, which covers scraping and manifest fetches before a
+ *       kernel exists, plus the kernels whose transfers pass through Java;
+ *   <li>{@code TrafficStats}, which alone can still see traffic from native engine
+ *       sockets that never reach Java.
+ * </ol>
+ */
+public final class PlaybackSpeedMeter {
+
+    /** Which source produced the current sample. */
+    public enum Source {
+        KERNEL,
+        OK_HTTP,
+        TRAFFIC_STATS,
+        NONE
+    }
+
+    /** Sentinel for a byte counter the platform cannot supply. */
+    static final long UNSUPPORTED = -1;
+
+    private static final DecimalFormat SPEED_FORMAT = new DecimalFormat("#.0");
+    private static final String UNIT_KB = " KB/s";
+    private static final String UNIT_MB = " MB/s";
+
+    private final LongSupplier byteCounter;
+    private final LongSupplier okHttpCounter;
+    private final LongSupplier clock;
+
+    private long lastRxBytes = UNSUPPORTED;
+    private long lastOkHttpBytes = UNSUPPORTED;
+    private long lastTimeStamp;
+    private long bytesPerSecond;
+    private Source source = Source.NONE;
+
+    public PlaybackSpeedMeter() {
+        this(PlaybackSpeedMeter::readUidRxBytes, OkTrafficCounter::totalBytes, System::currentTimeMillis);
+    }
+
+    PlaybackSpeedMeter(LongSupplier byteCounter, LongSupplier okHttpCounter, LongSupplier clock) {
+        this.byteCounter = byteCounter;
+        this.okHttpCounter = okHttpCounter;
+        this.clock = clock;
+    }
+
+    /**
+     * Samples the current download speed. Call at a steady interval — the
+     * {@code TrafficStats} fallback derives speed from the delta between calls.
+     */
+    public void sample(@Nullable PlayerManager player) {
+        if (player != null && PlaybackDiagnosticsSourcePolicy.isLocal(player.getUrl())) {
+            reset();
+            return;
+        }
+        observe(kernelBitsPerSecond(player));
+    }
+
+    /** Applies one sample given the kernel's reported bitrate, 0 when it has none. */
+    void observe(long kernelBitsPerSecond) {
+        long now = clock.getAsLong();
+        long elapsedMs = lastTimeStamp <= 0 || now <= lastTimeStamp ? 0 : now - lastTimeStamp;
+        // Advance every baseline on each sample, whichever source ends up winning, so a
+        // later handover measures one interval instead of everything since startup.
+        long okHttpDelta = advanceOkHttpBaseline();
+        long trafficDelta = advanceTrafficStatsBaseline();
+        lastTimeStamp = now;
+
+        if (kernelBitsPerSecond > 0) {
+            bytesPerSecond = kernelBitsPerSecond / 8L;
+            source = Source.KERNEL;
+            return;
+        }
+        if (elapsedMs <= 0) {
+            // No measurable interval yet; keep the previous readout rather than show 0.
+            return;
+        }
+        // Each counter undercounts what the other sees: OkHttp misses native engine
+        // sockets, TrafficStats misses nothing but may be unsupported or frozen. The
+        // larger delta is the better lower bound on what actually arrived.
+        if (okHttpDelta < 0 && trafficDelta < 0) {
+            bytesPerSecond = 0;
+            source = Source.NONE;
+            return;
+        }
+        source = trafficDelta > okHttpDelta ? Source.TRAFFIC_STATS : Source.OK_HTTP;
+        bytesPerSecond = Math.max(okHttpDelta, trafficDelta) * 1000L / elapsedMs;
+    }
+
+    public long getBytesPerSecond() {
+        return bytesPerSecond;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    /** True when neither the kernel nor the system counter produced a usable sample. */
+    public boolean isUnavailable() {
+        return source == Source.NONE;
+    }
+
+    public String getText() {
+        return source == Source.NONE ? "" : format(bytesPerSecond);
+    }
+
+    /** Clears the readout and re-bases the counters to now. */
+    public void reset() {
+        bytesPerSecond = 0;
+        source = Source.NONE;
+        markBaselines();
+    }
+
+    /** Formats bytes per second the way the playback readouts have always shown it. */
+    public static String format(long bytesPerSecond) {
+        long kbps = Math.max(0, bytesPerSecond / 1024);
+        return kbps < 1000 ? kbps + UNIT_KB : SPEED_FORMAT.format(kbps / 1024f) + UNIT_MB;
+    }
+
+    private long kernelBitsPerSecond(@Nullable PlayerManager player) {
+        if (player == null) return 0;
+        try {
+            return player.isExo()
+                    ? PlaybackAnalyticsListener.getSnapshot().bandwidthEstimate()
+                    : nativeBitsPerSecond(player);
+        } catch (Throwable error) {
+            // A kernel that cannot answer is expected; fall through to TrafficStats.
+            return 0;
+        }
+    }
+
+    private static long nativeBitsPerSecond(PlayerManager player) {
+        PlayerEngine.RuntimeMetrics metrics = player.getRuntimeMetrics();
+        if (metrics == null) return 0;
+        Long bits = metrics.bandwidthBitsPerSecond();
+        return bits == null ? 0 : bits;
+    }
+
+    /**
+     * Returns bytes read through OkHttp since the last sample, or {@link #UNSUPPORTED}
+     * when no baseline was established yet.
+     */
+    private long advanceOkHttpBaseline() {
+        long total = Math.max(0, okHttpCounter.getAsLong());
+        long previous = lastOkHttpBytes;
+        lastOkHttpBytes = total;
+        if (previous < 0 || total < previous) return UNSUPPORTED;
+        return total - previous;
+    }
+
+    /**
+     * Returns bytes counted by TrafficStats since the last sample, or
+     * {@link #UNSUPPORTED} when the counter is missing, reset, or unbaselined.
+     */
+    private long advanceTrafficStatsBaseline() {
+        long total = byteCounter.getAsLong();
+        long previous = lastRxBytes;
+        lastRxBytes = total;
+        if (total < 0 || previous < 0 || total < previous) return UNSUPPORTED;
+        return total - previous;
+    }
+
+    private void markBaselines() {
+        lastOkHttpBytes = Math.max(0, okHttpCounter.getAsLong());
+        lastRxBytes = byteCounter.getAsLong();
+        lastTimeStamp = clock.getAsLong();
+    }
+
+    private static long readUidRxBytes() {
+        long total = TrafficStats.getUidRxBytes(App.get().getApplicationInfo().uid);
+        return total == TrafficStats.UNSUPPORTED ? UNSUPPORTED : total;
+    }
+}

--- a/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
@@ -606,6 +606,11 @@ public class PlayerManager implements ParseCallback {
         return networkProtectionMediaBitrate;
     }
 
+    /** Runtime metrics reported by the active native engine, or unknown when absent. */
+    public PlayerEngine.RuntimeMetrics getRuntimeMetrics() {
+        return engine == null ? PlayerEngine.RuntimeMetrics.unknown() : engine.getRuntimeMetrics();
+    }
+
     public long getNetworkProtectionStableThroughput() {
         return networkProtectionMediaBitrate <= 0 ? 0 : Math.max(0, Math.round(networkProtectionMediaBitrate * networkProtectionSupportedSpeed));
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -6855,7 +6855,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     private void updateInlineLoadingTraffic() {
         if (binding == null || binding.playerProgress.getVisibility() != View.VISIBLE) return;
-        Traffic.setSpeed(binding.playerProgressTraffic);
+        Traffic.setSpeed(binding.playerProgressTraffic, service() == null ? null : player());
         tintInlineLoading();
     }
 

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerOsdController.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerOsdController.java
@@ -8,7 +8,6 @@ import android.media.MediaFormat;
 import android.net.ConnectivityManager;
 import android.net.NetworkCapabilities;
 import android.net.Uri;
-import android.net.TrafficStats;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
@@ -31,6 +30,7 @@ import com.fongmi.android.tv.player.GpuLoadMonitor;
 import com.fongmi.android.tv.player.PlayerManager;
 import com.fongmi.android.tv.player.PlaybackPanelResourceMonitor;
 import com.fongmi.android.tv.player.PlaybackDiagnosticsSourcePolicy;
+import com.fongmi.android.tv.player.PlaybackSpeedMeter;
 import com.fongmi.android.tv.player.PlaybackRoute;
 import com.fongmi.android.tv.player.engine.PlayerEngine;
 import com.fongmi.android.tv.player.exo.PlaybackAnalyticsListener;
@@ -53,8 +53,6 @@ public class PlayerOsdController {
         String getTitle();
     }
 
-    private static final DecimalFormat SPEED_FORMAT = new DecimalFormat("#.0");
-    private static final int UID = App.get().getApplicationInfo().uid;
     private static volatile String cachedDeviceText;
     private static volatile String cachedSystemText;
     private static volatile String cachedWebViewText;
@@ -79,8 +77,7 @@ public class PlayerOsdController {
     private final DecimalFormat frameFormat;
     private final DecimalFormat refreshFormat;
     private final DecimalFormat bitrateFormat;
-    private long lastTotalRxBytes;
-    private long lastTimeStamp;
+    private final PlaybackSpeedMeter speedMeter = new PlaybackSpeedMeter();
     private long lastSpeedKBps;
     private String lastSpeedText;
     private boolean controlsVisible;
@@ -387,23 +384,14 @@ public class PlayerOsdController {
     }
 
     private void updateSpeed(PlayerManager player) {
-        if (player == null || PlaybackDiagnosticsSourcePolicy.isLocal(player.getUrl())) {
+        // No player means no playback to report on; app-wide traffic would mislead here.
+        if (player == null) {
             resetSpeed();
             return;
         }
-        long total = TrafficStats.getUidRxBytes(UID);
-        if (total == TrafficStats.UNSUPPORTED) {
-            lastSpeedKBps = 0;
-            lastSpeedText = "";
-            return;
-        }
-        long now = System.currentTimeMillis();
-        long rxKb = total / 1024;
-        long speed = (rxKb - lastTotalRxBytes) * 1000 / Math.max(now - lastTimeStamp, 1);
-        lastTimeStamp = now;
-        lastTotalRxBytes = rxKb;
-        lastSpeedKBps = Math.max(0, speed);
-        lastSpeedText = formatSpeed(lastSpeedKBps);
+        speedMeter.sample(player);
+        lastSpeedKBps = speedMeter.getBytesPerSecond() / 1024;
+        lastSpeedText = speedMeter.getText();
     }
 
     private DiagnosticsText getDiagnostics(PlayerManager player) {
@@ -910,14 +898,6 @@ public class PlayerOsdController {
         return bitrateFormat.format(kb / 1024f) + "MB";
     }
 
-    private String formatSpeed(long kbps) {
-        return kbps < 1000 ? kbps + " KB/s" : SPEED_FORMAT.format(kbps / 1024f) + " MB/s";
-    }
-
-    private String formatByteSpeed(long bytesPerSecond) {
-        return formatSpeed(Math.max(0, bytesPerSecond / 1024));
-    }
-
     private String formatDuration(long ms) {
         if (ms <= 0) return "";
         if (ms >= 60_000) return Util.timeMs(ms);
@@ -1187,9 +1167,7 @@ public class PlayerOsdController {
     }
 
     private void resetSpeed() {
-        long total = TrafficStats.getUidRxBytes(UID);
-        lastTotalRxBytes = total == TrafficStats.UNSUPPORTED ? 0 : total / 1024;
-        lastTimeStamp = System.currentTimeMillis();
+        speedMeter.reset();
         lastSpeedKBps = 0;
         lastSpeedText = "";
     }

--- a/app/src/main/java/com/fongmi/android/tv/utils/Traffic.java
+++ b/app/src/main/java/com/fongmi/android/tv/utils/Traffic.java
@@ -1,40 +1,30 @@
 package com.fongmi.android.tv.utils;
 
-import android.net.TrafficStats;
 import android.view.View;
 import android.widget.TextView;
 
-import com.fongmi.android.tv.App;
+import androidx.annotation.Nullable;
 
-import java.text.DecimalFormat;
+import com.fongmi.android.tv.player.PlaybackSpeedMeter;
+import com.fongmi.android.tv.player.PlayerManager;
 
 public class Traffic {
 
-    private static final DecimalFormat format = new DecimalFormat("#.0");
-    private static final int UID = App.get().getApplicationInfo().uid;
-    private static final String UNIT_KB = " KB/s";
-    private static final String UNIT_MB = " MB/s";
+    private static final PlaybackSpeedMeter meter = new PlaybackSpeedMeter();
 
-    private static long lastTotalRxBytes;
-    private static long lastTimeStamp;
-
-    public static void setSpeed(TextView view) {
-        if (TrafficStats.getUidRxBytes(UID) == TrafficStats.UNSUPPORTED) return;
-        view.setVisibility(View.VISIBLE);
-        view.setText(getSpeed());
-    }
-
-    private static String getSpeed() {
-        long nowTimeStamp = System.currentTimeMillis();
-        long nowTotalRxBytes = TrafficStats.getUidRxBytes(UID) / 1024;
-        long speed = (nowTotalRxBytes - lastTotalRxBytes) * 1000 / Math.max(nowTimeStamp - lastTimeStamp, 1);
-        lastTimeStamp = nowTimeStamp;
-        lastTotalRxBytes = nowTotalRxBytes;
-        return speed < 1000 ? speed + UNIT_KB : format.format(speed / 1024f) + UNIT_MB;
+    /**
+     * Renders the current download speed, preferring the playback kernel's own byte
+     * accounting so the readout still works on ROMs whose per-UID TrafficStats
+     * counter is missing. Pass the active player, or null when none is attached.
+     */
+    public static void setSpeed(TextView view, @Nullable PlayerManager player) {
+        meter.sample(player);
+        String text = meter.getText();
+        view.setText(text);
+        view.setVisibility(text.isEmpty() ? View.GONE : View.VISIBLE);
     }
 
     public static void reset() {
-        lastTotalRxBytes = 0;
-        lastTimeStamp = 0;
+        meter.reset();
     }
 }

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
@@ -987,7 +987,7 @@ public class LiveActivity extends PlaybackActivity implements CustomKeyDown.List
     }
 
     private void setTraffic() {
-        Traffic.setSpeed(mBinding.progress.traffic);
+        Traffic.setSpeed(mBinding.progress.traffic, service() == null ? null : player());
         App.post(mR2, 1000);
     }
 

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -4622,7 +4622,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
     }
 
     private void setTraffic() {
-        Traffic.setSpeed(mBinding.progress.traffic);
+        Traffic.setSpeed(mBinding.progress.traffic, service() == null ? null : player());
         App.post(mR2, 1000);
     }
 

--- a/app/src/test/java/com/fongmi/android/tv/player/PlaybackSpeedMeterTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/player/PlaybackSpeedMeterTest.java
@@ -1,0 +1,212 @@
+package com.fongmi.android.tv.player;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * The regression these cover: a projector ROM whose per-UID TrafficStats counter is
+ * absent or frozen used to blank the speed readout entirely, because both readouts
+ * derived speed from that counter alone. The fix counts bytes in-process (OkHttp) and
+ * from the playback kernel instead, so the readout no longer depends on kernel
+ * accounting that some ROMs never compiled in.
+ */
+public class PlaybackSpeedMeterTest {
+
+    private static final long UNSUPPORTED = -1;
+
+    @Test
+    public void kernelSampleSurvivesUnsupportedTrafficStats() {
+        Fake fake = new Fake();
+        fake.trafficBytes = UNSUPPORTED;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        meter.observe(8_000_000);
+
+        assertEquals(PlaybackSpeedMeter.Source.KERNEL, meter.getSource());
+        assertEquals(1_000_000, meter.getBytesPerSecond());
+        assertFalse(meter.isUnavailable());
+        assertEquals("976 KB/s", meter.getText());
+    }
+
+    @Test
+    public void kernelSampleSurvivesFrozenTrafficStatsCounter() {
+        Fake fake = new Fake();
+        fake.trafficBytes = 4096;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        // A ROM that reports a constant never advances the delta.
+        fake.advance(1000);
+        meter.observe(16_000_000);
+
+        assertEquals(PlaybackSpeedMeter.Source.KERNEL, meter.getSource());
+        assertEquals(2_000_000, meter.getBytesPerSecond());
+    }
+
+    @Test
+    public void okHttpCounterReportsSpeedWhenTrafficStatsIsUnsupported() {
+        Fake fake = new Fake();
+        fake.trafficBytes = UNSUPPORTED;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        // The first sample only establishes a baseline.
+        meter.observe(0);
+        assertTrue(meter.isUnavailable());
+
+        fake.okHttpBytes = 512_000;
+        fake.advance(1000);
+        meter.observe(0);
+
+        assertEquals(PlaybackSpeedMeter.Source.OK_HTTP, meter.getSource());
+        assertEquals(512_000, meter.getBytesPerSecond());
+        assertEquals("500 KB/s", meter.getText());
+    }
+
+    @Test
+    public void okHttpCounterReportsSpeedWhenTrafficStatsIsFrozen() {
+        Fake fake = new Fake();
+        fake.trafficBytes = 4096;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        meter.observe(0);
+        fake.okHttpBytes = 256_000;
+        fake.advance(1000);
+        meter.observe(0);
+
+        assertEquals(PlaybackSpeedMeter.Source.OK_HTTP, meter.getSource());
+        assertEquals(256_000, meter.getBytesPerSecond());
+    }
+
+    @Test
+    public void trafficStatsWinsWhenItSeesMoreThanOkHttp() {
+        Fake fake = new Fake();
+        fake.trafficBytes = 0;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        meter.observe(0);
+        // A native engine socket bypasses Java, so only TrafficStats sees those bytes.
+        fake.trafficBytes = 1_024_000;
+        fake.okHttpBytes = 16_000;
+        fake.advance(1000);
+        meter.observe(0);
+
+        assertEquals(PlaybackSpeedMeter.Source.TRAFFIC_STATS, meter.getSource());
+        assertEquals(1_024_000, meter.getBytesPerSecond());
+    }
+
+    @Test
+    public void bothCountersIdleReportsZeroRatherThanUnavailable() {
+        Fake fake = new Fake();
+        fake.trafficBytes = 4096;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        meter.observe(0);
+        fake.advance(1000);
+        meter.observe(0);
+
+        assertEquals(PlaybackSpeedMeter.Source.OK_HTTP, meter.getSource());
+        assertEquals(0, meter.getBytesPerSecond());
+    }
+
+    @Test
+    public void firstFallbackSampleAfterKernelHandoverUsesLiveBaseline() {
+        Fake fake = new Fake();
+        fake.trafficBytes = 1_000_000;
+        fake.okHttpBytes = 1_000_000;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        // While the kernel answers, both baselines must keep tracking, or the first
+        // fallback sample would bill every byte since startup to one interval.
+        meter.observe(8_000_000);
+        fake.trafficBytes = 1_512_000;
+        fake.okHttpBytes = 1_512_000;
+        fake.advance(1000);
+        meter.observe(0);
+
+        assertEquals(512_000, meter.getBytesPerSecond());
+    }
+
+    @Test
+    public void counterResetIsNotReportedAsNegativeSpeed() {
+        Fake fake = new Fake();
+        fake.trafficBytes = 1_000_000;
+        fake.okHttpBytes = 1_000_000;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        meter.observe(0);
+        fake.trafficBytes = 4096;
+        fake.okHttpBytes = 0;
+        fake.advance(1000);
+        meter.observe(0);
+
+        assertEquals(PlaybackSpeedMeter.Source.NONE, meter.getSource());
+        assertEquals(0, meter.getBytesPerSecond());
+        assertEquals("", meter.getText());
+    }
+
+    @Test
+    public void resetClearsReadoutAndRebasesBaselines() {
+        Fake fake = new Fake();
+        fake.trafficBytes = 1_000_000;
+        fake.okHttpBytes = 1_000_000;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        meter.observe(8_000_000);
+        meter.reset();
+
+        assertEquals(PlaybackSpeedMeter.Source.NONE, meter.getSource());
+        assertEquals(0, meter.getBytesPerSecond());
+        assertEquals("", meter.getText());
+
+        // Rebased, so the next interval bills only bytes seen since the reset.
+        fake.trafficBytes = 1_512_000;
+        fake.okHttpBytes = 1_512_000;
+        fake.advance(1000);
+        meter.observe(0);
+        assertEquals(512_000, meter.getBytesPerSecond());
+    }
+
+    @Test
+    public void repeatedSampleWithinSameMillisecondKeepsPreviousReadout() {
+        Fake fake = new Fake();
+        fake.okHttpBytes = 1_000_000;
+        PlaybackSpeedMeter meter = fake.meter();
+
+        meter.observe(0);
+        fake.advance(1000);
+        fake.okHttpBytes = 1_512_000;
+        meter.observe(0);
+        assertEquals(512_000, meter.getBytesPerSecond());
+
+        // No elapsed time means no new sample; the last good value must stand rather
+        // than divide by zero or collapse to 0.
+        fake.okHttpBytes = 9_000_000;
+        meter.observe(0);
+        assertEquals(512_000, meter.getBytesPerSecond());
+    }
+
+    @Test
+    public void formatSwitchesToMegabytesAtOneThousandKilobytes() {
+        assertEquals("0 KB/s", PlaybackSpeedMeter.format(0));
+        assertEquals("999 KB/s", PlaybackSpeedMeter.format(999 * 1024));
+        assertEquals("1.0 MB/s", PlaybackSpeedMeter.format(1000 * 1024));
+        assertEquals("0 KB/s", PlaybackSpeedMeter.format(-1));
+    }
+
+    private static final class Fake {
+
+        private long trafficBytes;
+        private long okHttpBytes;
+        private long nowMs = 1_000;
+
+        private PlaybackSpeedMeter meter() {
+            return new PlaybackSpeedMeter(() -> trafficBytes, () -> okHttpBytes, () -> nowMs);
+        }
+
+        private void advance(long deltaMs) {
+            nowMs += deltaMs;
+        }
+    }
+}

--- a/catvod/build.gradle
+++ b/catvod/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     api libs.zxing.core
     coreLibraryDesugaring libs.desugar
     testImplementation libs.junit
+    testImplementation libs.okhttp.mockwebserver
 }

--- a/catvod/src/main/java/com/github/catvod/net/OkHttp.java
+++ b/catvod/src/main/java/com/github/catvod/net/OkHttp.java
@@ -234,7 +234,10 @@ public class OkHttp {
     }
 
     private static OkHttpClient.Builder getBuilder() {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder().addInterceptor(new HostExceptionInterceptor()).addInterceptor(requestInterceptor()).addInterceptor(authInterceptor()).addNetworkInterceptor(responseInterceptor()).connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS).readTimeout(TIMEOUT, TimeUnit.MILLISECONDS).writeTimeout(TIMEOUT, TimeUnit.MILLISECONDS).dns(dns()).hostnameVerifier((hostname, session) -> true).sslSocketFactory(getSSLContext().getSocketFactory(), trustAllCertificates());
+        // OkTrafficCounter must stay the last network interceptor: the innermost one sits
+        // closest to the socket and so counts compressed wire bytes. Moving it outside
+        // responseInterceptor() would count inflated bytes and silently overstate speed.
+        OkHttpClient.Builder builder = new OkHttpClient.Builder().addInterceptor(new HostExceptionInterceptor()).addInterceptor(requestInterceptor()).addInterceptor(authInterceptor()).addNetworkInterceptor(responseInterceptor()).addNetworkInterceptor(OkTrafficCounter.interceptor()).connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS).readTimeout(TIMEOUT, TimeUnit.MILLISECONDS).writeTimeout(TIMEOUT, TimeUnit.MILLISECONDS).dns(dns()).hostnameVerifier((hostname, session) -> true).sslSocketFactory(getSSLContext().getSocketFactory(), trustAllCertificates());
         HttpLoggingInterceptor logging = new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY);
         builder.proxyAuthenticator(authenticator());
         //builder.addNetworkInterceptor(logging);

--- a/catvod/src/main/java/com/github/catvod/net/OkTrafficCounter.java
+++ b/catvod/src/main/java/com/github/catvod/net/OkTrafficCounter.java
@@ -1,0 +1,71 @@
+package com.github.catvod.net;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ForwardingSource;
+import okio.Okio;
+import okio.Source;
+
+/**
+ * Process-wide count of response bytes read through {@link OkHttp}.
+ *
+ * <p>Exists because per-UID {@link android.net.TrafficStats} needs kernel support that
+ * some vendor ROMs never compiled in, leaving speed readouts with no byte source at
+ * all.  Counting in the HTTP layer is independent of that kernel support, so it works
+ * everywhere the traffic passes through Java — which includes the scraping and config
+ * requests that run before a playback kernel exists to report its own throughput.
+ *
+ * <p>Bytes are counted as they are consumed rather than when a response completes, so a
+ * long-lived video stream reports progress continuously instead of in one lump.
+ */
+public final class OkTrafficCounter {
+
+    private static final AtomicLong TOTAL_BYTES = new AtomicLong();
+    private static final int HTTP_SWITCHING_PROTOCOLS = 101;
+
+    private OkTrafficCounter() {
+    }
+
+    /** Monotonic count of response body bytes read since process start. */
+    public static long totalBytes() {
+        return TOTAL_BYTES.get();
+    }
+
+    static Interceptor interceptor() {
+        return chain -> count(chain.proceed(chain.request()));
+    }
+
+    private static Response count(Response response) {
+        // A 101 hands the socket to the WebSocket reader; rebuilding its body would
+        // break the upgrade, and its frames are not what a speed readout measures.
+        if (response.code() == HTTP_SWITCHING_PROTOCOLS) return response;
+        ResponseBody body = response.body();
+        if (body == null) return response;
+        BufferedSource counted = Okio.buffer(new CountingSource(body.source()));
+        return response.newBuilder()
+                .body(ResponseBody.create(counted, body.contentType(), body.contentLength()))
+                .build();
+    }
+
+    private static final class CountingSource extends ForwardingSource {
+
+        private CountingSource(Source delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public long read(@NonNull Buffer sink, long byteCount) throws IOException {
+            long read = super.read(sink, byteCount);
+            if (read > 0) TOTAL_BYTES.addAndGet(read);
+            return read;
+        }
+    }
+}

--- a/catvod/src/test/java/com/github/catvod/net/OkTrafficCounterTest.java
+++ b/catvod/src/test/java/com/github/catvod/net/OkTrafficCounterTest.java
@@ -1,0 +1,290 @@
+package com.github.catvod.net;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Exercises the counter against a real server, because it rewrites every response body
+ * that flows through {@link OkHttp} and a mistake there would corrupt playback and
+ * scraping rather than merely misreport a speed.
+ */
+public class OkTrafficCounterTest {
+
+    private MockWebServer server;
+    private OkHttpClient client;
+
+    @Before
+    public void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        client = new OkHttpClient.Builder()
+                .addNetworkInterceptor(OkTrafficCounter.interceptor())
+                .build();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    public void bodyContentSurvivesWrapping() throws IOException {
+        server.enqueue(new MockResponse().setBody("hello world"));
+
+        try (Response response = get()) {
+            assertEquals("hello world", response.body().string());
+        }
+    }
+
+    @Test
+    public void byteStreamConsumerSeesIntactBody() throws IOException {
+        // Glide loads every poster through OkHttpUrlLoader, which consumes the body as an
+        // InputStream rather than via string()/bytes(); a wrapper that only works for the
+        // latter would break image loading across the whole UI.
+        byte[] payload = new byte[32 * 1024];
+        for (int i = 0; i < payload.length; i++) payload[i] = (byte) (i % 253);
+        server.enqueue(new MockResponse().setBody(new Buffer().write(payload)));
+        long before = OkTrafficCounter.totalBytes();
+
+        byte[] received = new byte[payload.length];
+        try (Response response = get(); java.io.InputStream stream = response.body().byteStream()) {
+            int offset = 0;
+            while (offset < received.length) {
+                int read = stream.read(received, offset, received.length - offset);
+                if (read < 0) break;
+                offset += read;
+            }
+            assertEquals(payload.length, offset);
+            assertEquals(-1, stream.read());
+        }
+
+        assertArrayEquals(payload, received);
+        assertEquals(payload.length, OkTrafficCounter.totalBytes() - before);
+    }
+
+    @Test
+    public void countsBytesActuallyRead() throws IOException {
+        server.enqueue(new MockResponse().setBody("0123456789"));
+        long before = OkTrafficCounter.totalBytes();
+
+        try (Response response = get()) {
+            response.body().string();
+        }
+
+        assertEquals(10, OkTrafficCounter.totalBytes() - before);
+    }
+
+    @Test
+    public void contentLengthAndTypeArePreserved() throws IOException {
+        server.enqueue(new MockResponse()
+                .setBody("abcd")
+                .setHeader("Content-Type", "application/json"));
+
+        try (Response response = get()) {
+            ResponseBody body = response.body();
+            assertEquals(4, body.contentLength());
+            assertEquals("application/json", body.contentType().toString());
+            assertEquals("abcd", body.string());
+        }
+    }
+
+    @Test
+    public void binaryBodyIsNotCorrupted() throws IOException {
+        byte[] payload = new byte[8192];
+        for (int i = 0; i < payload.length; i++) payload[i] = (byte) (i % 251);
+        server.enqueue(new MockResponse().setBody(new Buffer().write(payload)));
+
+        try (Response response = get()) {
+            assertArrayEquals(payload, response.body().bytes());
+        }
+    }
+
+    @Test
+    public void emptyBodyIsCountedAsZero() throws IOException {
+        server.enqueue(new MockResponse().setBody(""));
+        long before = OkTrafficCounter.totalBytes();
+
+        try (Response response = get()) {
+            assertEquals("", response.body().string());
+        }
+
+        assertEquals(0, OkTrafficCounter.totalBytes() - before);
+    }
+
+    @Test
+    public void noContentResponseIsSafe() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        long before = OkTrafficCounter.totalBytes();
+
+        try (Response response = get()) {
+            assertEquals(204, response.code());
+            assertEquals("", response.body().string());
+        }
+
+        assertEquals(0, OkTrafficCounter.totalBytes() - before);
+    }
+
+    @Test
+    public void headResponseIsSafe() throws IOException {
+        server.enqueue(new MockResponse().setHeader("Content-Length", "1234"));
+
+        Request request = new Request.Builder().url(server.url("/")).head().build();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            assertEquals("", response.body().string());
+        }
+    }
+
+    @Test
+    public void partialRangeBodyIsCountedAndIntact() throws IOException {
+        server.enqueue(new MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 0-3/100")
+                .setBody("abcd"));
+        long before = OkTrafficCounter.totalBytes();
+
+        Request request = new Request.Builder()
+                .url(server.url("/"))
+                .header("Range", "bytes=0-3")
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(206, response.code());
+            assertEquals("abcd", response.body().string());
+        }
+
+        assertEquals(4, OkTrafficCounter.totalBytes() - before);
+    }
+
+    @Test
+    public void gzipCountsCompressedWireBytesAndStillDecodes() throws IOException {
+        // A speed readout should reflect what crossed the wire, not the inflated size.
+        Buffer gzipped = new Buffer();
+        try (okio.BufferedSink sink = okio.Okio.buffer(new okio.GzipSink(gzipped))) {
+            sink.writeUtf8("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        }
+        long wireBytes = gzipped.size();
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Encoding", "gzip")
+                .setBody(gzipped));
+        long before = OkTrafficCounter.totalBytes();
+
+        try (Response response = get()) {
+            // OkHttp inflates transparently above the network interceptor.
+            assertEquals("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", response.body().string());
+        }
+
+        long counted = OkTrafficCounter.totalBytes() - before;
+        assertEquals(wireBytes, counted);
+        assertTrue("compressed count should be below the inflated size", counted < 40);
+    }
+
+    @Test
+    public void partiallyReadBodyCountsOnlyWhatWasConsumed() throws IOException {
+        byte[] payload = new byte[64 * 1024];
+        server.enqueue(new MockResponse().setBody(new Buffer().write(payload)));
+        long before = OkTrafficCounter.totalBytes();
+
+        try (Response response = get()) {
+            // Read a little, then abandon the rest as a cancelled transfer would.
+            response.body().source().readByteString(16);
+        }
+
+        long counted = OkTrafficCounter.totalBytes() - before;
+        assertTrue("should count at least what was read", counted >= 16);
+        assertTrue("should not bill the unread remainder", counted < payload.length);
+    }
+
+    @Test
+    public void concurrentTransfersCountExactlyOnce() throws Exception {
+        // Real playback runs many transfers at once (segments, posters, subtitles), so a
+        // lost or double-counted update would skew every readout.
+        int requests = 24;
+        int bodySize = 4096;
+        for (int i = 0; i < requests; i++) {
+            server.enqueue(new MockResponse().setBody(new Buffer().write(new byte[bodySize])));
+        }
+        long before = OkTrafficCounter.totalBytes();
+
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(8);
+        java.util.List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+        for (int i = 0; i < requests; i++) {
+            futures.add(pool.submit(() -> {
+                try (Response response = get()) {
+                    response.body().bytes();
+                }
+                return null;
+            }));
+        }
+        for (java.util.concurrent.Future<?> future : futures) future.get();
+        pool.shutdown();
+
+        assertEquals((long) requests * bodySize, OkTrafficCounter.totalBytes() - before);
+    }
+
+    @Test
+    public void stacksWithResponseInterceptorDeflateBranch() throws IOException {
+        // Both interceptors rebuild the body. ResponseInterceptor registers first so it
+        // sits outside and inflates *through* this counter, which must therefore still
+        // see the raw compressed bytes and must not break its read.
+        String plain = "deflate payload deflate payload deflate payload";
+        Buffer deflated = new Buffer();
+        try (okio.BufferedSink sink = okio.Okio.buffer(
+                new okio.DeflaterSink(deflated, new java.util.zip.Deflater(-1, true)))) {
+            sink.writeUtf8(plain);
+        }
+        long wireBytes = deflated.size();
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Encoding", "deflate")
+                .setBody(deflated));
+
+        OkHttpClient stacked = new OkHttpClient.Builder()
+                .addNetworkInterceptor(new com.github.catvod.net.interceptor.ResponseInterceptor())
+                .addNetworkInterceptor(OkTrafficCounter.interceptor())
+                .build();
+        long before = OkTrafficCounter.totalBytes();
+
+        Request request = new Request.Builder().url(server.url("/")).build();
+        try (Response response = stacked.newCall(request).execute()) {
+            assertEquals(plain, response.body().string());
+        }
+
+        assertEquals(wireBytes, OkTrafficCounter.totalBytes() - before);
+    }
+
+    @Test
+    public void totalIsMonotonicAcrossRequests() throws IOException {
+        server.enqueue(new MockResponse().setBody("abc"));
+        server.enqueue(new MockResponse().setBody("defgh"));
+        long before = OkTrafficCounter.totalBytes();
+
+        try (Response first = get()) {
+            first.body().string();
+        }
+        long afterFirst = OkTrafficCounter.totalBytes();
+        try (Response second = get()) {
+            second.body().string();
+        }
+
+        assertEquals(3, afterFirst - before);
+        assertEquals(8, OkTrafficCounter.totalBytes() - before);
+    }
+
+    private Response get() throws IOException {
+        return client.newCall(new Request.Builder().url(server.url("/")).build()).execute();
+    }
+}


### PR DESCRIPTION
问题：部分投影仪/电视盒子的 ROM 未编译 per-UID TrafficStats 的内核支持
（xt_qtaguid 或 netd eBPF），getUidRxBytes 返回 UNSUPPORTED 或恒定不增长的 值。原先加载圈与屏显各有一份独立实现，都只读这个接口，因此在这些设备上
加载和播放阶段都不显示网速。同机的第三方悬浮窗同样恒为 0K/s，可佐证是
ROM 侧缺失而非应用逻辑问题。

方案：新增 PlaybackSpeedMeter 统一计量，三层降级取数：
1. 播放内核自报吞吐 —— Exo 读 bandwidthEstimate，IJK/MPV 读 RuntimeMetrics （即 ffmpeg 的 tcp_speed 与 mpv 的 raw-input-rate），播放中最准；
2. OkTrafficCounter —— 新增，装为 network interceptor 累计响应字节，覆盖 内核尚未建立的加载阶段（爬虫与配置请求走同一 client）；
3. TrafficStats —— 保留兜底，它是唯一能看到 native socket 流量的来源。

第 2、3 层取 delta 较大值：OkHttp 看不到 native socket，TrafficStats 在坏 ROM 上什么都看不到，两者互补。

顺带修正两个既有缺陷：Traffic.reset 原先把基线清成 0 而非当前值，导致
reset 后首帧必为 0；原实现连续两次读取计数器，中间字节被丢弃导致低估。
并将加载圈与屏显的两份重复实现收敛为一处（净减 26 行）。

防护：101 升级响应直接放行，避免破坏 WebSocket 握手；同毫秒重复采样保留
上次读数，不除零也不塌成 0。

验证：catvod 14 条打真实 HTTP 服务的测试（含 Glide 的 InputStream 消费路径、 与 ResponseInterceptor 的 deflate 叠加、8 线程并发精确计数、gzip 计压缩 字节、HEAD/204/Range/二进制完整性），PlaybackSpeedMeter 11 条分支测试， 以及流式代理既有 27 条测试，全部通过；两个 flavor 编译通过。

已知未覆盖：真机 ROM 行为无法在单测中验证，需装包实测确认。