### PR TITLE
优化：原生增强详情页选集加载不再长时间转圈

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -2415,15 +2415,18 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
     }
 
     private void showTmdbEpisodeFallback() {
-        if (mBinding.episodeLoadingIndicator.getVisibility() != View.VISIBLE) return;
         if (!isTmdbSourceEnabled() || mTmdbUIAdapter == null || !mTmdbUIAdapter.isReady()) return;
         if (mTmdbUIAdapter.isEpisodeMetadataLoaded()) {
             refreshEpisodeTitles();
             return;
         }
+        // 不能再以「占位符可见」为前提：选集现在会先上屏，占位符只在一集都没有时出现。
+        // 超时后必须置位 fallbackReleased，否则 tmdbEpisodeEnrichmentPending 永远为真，
+        // TMDB 匹配失败时表头会永久挂着。
         mTmdbEpisodeFallbackReleased = true;
         SpiderDebug.log("tmdb-tv", "episode metadata timeout fallback, reveal native list");
-        finishEpisodeLoading();
+        if (mBinding.episodeLoadingIndicator.getVisibility() == View.VISIBLE) finishEpisodeLoading();
+        else refreshEpisodeTitles();
     }
 
     private void setText(Vod item) {
@@ -2630,12 +2633,15 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         boolean tmdbAdapterReady = mTmdbUIAdapter != null && mTmdbUIAdapter.isReady();
         boolean tmdbEpisodeMetadataLoaded = mTmdbUIAdapter != null && mTmdbUIAdapter.isEpisodeMetadataLoaded();
         if (tmdbEpisodeMetadataLoaded) App.removeCallbacks(mTmdbEpisodeTimeout);
-        // 快速直达播放会跳过全屏 TMDB loading，但卡片数据返回前仍不能先闪出原生文字选集。
-        // 超时后保留已经揭开的原生列表，避免稍后的核心详情刷新再次把它隐藏。
+        // 富集是否仍在进行中。超时后保留已经揭开的原生列表，避免稍后的核心详情刷新再次把它隐藏。
         boolean tmdbEpisodeEnrichmentPending = !mTmdbEpisodeFallbackReleased
                 && (mTmdbDetailLoading || (tmdbAdapterReady && !tmdbEpisodeMetadataLoaded));
+        // 站源集数已可渲染时不再隐藏列表：先出纯文本，TMDB 到达后由 updateFlag / refreshTmdbEpisodeTitles
+        // 原地换成卡片。只有一集都还没有时才需要占位符。
         boolean waitTmdbEpisodes = EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(tmdbMode, tmdbEpisodeEnrichmentPending, tmdbAdapterReady, tmdbEpisodeMetadataLoaded, items);
-        boolean showTmdbEpisodeChrome = EpisodeDisplayPolicy.shouldShowTmdbEpisodeChrome(tmdbMode, waitTmdbEpisodes, items);
+        // chrome 跟随「富集中」而非「隐藏中」：站源选集先上屏时表头就位，TMDB 卡片到达后
+        // 不再二次插入表头造成列表跳动。
+        boolean showTmdbEpisodeChrome = EpisodeDisplayPolicy.shouldShowTmdbEpisodeChrome(tmdbMode, tmdbEpisodeEnrichmentPending, items);
         boolean useTmdbCards = EpisodeDisplayPolicy.shouldUseTmdbEpisodeCards(tmdbMode, items);
         mBinding.episodeContainer.setVisibility(isEmpty ? View.GONE : View.VISIBLE);
         mBinding.control.action.episodes.setVisibility(items.size() < 2 ? View.GONE : View.VISIBLE);
@@ -2646,8 +2652,11 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
             return;
         }
 
-        if (showTmdbEpisodeChrome && hasMultiple) episodeGridMode = Setting.getTmdbEpisodeGridMode();
-        if (!showTmdbEpisodeChrome || !hasMultiple) episodeGridMode = false;
+        // 网格模式跟随「是否真有卡片数据」而非 chrome 可见性：富集中的纯文本选集若进了
+        // 按卡片宽度算 spanCount 的网格会明显错位，而此时 episodeViewMode 按钮又因
+        // useTmdbCards=false 被隐藏，用户无法切回列表。
+        if (useTmdbCards && hasMultiple) episodeGridMode = Setting.getTmdbEpisodeGridMode();
+        if (!useTmdbCards || !hasMultiple) episodeGridMode = false;
         mBinding.episodeHeader.setVisibility(showTmdbEpisodeChrome && !isEmpty ? View.VISIBLE : View.GONE);
         mBinding.episodeReverse.setVisibility(showTmdbEpisodeChrome && hasMultiple ? View.VISIBLE : View.GONE);
         mBinding.episodeViewMode.setVisibility(showTmdbEpisodeChrome && hasMultiple && useTmdbCards ? View.VISIBLE : View.GONE);
@@ -2723,8 +2732,8 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         setR2Callback();
     }
 
-    // TMDB 加载结束后兜底：若仍卡在剧集加载指示器（电影无集数、未匹配到、获取失败等），
-    // 隐藏指示器并以普通文本模式揭开选集列表，避免「正在加载剧集信息...」永久停留
+    // 兜底：占位符只在站源一集都没返回时出现（有集数就直接上屏了）。这里负责在 TMDB
+    // 结束或超时后把它收掉，避免「正在加载剧集信息...」永久停留。
     private void finishEpisodeLoading() {
         if (mBinding.episodeLoadingIndicator.getVisibility() != View.VISIBLE) return;
         if (isTmdbSourceEnabled()
@@ -2887,6 +2896,8 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         updateEpisodeFileNameButton();
         updateEpisodeReverseText();
         updateFocus();
+        // 占位符可见时（站源一集都没有）不能把空列表揭出来。选集有内容时占位符恒不可见，
+        // 所以这里实际上总是揭开——保留判断是为了覆盖"零集占位"那条路径。
         setEpisodeContentVisible(mBinding.episodeLoadingIndicator.getVisibility() != View.VISIBLE);
         if (scrollToCurrent) scrollToCurrentEpisode();
     }
@@ -2918,10 +2929,6 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
             mBinding.episode.setAlpha(1f);
             mBinding.episodeGrid.setVisibility(View.GONE);
         }
