### PR TITLE
修复：播放核心选择丢失的外调选项

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/CastActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/CastActivity.java
@@ -216,28 +216,15 @@ public class CastActivity extends PlaybackActivity implements CustomKeyDownVod.L
         start();
     }
 
-    private void onChoose() {
-        if (player().isEmpty()) return;
-        String[] kernel = ResUtil.getStringArray(R.array.select_player_kernel);
-        String[] items = new String[kernel.length + 1];
-        System.arraycopy(kernel, 0, items, 0, kernel.length);
-        items[kernel.length] = "外调";
-        new androidx.appcompat.app.AlertDialog.Builder(this).setItems(items, (dialog, which) -> {
-            if (which < kernel.length) {
-                position = player().getPosition();
-                player().switchPlayerManually(which);
-                setPlayerKernel();
-                setDecode();
-            } else {
-                PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.widget.title.getText());
-                setRedirect(true);
-            }
-        }).show();
-    }
-
     private void onPlayerKernel() {
         if (player().isEmpty()) return;
-        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel);
+        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel, this::onExternalPlayer);
+    }
+
+    private void onExternalPlayer() {
+        if (player().isEmpty()) return;
+        PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.widget.title.getText());
+        setRedirect(true);
     }
 
     private boolean onPlayerKernelLong() {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
@@ -476,25 +476,13 @@ public class LiveActivity extends PlaybackActivity implements GroupAdapter.OnCli
         mBinding.control.action.change.setSelected(LiveSetting.isChange());
     }
 
-    private void onChoose() {
-        String[] kernel = ResUtil.getStringArray(R.array.select_player_kernel);
-        String[] items = new String[kernel.length + 1];
-        System.arraycopy(kernel, 0, items, 0, kernel.length);
-        items[kernel.length] = "外调";
-        new androidx.appcompat.app.AlertDialog.Builder(this).setItems(items, (dialog, which) -> {
-            if (which < kernel.length) {
-                player().switchPlayerManually(which);
-                setPlayerKernel();
-                setDecode();
-            } else {
-                PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.widget.title.getText());
-                setRedirect(true);
-            }
-        }).show();
+    private void onPlayerKernel() {
+        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel, this::onExternalPlayer);
     }
 
-    private void onPlayerKernel() {
-        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel);
+    private void onExternalPlayer() {
+        PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.widget.title.getText());
+        setRedirect(true);
     }
 
     private void switchPlayerKernel(int type) {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -1360,7 +1360,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         mBinding.control.action.reset.setOnClickListener(guarded(this::onReset));
         mBinding.control.action.title.setOnClickListener(guarded(this::onTitle));
         mBinding.control.action.player.setOnClickListener(guarded(this::onPlayerKernel));
-        mBinding.control.action.player.setOnLongClickListener(view -> onChooseLong());
+        mBinding.control.action.player.setOnLongClickListener(view -> onPlayerKernelLong());
         mBinding.control.action.decode.setOnClickListener(guarded(this::onDecode));
         mBinding.control.action.playParams.setOnClickListener(guarded(this::onPlayParams));
         mBinding.control.action.multiThreadProxy.setOnClickListener(guarded(this::onMultiThreadProxy));
@@ -3797,26 +3797,14 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         syncHistory();
     }
 
-    private void onChoose() {
-        String[] kernel = ResUtil.getStringArray(R.array.select_player_kernel);
-        String[] items = Arrays.copyOf(kernel, kernel.length + 1);
-        items[kernel.length] = "外调";
-        new androidx.appcompat.app.AlertDialog.Builder(this).setItems(items, (dialog, which) -> {
-            if (which < kernel.length) {
-                clearLyrics();
-                player().switchPlayerManually(which);
-                setPlayer();
-                setDecode();
-            } else {
-                PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.widget.title.getText());
-                setRedirect(true);
-            }
-        }).show();
-    }
-
     private void onPlayerKernel() {
         if (playerKernelSwitchRefreshing) return;
-        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel);
+        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel, this::onExternalPlayer);
+    }
+
+    private void onExternalPlayer() {
+        PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.widget.title.getText());
+        setRedirect(true);
     }
 
     private void switchPlayerKernel(int type) {
@@ -8682,11 +8670,6 @@ public void onLutSelected(LutPreset preset) {
         else player().applyLutPreview(true);
         setLut();
         setR1Callback();
-    }
-
-private boolean onChooseLong() {
-        onChoose();
-        return true;
     }
 
     private void setTraffic() {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -8022,7 +8022,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         if (service() == null || player().isEmpty()) return false;
         String[] kernels = ResUtil.getStringArray(R.array.select_player_kernel);
         String[] items = Arrays.copyOf(kernels, kernels.length + 1);
-        items[kernels.length] = "外调";
+        items[kernels.length] = getString(R.string.player_kernel_external);
         new MaterialAlertDialogBuilder(this).setItems(items, (dialog, which) -> onInlinePlayerChoice(kernels, which)).show();
         return true;
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/PlayerKernelDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/PlayerKernelDialog.java
@@ -6,26 +6,55 @@ import androidx.fragment.app.FragmentActivity;
 import com.fongmi.android.tv.R;
 import com.fongmi.android.tv.setting.PlayerSetting;
 
+import java.util.Arrays;
+
 public final class PlayerKernelDialog {
 
     public interface Listener {
         void onSelected(int player);
     }
 
+    public interface ExternalListener {
+        void onExternal();
+    }
+
     private PlayerKernelDialog() {
     }
 
     public static void show(FragmentActivity activity, int selected, Listener listener) {
+        show(activity, selected, listener, null);
+    }
+
+    public static void show(FragmentActivity activity, int selected, Listener listener, ExternalListener external) {
         int current = PlayerSetting.sanitizePlayer(selected);
-        ChoiceDialog.showSingleNoCancel(activity, R.string.player_kernel, activity.getResources().getStringArray(R.array.select_player_kernel), current, which -> notifySelected(current, which, listener));
+        String[] kernel = activity.getResources().getStringArray(R.array.select_player_kernel);
+        String[] items = withExternal(kernel, external, activity.getString(R.string.player_kernel_external));
+        ChoiceDialog.showSingleNoCancel(activity, R.string.player_kernel, items, current, which -> notifySelected(kernel.length, current, which, listener, external));
     }
 
     public static void show(Fragment fragment, int selected, Listener listener) {
-        int current = PlayerSetting.sanitizePlayer(selected);
-        ChoiceDialog.showSingleNoCancel(fragment, R.string.player_kernel, fragment.getResources().getStringArray(R.array.select_player_kernel), current, which -> notifySelected(current, which, listener));
+        show(fragment, selected, listener, null);
     }
 
-    private static void notifySelected(int current, int selected, Listener listener) {
+    public static void show(Fragment fragment, int selected, Listener listener, ExternalListener external) {
+        int current = PlayerSetting.sanitizePlayer(selected);
+        String[] kernel = fragment.getResources().getStringArray(R.array.select_player_kernel);
+        String[] items = withExternal(kernel, external, fragment.getString(R.string.player_kernel_external));
+        ChoiceDialog.showSingleNoCancel(fragment, R.string.player_kernel, items, current, which -> notifySelected(kernel.length, current, which, listener, external));
+    }
+
+    private static String[] withExternal(String[] kernel, ExternalListener external, String label) {
+        if (external == null) return kernel;
+        String[] items = Arrays.copyOf(kernel, kernel.length + 1);
+        items[kernel.length] = label;
+        return items;
+    }
+
+    private static void notifySelected(int count, int current, int selected, Listener listener, ExternalListener external) {
+        if (external != null && selected >= count) {
+            external.onExternal();
+            return;
+        }
         int target = PlayerSetting.sanitizePlayer(selected);
         if (target != current && listener != null) listener.onSelected(target);
     }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1130,6 +1130,7 @@
     <string name="pan_diagnostic_entry">链路诊断</string>
     <string name="pan_diagnostic_title">播放链路诊断</string>
     <string name="player_kernel">播放器内核</string>
+    <string name="player_kernel_external">外调</string>
     <string name="player_scale">缩放比例</string>
     <string name="player_lut">LUT 调色</string>
     <string name="player_mpv_config">MPV 配置管理</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1089,6 +1089,7 @@
     <string name="pan_diagnostic_entry">鏈路診斷</string>
     <string name="pan_diagnostic_title">播放鏈路診斷</string>
     <string name="player_kernel">播放器內核</string>
+    <string name="player_kernel_external">外調</string>
     <string name="player_scale">縮放比例</string>
     <string name="player_lut">LUT 調色</string>
     <string name="player_mpv_config">MPV 設定管理</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1133,6 +1133,7 @@
     <string name="pan_diagnostic_entry">Link test</string>
     <string name="pan_diagnostic_title">Playback link diagnostics</string>
     <string name="player_kernel">Player engine</string>
+    <string name="player_kernel_external">External</string>
     <string name="player_scale">Scale</string>
     <string name="player_lut">LUT color</string>
     <string name="player_mpv_config">MPV config manager</string>

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
@@ -817,25 +817,13 @@ public class LiveActivity extends PlaybackActivity implements CustomKeyDown.List
         setDecode();
     }
 
-    private void onChoose() {
-        String[] kernel = ResUtil.getStringArray(R.array.select_player_kernel);
-        String[] items = new String[kernel.length + 1];
-        System.arraycopy(kernel, 0, items, 0, kernel.length);
-        items[kernel.length] = "外调";
-        new com.google.android.material.dialog.MaterialAlertDialogBuilder(this).setItems(items, (dialog, which) -> {
-            if (which < kernel.length) {
-                player().switchPlayerManually(which);
-                setPlayerKernel();
-                setDecode();
-            } else {
-                PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.control.title.getText());
-                setRedirect(true);
-            }
-        }).show();
+    private void onPlayerKernel() {
+        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel, this::onExternalPlayer);
     }
 
-    private void onPlayerKernel() {
-        PlayerKernelDialog.show(this, player().getPlayerType(), this::switchPlayerKernel);
+    private void onExternalPlayer() {
+        PlayerHelper.choose(this, player().getUrl(), player().getHeaders(), player().isVod(), player().getPosition(), mBinding.control.title.getText());
+        setRedirect(true);
     }
 
     private void switchPlayerKernel(int type) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -4231,7 +4231,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         String[] kernel = ResUtil.getStringArray(R.array.select_player_kernel);
         String[] items = new String[kernel.length + 1];
         System.arraycopy(kernel, 0, items, 0, kernel.length);
-        items[kernel.length] = "外调";
+        items[kernel.length] = getString(R.string.player_kernel_external);
         new com.google.android.material.dialog.MaterialAlertDialogBuilder(this).setItems(items, (dialog, which) -> {
             if (which < kernel.length) {
                 if (!refreshAndSwitchPlayerKernel(which)) {

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/PlayerControlFocusIntegrationTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/PlayerControlFocusIntegrationTest.java
@@ -114,7 +114,7 @@ public class PlayerControlFocusIntegrationTest {
         assertTrue("inline player choice must append an external dispatch option",
                 show >= 0
                         && activity.indexOf("String[] items = Arrays.copyOf(kernels, kernels.length + 1);", show) > show
-                        && activity.indexOf("items[kernels.length] = \"外调\";", show) > show);
+                        && activity.indexOf("items[kernels.length] = getString(R.string.player_kernel_external);", show) > show);
         assertTrue("inline player choice dialog must show the expanded item list",
                 show >= 0 && activity.indexOf("setItems(items", show) > show);
         assertTrue("inline player choice dialog should stay compact on mobile like native enhanced",
@@ -124,6 +124,68 @@ public class PlayerControlFocusIntegrationTest {
                 show >= 0 && switchMethod > show
                         && activity.indexOf("openInlineExternal()", show) > show
                         && activity.indexOf("openInlineExternal()", show) < switchMethod);
+    }
+
+    @Test
+    public void sharedPlayerKernelDialogOffersExternalDispatchWhereverPlaybackRuns() throws Exception {
+        Path dialogPath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "dialog", "PlayerKernelDialog.java"));
+        String dialog = new String(Files.readAllBytes(dialogPath), StandardCharsets.UTF_8);
+
+        assertTrue(dialogPath + " must expose an external dispatch callback so playback screens can append the option",
+                dialog.contains("public interface ExternalListener"));
+        assertTrue("the external row must be appended past the kernel array rather than replacing a kernel",
+                dialog.contains("Arrays.copyOf(kernel, kernel.length + 1)")
+                        && dialog.contains("items[kernel.length] = label;"));
+        assertTrue("the external label must come from resources instead of a hardcoded literal",
+                dialog.contains("R.string.player_kernel_external") && !dialog.contains("\"外调\""));
+        int notify = dialog.indexOf("private static void notifySelected(");
+        assertTrue(dialogPath + " is missing notifySelected", notify >= 0);
+        int dispatch = dialog.indexOf("if (external != null && selected >= count)", notify);
+        int clamp = dialog.indexOf("PlayerSetting.sanitizePlayer(selected)", notify);
+        assertTrue("notifySelected must dispatch the appended row externally", dispatch >= 0);
+        assertTrue("notifySelected must still clamp real kernel selections", clamp >= 0);
+        assertTrue("the external dispatch must be decided before the kernel clamp can rewrite the index",
+                dispatch < clamp);
+        assertTrue("screens that pass no external callback must keep the plain kernel list",
+                dialog.contains("if (external == null) return kernel;"));
+
+        assertPlaybackScreenOffersExternalDispatch(findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "LiveActivity.java")));
+        assertPlaybackScreenOffersExternalDispatch(findLeanbackJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "LiveActivity.java")));
+        assertPlaybackScreenOffersExternalDispatch(findLeanbackJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "CastActivity.java")));
+        assertPlaybackScreenOffersExternalDispatch(findLeanbackJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java")));
+    }
+
+    private static void assertPlaybackScreenOffersExternalDispatch(Path sourcePath) throws Exception {
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        int kernel = source.indexOf("private void onPlayerKernel()");
+        int external = source.indexOf("private void onExternalPlayer()");
+
+        assertTrue(sourcePath + " is missing onPlayerKernel", kernel >= 0);
+        assertTrue(sourcePath + " is missing onExternalPlayer", external >= 0);
+
+        String kernelBody = enclosingMethodBody(source, kernel);
+        String externalBody = enclosingMethodBody(source, external);
+
+        assertTrue(sourcePath + " must offer external dispatch in its player kernel dialog",
+                kernelBody.contains("this::onExternalPlayer"));
+        assertTrue(sourcePath + " must launch the external player from onExternalPlayer",
+                externalBody.contains("PlayerHelper.choose("));
+        assertTrue(sourcePath + " must mark the redirect so returning from the external player is handled",
+                externalBody.contains("setRedirect(true);"));
+        assertFalse(sourcePath + " must not keep the orphaned hand-rolled kernel chooser",
+                source.contains("private void onChoose()"));
+    }
+
+    private static String enclosingMethodBody(String source, int declaration) {
+        int open = source.indexOf('{', declaration);
+        if (open < 0) return "";
+        int depth = 0;
+        for (int index = open; index < source.length(); index++) {
+            char current = source.charAt(index);
+            if (current == '{') depth++;
+            else if (current == '}' && --depth == 0) return source.substring(open, index + 1);
+        }
+        return "";
     }
 
     @Test


### PR DESCRIPTION
共享的 PlayerKernelDialog 只渲染 select_player_kernel 的四个内核， 接入它的界面因此没有了外调这一行，各自手写追加外调的 onChoose()
被留在文件里但已无人调用。手机版直播、电视版直播、电视版投屏、
电视版点播（短按）四处受影响。

在对话框一处补齐而非让四个界面各自退回原来的 AlertDialog：
新增可选的 ExternalListener，传了回调才在内核列表末尾追加外调行，
设置页不传则保持纯内核列表。选中该行直接分派外调，绕开
sanitizePlayer 的钳制——外调从来不是一种播放器类型，
硬塞进内核枚举只会被夹回 EXO。

顺带把外调文案从硬编码中文字面量收进 strings.xml，
补齐繁中与英文，原先这两种语言下也显示简体；
另外两处手写对话框的同样字面量一并资源化。

电视版点播的长按此前指向 onChoose()，改指原本就存在却没人用的
onPlayerKernelLong()，与手机版一致。

新增回归测试覆盖四个共享对话框界面，去掉外调回调可复现失败；
判据限定在方法体内，避免文件他处的无关匹配把断言撑成恒真。