-    }
-
-    private View getActiveEpisodeContentView() {
-        return episodeGridMode ? mBinding.episodeGrid : mBinding.episode;
     }
 
     private void clearEpisodeGridDecoration() {
@@ -4710,25 +4717,9 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         items.forEach(item -> mFlagAdapter.getItems().stream()
                 .filter(item::equals).findFirst().ifPresentOrElse(target -> {
                     target.mergeEpisodes(item.getEpisodes(), mHistory.isRevSort());
-                    if (target.equals(activated)) {
-                        boolean useTmdbCard = EpisodeDisplayPolicy.shouldUseTmdbEpisodeCards(isTmdbSourceEnabled(), target.getEpisodes());
-
-                        if (useTmdbCard && mBinding.episodeLoadingIndicator.getVisibility() == View.VISIBLE) {
-                            // TMDB数据加载完成，执行淡入动画
-                            setEpisodeAdapter(target.getEpisodes());
-                            mBinding.episodeLoadingIndicator.setVisibility(View.GONE);
-                            setEpisodeContentVisible(true);
-                            View episodeView = getActiveEpisodeContentView();
-                            episodeView.setAlpha(0f);
-                            episodeView.animate()
-                                    .alpha(1f)
-                                    .setDuration(300)
-                                    .start();
-                        } else {
-                            // 普通更新或初始加载
-                            setEpisodeAdapter(target.getEpisodes());
-                        }
-                    }
+                    // 选集不再等 TMDB 才上屏，占位符只在「一集都没有」时出现，与「已有卡片数据」
+                    // 互斥，原先那条淡入分支已无法命中，故只保留常规刷新。
+                    if (target.equals(activated)) setEpisodeAdapter(target.getEpisodes());
                 }, () -> mFlagAdapter.add(item)));
     }
 
@@ -5338,8 +5329,10 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         boolean tmdbMode = isTmdbSourceEnabled();
         boolean useTmdbCards = EpisodeDisplayPolicy.shouldUseTmdbEpisodeCards(tmdbMode, items);
         boolean showTmdbEpisodeChrome = EpisodeDisplayPolicy.shouldShowTmdbEpisodeChrome(tmdbMode, false, items);
-        if (showTmdbEpisodeChrome && hasMultiple) episodeGridMode = Setting.getTmdbEpisodeGridMode();
-        if (!showTmdbEpisodeChrome || !hasMultiple) episodeGridMode = false;
+        // 与 setEpisodeAdapter 保持同一判据：网格模式只跟随「真有卡片数据」。此处 chrome
+        // 参数传 false 时两者恰好等价，显式写成 useTmdbCards 是为了以后改策略时不会漏掉这里。
+        if (useTmdbCards && hasMultiple) episodeGridMode = Setting.getTmdbEpisodeGridMode();
+        if (!useTmdbCards || !hasMultiple) episodeGridMode = false;
         mBinding.episodeHeader.setVisibility(showTmdbEpisodeChrome && !items.isEmpty() ? View.VISIBLE : View.GONE);
         mBinding.episodeReverse.setVisibility(showTmdbEpisodeChrome && hasMultiple ? View.VISIBLE : View.GONE);
         mBinding.episodeViewMode.setVisibility(showTmdbEpisodeChrome && hasMultiple && useTmdbCards ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/com/fongmi/android/tv/ui/helper/EpisodeDisplayPolicy.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/helper/EpisodeDisplayPolicy.java
@@ -21,12 +21,22 @@ public final class EpisodeDisplayPolicy {
         return tmdbSourceEnabled && hasTmdbEpisodeData(items);
     }
 
+    /**
+     * 站源集数已经可用时不再隐藏列表：先渲染纯文本选集，TMDB 元数据到达后原地换成卡片。
+     * 隐藏整个列表等 TMDB 会让用户对着「正在加载剧集信息...」干等最长 15 秒，而列表内容
+     * 其实早就拿到了。只有在还没有任何集数可渲染时才有必要占位。
+     */
     public static boolean shouldWaitForTmdbEpisodes(boolean tmdbSourceEnabled, boolean tmdbEpisodeEnrichmentPending, boolean tmdbAdapterReady, boolean tmdbEpisodeMetadataLoaded, List<Episode> items) {
-        return tmdbSourceEnabled && tmdbEpisodeEnrichmentPending && tmdbAdapterReady && !tmdbEpisodeMetadataLoaded && items != null && !items.isEmpty() && !hasTmdbEpisodeData(items);
+        return tmdbSourceEnabled && tmdbEpisodeEnrichmentPending && tmdbAdapterReady && !tmdbEpisodeMetadataLoaded && (items == null || items.isEmpty());
     }
 
-    public static boolean shouldShowTmdbEpisodeChrome(boolean tmdbSourceEnabled, boolean waitingForTmdbEpisodes, List<Episode> items) {
-        return tmdbSourceEnabled && (hasTmdbEpisodeData(items) || waitingForTmdbEpisodes);
+    /**
+     * 表头（倒序 / 列表 / 原文件名）在「已有卡片数据」或「富集仍在进行」时显示。
+     * 参数不再叫 waitingForTmdbEpisodes：选集现在先上屏，隐藏与富集已经解耦，调用方传的是
+     * 富集是否进行中，让表头在纯文本阶段就位、卡片到达时不必二次插入造成列表跳动。
+     */
+    public static boolean shouldShowTmdbEpisodeChrome(boolean tmdbSourceEnabled, boolean enrichmentPending, List<Episode> items) {
+        return tmdbSourceEnabled && (hasTmdbEpisodeData(items) || enrichmentPending);
     }
 
     public static boolean shouldShowEpisodeGroup(int groupCount, boolean tmdbDetailLayout) {

--- a/app/src/main/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapter.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapter.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * TMDB 数据适配器
@@ -69,6 +70,10 @@ public class TmdbUIAdapter {
 
     private static final long VOD_REFRESH_COALESCE_MS = 240;
     private static final long TMDB_STARTUP_BACKGROUND_DELAY_MS = 1200;
+    // 选集是首屏内容，不能和推荐/个性化一起排在 1200ms 之后：用户盯着的就是它。
+    // 集数元数据立刻发起（磁盘缓存命中时几乎瞬时），推荐等仍延后给首帧让路。
+    private static final long TMDB_STARTUP_EPISODE_DELAY_MS = 0;
+    private static final int MAX_CACHED_SEASONS = 24;
 
     private final Activity activity;
     private final TmdbService tmdbService;
@@ -77,6 +82,7 @@ public class TmdbUIAdapter {
     private final Runnable pendingVodRefresh = this::dispatchPendingVodRefresh;
     private final TmdbDetailPrefetch detailPrefetch;
     private final Task.Scope backgroundTasks;
+    private final Task.Scope episodeTasks;
     private ListenableFuture<TmdbDetailPrefetch.Result> activePrefetch;
 
     private TmdbItem tmdbItem;
@@ -117,10 +123,14 @@ public class TmdbUIAdapter {
     private volatile int episodeMetadataGeneration;
     private volatile int relatedVideoGeneration;
     private final Object episodeMetadataLock = new Object();
+    // 季级内存缓存：切季 / 切线路会反复要同一季的集数，磁盘缓存虽然命中但仍要读文件 +
+    // 解析整季 JSON。缓存解析结果让重复访问零 IO。键为 tmdbId|mediaType|season。
+    private final Map<String, List<TmdbEpisode>> seasonEpisodeCache = new ConcurrentHashMap<>();
     private volatile int pendingVodRefreshGeneration;
     private volatile Vod pendingVodRefreshVod;
     private final java.util.EnumSet<RefreshEvent.Type> pendingVodRefreshTypes = java.util.EnumSet.noneOf(RefreshEvent.Type.class);
     private Runnable pendingStartupBackgroundLoads;
+    private Runnable pendingStartupEpisodeLoad;
     private PersonalAiUpdateListener personalAiUpdateListener;
 
     public interface LoadMoreCallback {
@@ -137,6 +147,10 @@ public class TmdbUIAdapter {
         this.tmdbConfig = TmdbConfig.objectFrom(Setting.getTmdbConfig());
         this.tmdbMatcher = new TmdbMatcher(tmdbService, tmdbConfig);
         this.backgroundTasks = new Task.Scope(Task.recommendationExecutor());
+        // 选集元数据独立线程池：recommendationExecutor 只有 3 条线程，推荐 / 个性化 / AI 推荐
+        // 都挤在里面。原先 1200ms 延迟天然把选集和它们错开了，现在选集不再延迟，必须换到
+        // largeExecutor(20)，否则选集会排在推荐后面，反而更慢。
+        this.episodeTasks = new Task.Scope(Task.largeExecutor());
         this.detailPrefetch = new TmdbDetailPrefetch(Task.recommendationExecutor());
     }
 
@@ -347,6 +361,11 @@ public class TmdbUIAdapter {
     public void beginDetailRequest() {
         resetLoadState();
         backgroundTasks.cancelAll();
+        episodeTasks.cancelAll();
+        // 季缓存在这里清而不是在 resetLoadState 里：本方法由 getDetail() 在 prefetch 之前调用，
+        // 清完紧接着的预热会重新填。放在 resetLoadState 会被 load() 冲掉预热结果；不清则
+        // getDetail(refresh=true) 这类强制刷新会被内存缓存挡住，拿到陈旧集数。
+        seasonEpisodeCache.clear();
         cancelActivePrefetch();
         detailPrefetch.cancel();
     }
@@ -354,6 +373,7 @@ public class TmdbUIAdapter {
     public void release() {
         resetLoadState();
         backgroundTasks.close();
+        episodeTasks.close();
         cancelActivePrefetch();
         detailPrefetch.cancel();
     }
@@ -364,11 +384,18 @@ public class TmdbUIAdapter {
     public void prefetch(TmdbItem item) {
         if (item == null || !isReady()) return;
         long start = System.currentTimeMillis();
+        // Intent 在主线程读：本方法由 prefetchDirectTmdbDetail 在主线程调用，而 Intent 内部是
+        // 非线程安全的 Bundle，主线程还会 putExtras/removeExtra 改它。算好季号再传进后台任务。
+        int intentSeason = intentSeasonNumber();
         TmdbDetailPrefetch.StartResult started = detailPrefetch.start(item, () -> {
             JsonObject detail = tmdbService.detail(item, tmdbConfig, false);
             TmdbItem loadedItem = normalizeLoadedItem(item, detail);
             List<TmdbPerson> cast = tmdbService.cast(detail, tmdbConfig);
             SpiderDebug.log("tmdb-prefetch", "finish cost=%dms media=%s id=%d", System.currentTimeMillis() - start, loadedItem.getMediaType(), loadedItem.getTmdbId());
+            // 选集卡片要的是 season/episodes，detail 里没有，所以顺手预热最可能的那一季。
+            // 必须另起任务：这个 future 完成才会触发 loadDetailSync，串在里面等于用选集
+            // 预热延后核心详情上屏。
+            warmLikelySeasonAsync(loadedItem, detail, intentSeason);
             return new TmdbDetailPrefetch.Result(loadedItem, detail, cast);
         });
         if (started == null) {
@@ -377,6 +404,57 @@ public class TmdbUIAdapter {
         }
         SpiderDebug.log("tmdb-prefetch", "%s media=%s id=%d", prefetchStateText(started.getState()), item.getMediaType(), item.getTmdbId());
         if (started.getState() != TmdbDetailPrefetch.StartState.REUSED) logPrefetchFailure(started.getFuture(), item, start);
+    }
+
+    /**
+     * 预热最可能用到的那一季，跑在独立任务里，不阻塞 prefetch future。
+     *
+     * 预热可能与随后的 loadEpisodeTitlesAsync 并发请求同一季，两者都 miss 时会重复读一次
+     * 磁盘/网络。这是有意接受的：预热猜错季本来也会浪费一次，为去重引入 per-key future
+     * 不划算，且 TmdbEpisode 全是 final 字段、缓存值用 List.copyOf，重复写入不会产生脏数据。
+     */
+    private void warmLikelySeasonAsync(TmdbItem item, JsonObject detail, int intentSeason) {
+        if (item == null || !item.isTv() || detail == null) return;
+        int target = likelySeasonNumber(detail, intentSeason);
+        if (target < 0) return;
+        // 走 episodeTasks 而非裸 Task.submitLarge：换源 / 销毁时能随 generation 一起取消，
+        // 不会在后台继续跑并往缓存里写已经没人要的数据。
+        episodeTasks.submit(() -> {
+            try {
+                long start = System.currentTimeMillis();
+                List<TmdbEpisode> episodes = seasonEpisodes(item, target);
+                SpiderDebug.log("tmdb-prefetch", "season warm season=%d count=%d cost=%dms", target, episodes.size(), System.currentTimeMillis() - start);
+            } catch (CancellationException ignored) {
+                // 预热是纯优化，取消无需处理。
+            } catch (Throwable e) {
+                SpiderDebug.log("tmdb-prefetch", "season warm failed error=%s", e.getMessage());
+            }
+        });
+    }
+
+    /**
+     * 猜测预热哪一季。prefetch 早于 captureSourceSeason，季解析还没跑，所以只能用 Intent
+     * 指定的季号，没有时退化为唯一正片季（单季剧最常见）。返回 < 0 表示证据不足，不猜。
+     */
+    static int likelySeasonNumber(JsonObject detail, int intentSeason) {
+        List<SeasonOption> options = parseSeasonOptions(detail);
+        if (options.isEmpty()) return -1;
+        int target = intentSeason;
+        if (target < 0) {
+            List<Integer> ordinary = new ArrayList<>();
+            for (SeasonOption option : options) if (option.getSeasonNumber() > 0) ordinary.add(option.getSeasonNumber());
+            if (ordinary.size() != 1) return -1;
+            target = ordinary.get(0);
+        }
+        for (SeasonOption option : options) if (option.getSeasonNumber() == target) return target;
+        return -1;
+    }
+
+    private int intentSeasonNumber() {
+        if (activity == null || activity.getIntent() == null) return -1;
+        int requested = activity.getIntent().getIntExtra("tmdb_play_season_number", -1);
+        if (requested >= 0) return requested;
+        return EpisodeSeasonPolicy.resolveSourceSeason(activityIntentTitle());
     }
 
     private String prefetchStateText(TmdbDetailPrefetch.StartState state) {
@@ -656,6 +734,8 @@ public class TmdbUIAdapter {
         App.removeCallbacks(pendingVodRefresh);
         if (pendingStartupBackgroundLoads != null) App.removeCallbacks(pendingStartupBackgroundLoads);
         pendingStartupBackgroundLoads = null;
+        if (pendingStartupEpisodeLoad != null) App.removeCallbacks(pendingStartupEpisodeLoad);
+        pendingStartupEpisodeLoad = null;
         return generation;
     }
 
@@ -1232,20 +1312,11 @@ public class TmdbUIAdapter {
     }
 
     private void scheduleStartupBackgroundLoads(Vod vod, TmdbItem item, JsonObject detail, int generation) {
+        scheduleStartupEpisodeLoad(vod, item, generation);
         if (pendingStartupBackgroundLoads != null) App.removeCallbacks(pendingStartupBackgroundLoads);
         pendingStartupBackgroundLoads = () -> {
             if (!isCurrentGeneration(generation)) return;
             SpiderDebug.log("tmdb", "startup background loads begin title=%s delay=%dms", item == null ? "" : item.getTitle(), TMDB_STARTUP_BACKGROUND_DELAY_MS);
-            if (vod != null && item != null && item.isTv()) {
-                int metadataGeneration = ++episodeMetadataGeneration;
-                Integer selectedSeason = currentEpisodeMetadataSeason();
-                episodeMetadataLoaded = false;
-                if (selectedSeason == null && !isMultiSliceResolution()) {
-                    finishEpisodeMetadataLoad(vod, generation, metadataGeneration, null);
-                } else {
-                    loadEpisodeTitlesAsync(vod, item, generation, metadataGeneration, selectedSeason);
-                }
-            }
             loadRelatedVideosAsync(sourceSeasonNumber, -1);
             loadRelatedRecommendationsAsync(vod, item, detail, generation);
             loadPersonalRecommendationsAsync(vod, item, detail, generation);
@@ -1253,9 +1324,28 @@ public class TmdbUIAdapter {
         App.post(pendingStartupBackgroundLoads, TMDB_STARTUP_BACKGROUND_DELAY_MS);
     }
 
+    // 选集元数据单独排程且不延迟：它决定「正在加载剧集信息...」占位符何时消失。
+    private void scheduleStartupEpisodeLoad(Vod vod, TmdbItem item, int generation) {
+        if (pendingStartupEpisodeLoad != null) App.removeCallbacks(pendingStartupEpisodeLoad);
+        pendingStartupEpisodeLoad = () -> {
+            if (!isCurrentGeneration(generation)) return;
+            SpiderDebug.log("tmdb", "startup episode load begin title=%s delay=%dms", item == null ? "" : item.getTitle(), TMDB_STARTUP_EPISODE_DELAY_MS);
+            if (vod == null || item == null || !item.isTv()) return;
+            int metadataGeneration = ++episodeMetadataGeneration;
+            Integer selectedSeason = currentEpisodeMetadataSeason();
+            episodeMetadataLoaded = false;
+            if (selectedSeason == null && !isMultiSliceResolution()) {
+                finishEpisodeMetadataLoad(vod, generation, metadataGeneration, null);
+            } else {
+                loadEpisodeTitlesAsync(vod, item, generation, metadataGeneration, selectedSeason);
+            }
+        };
+        App.post(pendingStartupEpisodeLoad, TMDB_STARTUP_EPISODE_DELAY_MS);
+    }
+
     private void loadEpisodeTitlesAsync(Vod vod, TmdbItem item, int generation, int metadataGeneration, Integer selectedSeason) {
         if (vod == null || item == null || !item.isTv()) return;
-        backgroundTasks.submit(() -> {
+        episodeTasks.submit(() -> {
             if (!isCurrentEpisodeMetadataRequest(generation, metadataGeneration, selectedSeason)) return;
             long start = System.currentTimeMillis();
             boolean changed = selectedSeason != null
@@ -1404,6 +1494,32 @@ public class TmdbUIAdapter {
         if (!isCurrentEpisodeMetadataRequest(generation, metadataGeneration, selectedSeason)) return;
         episodeMetadataLoaded = true;
         notifyVodChanged(vod, generation, RefreshEvent.Type.VOD_EPISODE_TITLES);
+    }
+
+    /**
+     * 取某季集数，优先命中进程内缓存。缓存未命中才走 TmdbService（磁盘缓存 / 网络）。
+     * 空结果不写缓存，避免把一次失败固化成整个会话的空列表。
+     *
+     * 缓存生命周期绑定一次详情请求：由 beginDetailRequest() 清空（在 prefetch 预热之前），
+     * 所以既不会挡住强制刷新，也不会被 load() 冲掉预热结果。MAX_CACHED_SEASONS 只是
+     * 防御多季剧反复切季时的无界增长。
+     */
+    private List<TmdbEpisode> seasonEpisodes(TmdbItem item, int seasonNumber) throws Exception {
+        if (item == null || seasonNumber < 0) return List.of();
+        String key = item.getTmdbId() + "|" + item.getMediaType() + "|" + seasonNumber;
+        List<TmdbEpisode> cached = seasonEpisodeCache.get(key);
+        if (cached != null) {
+            SpiderDebug.log("tmdb", "season episodes source=memory season=%d count=%d", seasonNumber, cached.size());
+            return cached;
+        }
+        JsonObject season = tmdbService.season(item, seasonNumber, tmdbConfig);
+        if (season == null) return List.of();
+        List<TmdbEpisode> episodes = tmdbService.episodes(season, tmdbConfig, item.getTmdbId(), seasonNumber);
+        if (!episodes.isEmpty()) {
+            if (seasonEpisodeCache.size() >= MAX_CACHED_SEASONS) seasonEpisodeCache.clear();
+            seasonEpisodeCache.put(key, List.copyOf(episodes));
+        }
+        return episodes;
     }
 
     private Integer currentEpisodeMetadataSeason() {
@@ -1572,10 +1688,7 @@ public class TmdbUIAdapter {
         if (vod == null || item == null || vod.getFlags() == null) return false;
         if (!isCurrentEpisodeMetadataRequest(generation, metadataGeneration, selectedSeason)) return false;
         try {
-            JsonObject season = tmdbService.season(item, selectedSeason, tmdbConfig);
-            if (season == null) return false;
-
-            List<TmdbEpisode> episodes = tmdbService.episodes(season, tmdbConfig, item.getTmdbId(), selectedSeason);
+            List<TmdbEpisode> episodes = seasonEpisodes(item, selectedSeason);
             if (episodes.isEmpty()) return false;
             Map<Integer, TmdbEpisode> episodesByNumber = indexEpisodesByNumber(episodes);
 
@@ -1604,9 +1717,9 @@ public class TmdbUIAdapter {
         try {
             for (Integer season : seasons) {
                 if (!isCurrentEpisodeMetadataRequest(generation, metadataGeneration, null)) return false;
-                JsonObject detail = tmdbService.season(item, season, tmdbConfig);
-                if (detail == null) return false;
-                episodesBySeason.put(season, indexEpisodesByNumber(tmdbService.episodes(detail, tmdbConfig, item.getTmdbId(), season)));
+                List<TmdbEpisode> seasonItems = seasonEpisodes(item, season);
+                if (seasonItems.isEmpty()) return false;
+                episodesBySeason.put(season, indexEpisodesByNumber(seasonItems));
             }
             synchronized (episodeMetadataLock) {
                 if (!isCurrentEpisodeMetadataRequest(generation, metadataGeneration, null)) return false;

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
@@ -1,5 +1,8 @@
 package com.fongmi.android.tv.ui.activity;
 
+import com.fongmi.android.tv.bean.Episode;
+import com.fongmi.android.tv.ui.helper.EpisodeDisplayPolicy;
+
 import org.junit.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -17,6 +20,7 @@ import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -1378,7 +1382,7 @@ public class VideoActivityLayoutTest {
     }
 
     @Test
-    public void leanbackFastTmdbPlaybackKeepsEpisodesHiddenUntilEpisodeMetadataFinishes() throws Exception {
+    public void leanbackScrapedEpisodesRenderBeforeTmdbMetadataFinishes() throws Exception {
         Path sourcePath = findLeanbackJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"));
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
         int setEpisode = source.indexOf("private void setEpisodeAdapter(List<Episode> items, boolean scrollToCurrent)");
@@ -1388,7 +1392,10 @@ public class VideoActivityLayoutTest {
         int pending = body.indexOf("boolean tmdbEpisodeEnrichmentPending = !mTmdbEpisodeFallbackReleased", metadata);
         int pendingCondition = body.indexOf("&& (mTmdbDetailLoading || (tmdbAdapterReady && !tmdbEpisodeMetadataLoaded));", pending);
         int wait = body.indexOf("EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(tmdbMode, tmdbEpisodeEnrichmentPending, tmdbAdapterReady, tmdbEpisodeMetadataLoaded, items);", pendingCondition);
-        int hide = body.indexOf("setEpisodeContentVisible(false);", wait);
+        // 网格模式必须跟随「真有卡片数据」，否则纯文本项会被塞进按卡片宽度算 spanCount 的
+        // 网格，而 episodeViewMode 按钮此时因 useTmdbCards=false 隐藏，用户切不回列表。
+        int gridFollowsCards = body.indexOf("if (useTmdbCards && hasMultiple) episodeGridMode = Setting.getTmdbEpisodeGridMode();", wait);
+        int gridResetFollowsCards = body.indexOf("if (!useTmdbCards || !hasMultiple) episodeGridMode = false;", gridFollowsCards);
         int finishLoading = source.indexOf("private void finishEpisodeLoading()");
         int refreshTitles = source.indexOf("private void refreshEpisodeTitles()", finishLoading);
         String finishBody = finishLoading >= 0 && refreshTitles > finishLoading ? source.substring(finishLoading, refreshTitles) : "";
@@ -1396,9 +1403,39 @@ public class VideoActivityLayoutTest {
 
         assertTrue(sourcePath + " is missing setEpisodeAdapter", setEpisode >= 0);
         assertTrue("native-enhanced playback must track episode metadata separately from core TMDB detail", metadata >= 0);
-        assertTrue("the episode area must remain pending after core detail loads but before episode metadata finishes", pending > metadata && pendingCondition > pending && wait > pendingCondition);
-        assertTrue("the temporary native text row must stay hidden while TMDB episode enrichment is pending", hide > wait);
+        assertTrue("the episode area must still know enrichment is pending after core detail loads", pending > metadata && pendingCondition > pending && wait > pendingCondition);
+        assertTrue("episode grid mode must follow real TMDB card data, not chrome visibility", gridFollowsCards > wait && gridResetFollowsCards > gridFollowsCards);
+        // 隐藏选集只允许发生在 waitTmdbEpisodes 分支里，而该分支的条件由 EpisodeDisplayPolicy
+        // 收窄为「一集都没有」。用真实的策略调用来断言，而不是匹配源码缩进（文件是 CRLF，
+        // 带 \n 的字面量匹配会恒假，成为空断言）。
+        assertFalse("scraped episodes must render instead of being hidden while enrichment is pending",
+                EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(true, true, true, false, List.of(Episode.create("第1集", "u1"))));
+        assertTrue("with no episode at all the placeholder is still the only thing to show",
+                EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(true, true, true, false, List.of()));
+        assertEquals("hiding the episode content must remain confined to the wait branch", 1, countOccurrences(body, "setEpisodeContentVisible(false);"));
         assertTrue("core TMDB completion must not trigger the plain-list fallback while episode metadata is still loading", metadataGuard >= 0);
+    }
+
+    private static int countOccurrences(String text, String token) {
+        int count = 0;
+        for (int at = text.indexOf(token); at >= 0; at = text.indexOf(token, at + token.length())) count++;
+        return count;
+    }
+
+    @Test
+    public void leanbackTmdbCardUpgradeHasSingleRefreshPath() throws Exception {
+        Path sourcePath = findLeanbackJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int updateFlag = source.indexOf("private void updateFlag(Flag activated, List<Flag> items)");
+        int nextMethod = source.indexOf("\n    private final PlaybackService.NavigationCallback", updateFlag);
+        String body = updateFlag >= 0 && nextMethod > updateFlag ? source.substring(updateFlag, nextMethod) : "";
+
+        assertTrue(sourcePath + " is missing updateFlag", updateFlag >= 0);
+        assertTrue("the activated line must rebind episodes so TMDB cards replace the plain text rows",
+                body.contains("if (target.equals(activated)) setEpisodeAdapter(target.getEpisodes());"));
+        // 占位符只在「一集都没有」时可见，与「已有卡片数据」互斥，那条淡入分支已无法命中。
+        assertFalse("the unreachable placeholder fade-in branch must not come back",
+                body.contains("mBinding.episodeLoadingIndicator.getVisibility() == View.VISIBLE"));
     }
 
     @Test
@@ -1415,9 +1452,9 @@ public class VideoActivityLayoutTest {
         int terminalCancel = source.indexOf("if (tmdbEpisodeMetadataLoaded) App.removeCallbacks(mTmdbEpisodeTimeout);", setEpisode);
         int fallbackAwarePending = source.indexOf("boolean tmdbEpisodeEnrichmentPending = !mTmdbEpisodeFallbackReleased", setEpisode);
         int fallback = source.indexOf("private void showTmdbEpisodeFallback()");
-        int indicatorGuard = source.indexOf("mBinding.episodeLoadingIndicator.getVisibility() != View.VISIBLE", fallback);
-        int release = source.indexOf("mTmdbEpisodeFallbackReleased = true;", indicatorGuard);
-        int finish = source.indexOf("finishEpisodeLoading();", release);
+        int metadataShortCircuit = source.indexOf("if (mTmdbUIAdapter.isEpisodeMetadataLoaded())", fallback);
+        int release = source.indexOf("mTmdbEpisodeFallbackReleased = true;", metadataShortCircuit);
+        int indicatorBranch = source.indexOf("if (mBinding.episodeLoadingIndicator.getVisibility() == View.VISIBLE) finishEpisodeLoading();", release);
         int finishMethod = source.indexOf("private void finishEpisodeLoading()");
         int allowTimedFallback = source.indexOf("&& !mTmdbEpisodeFallbackReleased", finishMethod);
         int destroy = source.indexOf("protected void onDestroy()");
@@ -1427,8 +1464,10 @@ public class VideoActivityLayoutTest {
         assertTrue("each enhanced detail load must reset and schedule the episode fallback", reset > setDetail && schedule > reset);
         assertTrue("completed episode metadata must cancel the fallback timer", terminalCancel > setEpisode);
         assertTrue("once timeout fallback is released, later core-detail refreshes must not hide the native list again", fallbackAwarePending > terminalCancel);
-        assertTrue("the timeout must only release a visible placeholder, then reveal the native episode list",
-                fallback >= 0 && indicatorGuard > fallback && release > indicatorGuard && finish > release);
+        // 选集现在先上屏，占位符只在「一集都没有」时出现，所以超时不能再以占位符可见为前提：
+        // 必须无条件置位 fallbackReleased 让表头收起，再按占位符是否可见决定走哪条揭开路径。
+        assertTrue("the timeout must release the pending flag regardless of placeholder visibility, then reveal the native episode list",
+                fallback >= 0 && metadataShortCircuit > fallback && release > metadataShortCircuit && indicatorBranch > release);
         assertTrue("finishEpisodeLoading must allow the explicit timeout fallback through its metadata guard", allowTimedFallback > finishMethod);
         assertTrue("episode timeout callback must be removed when the activity is destroyed", destroyCancel > destroy);
     }
@@ -1979,7 +2018,7 @@ public class VideoActivityLayoutTest {
                 span >= 0
                         && activity.indexOf("return TmdbEpisodeGridPolicy.tvAdaptiveSpanCount(getResources().getConfiguration().screenWidthDp);", span) > span
                         && setEpisode >= 0
-                        && activity.indexOf("if (showTmdbEpisodeChrome && hasMultiple) episodeGridMode = Setting.getTmdbEpisodeGridMode();", setEpisode) > setEpisode
+                        && activity.indexOf("if (useTmdbCards && hasMultiple) episodeGridMode = Setting.getTmdbEpisodeGridMode();", setEpisode) > setEpisode
                         && activity.indexOf("mBinding.episodeViewMode.setVisibility(showTmdbEpisodeChrome && hasMultiple && useTmdbCards ? View.VISIBLE : View.GONE);", setEpisode) > setEpisode
                         && toggle >= 0
                         && activity.indexOf("if (mBinding.episodeViewMode.getVisibility() != View.VISIBLE) return;", toggle) > toggle

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/helper/EpisodeDisplayPolicyTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/helper/EpisodeDisplayPolicyTest.java
@@ -28,9 +28,17 @@ public class EpisodeDisplayPolicyTest {
     }
 
     @Test
-    public void tmdbModeWhileLoading_canShowTemporaryLoadingChrome() {
-        assertTrue(EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(true, true, true, false, Collections.singletonList(nativeEpisode())));
+    public void tmdbModeWhileLoading_showsScrapedEpisodesImmediatelyWithLoadingChrome() {
+        // 站源集数已可渲染时不再等 TMDB：先出纯文本列表，卡片随后原地替换。
+        assertFalse(EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(true, true, true, false, Collections.singletonList(nativeEpisode())));
         assertTrue(EpisodeDisplayPolicy.shouldShowTmdbEpisodeChrome(true, true, Collections.singletonList(nativeEpisode())));
+    }
+
+    @Test
+    public void tmdbModeWhileLoadingWithoutAnyEpisode_stillShowsPlaceholder() {
+        // 一集都还没有时占位符仍是唯一能显示的东西。
+        assertTrue(EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(true, true, true, false, Collections.emptyList()));
+        assertTrue(EpisodeDisplayPolicy.shouldWaitForTmdbEpisodes(true, true, true, false, null));
     }
 
     @Test

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapterTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapterTest.java
@@ -8,6 +8,8 @@ import com.fongmi.android.tv.bean.TmdbSeasonMatchCache;
 import com.fongmi.android.tv.bean.TmdbSeasonScope;
 import com.fongmi.android.tv.bean.Vod;
 import com.fongmi.android.tv.utils.Task;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonObject;
 
 import org.junit.Test;
 
@@ -426,12 +428,18 @@ public class TmdbUIAdapterTest {
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
         int constants = source.indexOf("VOD_REFRESH_COALESCE_MS");
         int backgroundDelay = source.indexOf("TMDB_STARTUP_BACKGROUND_DELAY_MS", constants);
-        int firstRefresh = source.indexOf("notifyVodChanged(vod, generation, RefreshEvent.Type.VOD_CORE);", backgroundDelay);
+        int episodeDelay = source.indexOf("TMDB_STARTUP_EPISODE_DELAY_MS", backgroundDelay);
+        int firstRefresh = source.indexOf("notifyVodChanged(vod, generation, RefreshEvent.Type.VOD_CORE);", episodeDelay);
         int deferredLoads = source.indexOf("scheduleStartupBackgroundLoads(vod, item, detail, generation);", firstRefresh);
         int scheduler = source.indexOf("private void scheduleStartupBackgroundLoads", deferredLoads);
-        int episode = source.indexOf("loadEpisodeTitlesAsync(vod, item, generation, metadataGeneration, selectedSeason);", scheduler);
-        int related = source.indexOf("loadRelatedRecommendationsAsync(vod, item, detail, generation);", episode);
+        // 选集不排在 1200ms 之后：它是首屏内容，单独立刻排程。
+        int episodeScheduleCall = source.indexOf("scheduleStartupEpisodeLoad(vod, item, generation);", scheduler);
+        int related = source.indexOf("loadRelatedRecommendationsAsync(vod, item, detail, generation);", episodeScheduleCall);
         int personal = source.indexOf("loadPersonalRecommendationsAsync(vod, item, detail, generation);", related);
+        int backgroundPost = source.indexOf("App.post(pendingStartupBackgroundLoads, TMDB_STARTUP_BACKGROUND_DELAY_MS);", personal);
+        int episodeScheduler = source.indexOf("private void scheduleStartupEpisodeLoad", backgroundPost);
+        int episode = source.indexOf("loadEpisodeTitlesAsync(vod, item, generation, metadataGeneration, selectedSeason);", episodeScheduler);
+        int episodePost = source.indexOf("App.post(pendingStartupEpisodeLoad, TMDB_STARTUP_EPISODE_DELAY_MS);", episode);
         int notify = source.indexOf("private void notifyVodChanged");
         int pending = source.indexOf("pendingVodRefresh", notify);
         int post = source.indexOf("App.post(pendingVodRefresh, VOD_REFRESH_COALESCE_MS);", pending);
@@ -440,15 +448,72 @@ public class TmdbUIAdapterTest {
         int personalMethod = source.indexOf("private void loadPersonalRecommendationsAsync");
         int personalNotify = source.indexOf("notifyVodChanged(vod, generation, RefreshEvent.Type.VOD_PERSONAL);", personalMethod);
 
-        assertTrue(sourcePath + " is missing TMDB playback refresh throttle constants", constants >= 0 && backgroundDelay > constants);
+        assertTrue(sourcePath + " is missing TMDB playback refresh throttle constants", constants >= 0 && backgroundDelay > constants && episodeDelay > backgroundDelay);
         assertTrue("TMDB detail should queue one lightweight VOD refresh before deferred background work",
-                firstRefresh > backgroundDelay && deferredLoads > firstRefresh);
-        assertTrue("episode titles and recommendation loads should start after the first-frame delay",
-                scheduler > deferredLoads && episode > scheduler && related > episode && personal > related);
+                firstRefresh > episodeDelay && deferredLoads > firstRefresh);
+        assertTrue("recommendation loads should stay behind the first-frame delay",
+                scheduler > deferredLoads && related > episodeScheduleCall && personal > related && backgroundPost > personal);
+        assertTrue("episode titles must be scheduled without the first-frame delay so the episode list is not gated on it",
+                episodeScheduleCall > scheduler && episodeScheduler > backgroundPost && episode > episodeScheduler && episodePost > episode);
         assertTrue("VOD refreshes should be coalesced on the main thread instead of posting every async result",
                 notify >= 0 && pending > notify && post > pending);
         assertTrue("related and personal recommendation completion should reuse the coalesced VOD refresh path",
                 relatedNotify > relatedMethod && personalNotify > personalMethod);
+    }
+
+    @Test
+    public void seasonWarmUpOnlyGuessesWhenEvidenceIsUnambiguous() {
+        JsonObject multiSeason = detailWithSeasons("[{\"season_number\":0},{\"season_number\":1},{\"season_number\":2}]");
+        JsonObject singleSeason = detailWithSeasons("[{\"season_number\":0},{\"season_number\":1}]");
+
+        // 多季且没有 Intent 季号：证据不足，不猜，避免白拉一整季。
+        assertEquals(-1, TmdbUIAdapter.likelySeasonNumber(multiSeason, -1));
+        // 单一正片季：可以放心预热。
+        assertEquals(1, TmdbUIAdapter.likelySeasonNumber(singleSeason, -1));
+        // Intent 指定的季号优先，但必须真的存在于 TMDB。
+        assertEquals(2, TmdbUIAdapter.likelySeasonNumber(multiSeason, 2));
+        assertEquals(-1, TmdbUIAdapter.likelySeasonNumber(multiSeason, 9));
+        assertEquals(-1, TmdbUIAdapter.likelySeasonNumber(detailWithSeasons("[]"), 1));
+    }
+
+    private static JsonObject detailWithSeasons(String seasonsJson) {
+        return JsonParser.parseString("{\"seasons\":" + seasonsJson + "}").getAsJsonObject();
+    }
+
+    @Test
+    public void episodeLoadsUseTheirOwnWidePoolAndCacheIsScopedToOneDetailRequest() throws Exception {
+        Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "helper", "TmdbUIAdapter.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        // recommendationExecutor 只有 3 条线程，推荐 / 个性化 / AI 推荐都在里面。选集不再延迟后
+        // 若继续共用会排在推荐后面，反而更慢，所以必须走 largeExecutor。
+        int episodeScope = source.indexOf("this.episodeTasks = new Task.Scope(Task.largeExecutor());");
+        int episodeSubmit = source.indexOf("episodeTasks.submit(", episodeScope);
+        int beginRequest = source.indexOf("public void beginDetailRequest()");
+        int cancelEpisodes = source.indexOf("episodeTasks.cancelAll();", beginRequest);
+        // 季缓存必须在 beginDetailRequest 清空：它在 prefetch 预热之前调用，所以既不会挡住
+        // 强制刷新，也不会冲掉预热结果。放到 resetLoadState 会被 load() 冲掉预热。
+        int clearCache = source.indexOf("seasonEpisodeCache.clear();", cancelEpisodes);
+        int releaseMethod = source.indexOf("public void release()");
+        int closeEpisodes = source.indexOf("episodeTasks.close();", releaseMethod);
+        int resetMethod = source.indexOf("private int resetLoadState()");
+        int resetEnd = source.indexOf("\n    private void captureSourceSeason", resetMethod);
+        String resetBody = resetMethod >= 0 && resetEnd > resetMethod ? source.substring(resetMethod, resetEnd) : "";
+        int prefetchMethod = source.indexOf("public void prefetch(TmdbItem item)");
+        int prefetchEnd = source.indexOf("\n    /**", prefetchMethod);
+        String prefetchBody = prefetchMethod >= 0 && prefetchEnd > prefetchMethod ? source.substring(prefetchMethod, prefetchEnd) : "";
+
+        assertTrue("episode metadata must not share the 3-thread recommendation pool", episodeScope >= 0 && episodeSubmit > episodeScope);
+        assertTrue("a new detail request must cancel in-flight episode work", cancelEpisodes > beginRequest);
+        assertTrue("the season memory cache must be cleared per detail request so refresh is not shadowed", clearCache > cancelEpisodes);
+        assertTrue("destroying the adapter must close the episode scope", closeEpisodes > releaseMethod);
+        assertFalse("clearing the season cache in resetLoadState would discard the prefetch warm-up", resetBody.contains("seasonEpisodeCache.clear();"));
+        // 季预热若同步跑在 prefetch 的 Callable 里，会阻塞 future，进而延后 loadDetailSync
+        // 和整个详情页首屏——那正好和优化目标相反。
+        assertTrue("the season warm-up must be dispatched asynchronously", prefetchBody.contains("warmLikelySeasonAsync(loadedItem, detail, intentSeason);"));
+        assertFalse("the season warm-up must not block the prefetch future", prefetchBody.contains("seasonEpisodes(loadedItem"));
+        // Intent 内部是非线程安全的 Bundle，主线程会并发改它，季号必须在主线程算好再传进去。
+        assertTrue("the intent season must be read on the calling thread, not inside the background callable",
+                prefetchBody.indexOf("int intentSeason = intentSeasonNumber();") < prefetchBody.indexOf("detailPrefetch.start("));
     }
 
     @Test


### PR DESCRIPTION
原生增强模式下选集区域会停在「正在加载剧集信息...」很久，TMDB 磁盘缓存
命中也一样，退出重进依旧。原因是两道与缓存无关的阻塞：

1. 选集元数据被排在 1200ms 的启动延迟之后，缓存再快也没用——请求还没发出。 拆出 scheduleStartupEpisodeLoad 立即发起，推荐/个性化仍延后给首帧让路。
2. 站源集数已经拿到，却因为还没有 TMDB 元数据而把整个列表隐藏，最长等 15 秒。 改为只在一集都没有时才占位，纯文本选集先上屏，卡片到达后原地替换。

并顺带补上两处让缓存真正生效的改动：

3. prefetch 只拉 detail+cast，不含选集卡片真正需要的 season。新增季预热， 跑在独立任务里，避免阻塞 prefetch future 反而延后详情首屏。
4. 新增季级进程内缓存，切季/切线路不再重复读盘并解析整季 JSON。缓存在 beginDetailRequest 清空，既不挡强制刷新，也不冲掉预热结果。

配套修正：
- 选集元数据改用独立的 largeExecutor 线程池。原先与推荐共用只有 3 条线程的 recommendationExecutor，取消延迟后选集会排在推荐后面，反而更慢。
- 网格模式改为跟随「真有卡片数据」而非表头可见性。否则纯文本项会被塞进按 卡片宽度算 spanCount 的网格，且切换按钮此时隐藏，用户切不回列表。
- 超时回退不再以占位符可见为前提，否则 fallbackReleased 永不置位，TMDB 匹配失败时表头会永久挂着。
- 预热的季号在主线程从 Intent 读出后传入，不在后台线程访问 Bundle。
- 删除 updateFlag 中已无法命中的占位符淡入分支及其失去调用者的辅助方法。

测试：更新被行为变更影响的断言，新增防回归守卫（线程池归属、缓存清理时机、
预热不阻塞 future、网格判据、卡片升级路径），并为 likelySeasonNumber 补真 正的纯函数单测。守卫断言均已通过「重新引入 bug 时会失败」验证。