### PR TITLE
修复：电视版更新弹窗看不到网速与按钮，改为铺满全屏

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/UpdateDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/UpdateDialog.java
@@ -1,7 +1,6 @@
 package com.fongmi.android.tv.ui.dialog;
 
 import android.graphics.Color;
-import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.text.TextUtils;
 import android.view.KeyEvent;
@@ -26,7 +25,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class UpdateDialog extends BaseAlertDialog {
 
-    private static final int DIALOG_VERTICAL_MARGIN_DP = 96;
+    private static final int FULLSCREEN_INSET_DP = 32;
 
     private DialogUpdateBinding binding;
     private UpdateListener listener;
@@ -36,7 +35,6 @@ public class UpdateDialog extends BaseAlertDialog {
     private boolean stableExpanded = true;
     private boolean betaExpanded;
     private boolean downloading;
-    private int lastProgressPanelHeight = -1;
 
     public static UpdateDialog create() {
         return new UpdateDialog();
@@ -77,7 +75,7 @@ public class UpdateDialog extends BaseAlertDialog {
 
     @Override
     protected MaterialAlertDialogBuilder getBuilder() {
-        return new MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_WebHTV_LightDialog).setView(getBinding().getRoot()).setCancelable(false);
+        return new MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_WebHTV_LightDialog_NoInset).setView(getBinding().getRoot()).setCancelable(false);
     }
 
     @Override
@@ -158,7 +156,6 @@ public class UpdateDialog extends BaseAlertDialog {
         updateFocusLinks();
         binding.close.setVisibility(View.VISIBLE);
         binding.progressPanel.setVisibility(View.GONE);
-        lastProgressPanelHeight = -1;
         downloading = false;
     }
 
@@ -270,74 +267,58 @@ public class UpdateDialog extends BaseAlertDialog {
 
     private void clearWindowInset() {
         Window window = getDialog() == null ? null : getDialog().getWindow();
-        if (window != null) window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        if (window == null) return;
+        window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        // ColorDrawable.getPadding() 返回 false，setBackgroundDrawable 不会重置已有 padding，
+        // 所以此前 InsetDrawable 写进 DecorView 的 inset padding 必须显式清掉，否则窗口高度
+        // 与内容可用高度会差出一个 inset，底部的进度面板和按钮会被裁掉。
+        window.getDecorView().setPadding(0, 0, 0, 0);
     }
 
+    /**
+     * 铺满全屏，不再手算窗口高度。
+     *
+     * 原先要同时算对屏宽高、content 高度、visibleFrame、Material 背景 inset 和 chrome 高度，
+     * 每项都有设备差异，任何一项出错就裁掉底部的进度面板和取消按钮。铺满后这些变量全部无关：
+     * listScroll 带 layout_weight 吃掉剩余空间，progressPanel 和 cancel 作为固定高子项永远保住。
+     */
     private void configureWindow() {
         Window window = getDialog() == null ? null : getDialog().getWindow();
         if (window == null) return;
-        int screenWidth = ResUtil.getScreenWidth(requireContext());
-        int width = UpdateDialogLayout.calculateDialogWidth(screenWidth, ResUtil.dp2px(960), ResUtil.dp2px(96));
         WindowManager.LayoutParams params = window.getAttributes();
-        params.width = width;
-        params.height = WindowManager.LayoutParams.WRAP_CONTENT;
+        params.width = WindowManager.LayoutParams.MATCH_PARENT;
+        params.height = WindowManager.LayoutParams.MATCH_PARENT;
         window.setAttributes(params);
-
-        int contentHeight = requireActivity().findViewById(android.R.id.content).getHeight();
-        Rect visibleFrame = new Rect();
-        window.getDecorView().getWindowVisibleDisplayFrame(visibleFrame);
-        int availableHeight = UpdateDialogLayout.resolveAvailableHeight(
-                ResUtil.getScreenHeight(requireContext()),
-                contentHeight,
-                visibleFrame.height());
-        int preferredHeight = binding.listScroll.getLayoutParams().height;
-        int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
-        int heightSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-        binding.listScroll.getLayoutParams().height = 1;
-        binding.getRoot().measure(widthSpec, heightSpec);
-        int chromeHeight = binding.getRoot().getMeasuredHeight() - 1;
-        binding.listScroll.getLayoutParams().height = UpdateDialogLayout.fitScrollHeight(
-                preferredHeight,
-                availableHeight,
-                chromeHeight,
-                UpdateDialogLayout.calculateVerticalMargin(
-                        availableHeight,
-                        ResUtil.dp2px(DIALOG_VERTICAL_MARGIN_DP)));
-        binding.getRoot().measure(widthSpec, heightSpec);
-        int dialogHeight = Math.min(binding.getRoot().getMeasuredHeight(), availableHeight);
-        window.setLayout(width, dialogHeight);
+        // XML 里 root 是 wrap_content，铺满全屏必须显式改成 match_parent，
+        // 否则窗口虽然全屏、内容仍只占中间一小块。
+        ViewGroup.LayoutParams rootParams = binding.getRoot().getLayoutParams();
+        if (rootParams != null) {
+            rootParams.width = ViewGroup.LayoutParams.MATCH_PARENT;
+            rootParams.height = ViewGroup.LayoutParams.MATCH_PARENT;
+            binding.getRoot().setLayoutParams(rootParams);
+        }
     }
 
-    private void configureScrollHeight() {
-        int screenHeight = ResUtil.getScreenHeight(requireContext());
-        int height = UpdateDialogLayout.calculatePreferredScrollHeight(
-                screenHeight,
-                ResUtil.dp2px(220),
-                ResUtil.dp2px(320));
-        ViewGroup.LayoutParams params = binding.listScroll.getLayoutParams();
-        params.height = height;
-        binding.listScroll.setLayoutParams(params);
-    }
-
-    private int getProgressPanelHeight() {
-        int width = binding.listScroll.getWidth();
-        if (width <= 0) width = binding.getRoot().getWidth() - binding.getRoot().getPaddingStart() - binding.getRoot().getPaddingEnd();
-        if (width > 0) {
-            int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
-            int heightSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-            binding.progressPanel.measure(widthSpec, heightSpec);
-        }
-        int height = binding.progressPanel.getMeasuredHeight();
-        ViewGroup.LayoutParams layoutParams = binding.progressPanel.getLayoutParams();
-        if (layoutParams instanceof ViewGroup.MarginLayoutParams) {
-            ViewGroup.MarginLayoutParams margins = (ViewGroup.MarginLayoutParams) layoutParams;
-            height += margins.topMargin + margins.bottomMargin;
-        }
-        return height;
+    /**
+     * 电视存在 overscan，正文不能贴边。在 XML 既有 padding 之上再加一圈安全边距。
+     *
+     * 用 tag 记在 root 上而不是记在 Fragment 实例字段上：配置变更（HDMI 分辨率切换、字体缩放）
+     * 后 Fragment 实例保留、binding 却会重新 inflate，实例字段会让新 root 永远拿不到边距。
+     */
+    private void applyFullscreenInset() {
+        View root = binding.getRoot();
+        if (Boolean.TRUE.equals(root.getTag(R.id.update_fullscreen_inset))) return;
+        root.setTag(R.id.update_fullscreen_inset, Boolean.TRUE);
+        int inset = ResUtil.dp2px(FULLSCREEN_INSET_DP);
+        root.setPadding(
+                root.getPaddingLeft() + inset,
+                root.getPaddingTop() + inset,
+                root.getPaddingRight() + inset,
+                root.getPaddingBottom() + inset);
     }
 
     private void configureDialogLayout() {
-        configureScrollHeight();
+        applyFullscreenInset();
         binding.getRoot().requestLayout();
         configureWindow();
     }
@@ -379,11 +360,8 @@ public class UpdateDialog extends BaseAlertDialog {
         if (!indeterminate) binding.progress.setProgress(value);
         binding.progressText.setText(getProgressText(indeterminate, value, bytes, total, speed, elapsed));
         binding.cancel.setText(R.string.update_cancel);
-        int progressPanelHeight = getProgressPanelHeight();
-        if (UpdateDialogLayout.hasProgressPanelHeightChanged(lastProgressPanelHeight, progressPanelHeight)) {
-            lastProgressPanelHeight = progressPanelHeight;
-            configureDialogLayout();
-        }
+        // 全屏 + listScroll 带 weight，progressPanel 由 VISIBLE 引起的高度变化由 LinearLayout
+        // 自行吸收，不再需要探测面板高度后重设窗口——那套逻辑还会因文案逐秒变长变短而抖动。
         if (requestFocus) binding.cancel.requestFocus();
         return true;
     }

--- a/app/src/leanback/res/layout/dialog_update.xml
+++ b/app/src/leanback/res/layout/dialog_update.xml
@@ -53,8 +53,9 @@
     <androidx.core.widget.NestedScrollView
         android:id="@+id/listScroll"
         android:layout_width="match_parent"
-        android:layout_height="320dp"
+        android:layout_height="0dp"
         android:layout_marginTop="16dp"
+        android:layout_weight="1"
         android:clipToPadding="false"
         android:fadeScrollbars="false"
         android:overScrollMode="never"

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/AboutDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/AboutDialog.java
@@ -31,6 +31,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 public final class AboutDialog {
 
     private static final int DIALOG_VERTICAL_MARGIN_DP = 96;
+    private static final int FULLSCREEN_INSET_DP = 32;
 
     private AboutDialog() {
     }
@@ -138,43 +139,82 @@ public final class AboutDialog {
         if (!Util.isLeanback()) return;
         Window window = dialog.getWindow();
         if (window == null) return;
-        int screenWidth = ResUtil.getScreenWidth(activity);
-        int screenHeight = ResUtil.getScreenHeight(activity);
-        int contentHeight = activity.findViewById(android.R.id.content).getHeight();
-        if (contentHeight > 0) screenHeight = Math.min(screenHeight, contentHeight);
-        int width = resolveGithubProxyWidth(screenWidth, screenHeight);
-        int height = resolveGithubProxyHeight(screenHeight);
+        // 电视端铺满全屏：不再按屏幕比例手算宽高，列表改为吃掉剩余空间。
+        // 这个弹窗经 MaterialAlertDialogBuilder.setView 装载，root 会被 AlertController
+        // 以 MATCH_PARENT 塞进 @id/custom，窗口给满高度后列表即可自由伸展。
+        WindowManager.LayoutParams params = window.getAttributes();
+        params.width = WindowManager.LayoutParams.MATCH_PARENT;
+        params.height = WindowManager.LayoutParams.MATCH_PARENT;
+        window.setAttributes(params);
+        // 这个弹窗有 URL 输入框。小窗居中时系统还能上推窗口避让键盘，铺满全屏后没有余量，
+        // 必须显式 ADJUST_RESIZE 让窗口自身缩小，否则输入框会被屏幕键盘盖住。
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         ViewGroup.LayoutParams listParams = binding.list.getLayoutParams();
-        listParams.height = resolveGithubProxyListHeight(screenHeight);
+        listParams.height = 0;
+        if (listParams instanceof androidx.appcompat.widget.LinearLayoutCompat.LayoutParams) {
+            ((androidx.appcompat.widget.LinearLayoutCompat.LayoutParams) listParams).weight = 1;
+        } else if (listParams instanceof android.widget.LinearLayout.LayoutParams) {
+            ((android.widget.LinearLayout.LayoutParams) listParams).weight = 1;
+        }
         binding.list.setLayoutParams(listParams);
-        window.setLayout(width, height);
     }
-
-    static int resolveGithubProxyWidth(int screenWidth, int screenHeight) {
-        boolean landscape = screenWidth >= screenHeight;
-        float widthFactor = landscape ? 0.68f : 0.92f;
-        float heightFactor = landscape ? 1.18f : 0.95f;
-        return Math.max(1, Math.min(
-                Math.round(screenWidth * widthFactor),
-                Math.round(screenHeight * heightFactor)));
-    }
-
-    static int resolveGithubProxyHeight(int screenHeight) {
-        return Math.max(1, Math.round(screenHeight * 0.82f));
-    }
-
-    static int resolveGithubProxyListHeight(int screenHeight) {
-        return Math.max(1, Math.round(screenHeight * 0.24f));
-    }
-
 
     private static void refreshGithubProxy(DialogGithubProxyBinding binding) {
         ((GithubProxyAdapter) binding.list.getAdapter()).setItems(GithubProxy.getSources(), GithubProxy.getActive());
     }
 
+    /**
+     * 电视端铺满全屏，不再手算窗口高度。
+     *
+     * 手算精确高度需要同时算对屏宽高、content 高度、visibleFrame、systemBars inset、
+     * Material 背景 inset 和 chrome 高度，每一项都有设备差异，任何一项出错就裁掉内容底部。
+     * 铺满全屏后这些变量全部无关，改由 LinearLayout 分配空间：固定高的按钮区永远保住，
+     * 滚动区吃掉剩余空间。
+     */
+    private static boolean configureFullscreenWindow(Window window, DialogAboutBinding binding) {
+        window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        window.getDecorView().setPadding(0, 0, 0, 0);
+        WindowManager.LayoutParams params = window.getAttributes();
+        params.width = WindowManager.LayoutParams.MATCH_PARENT;
+        params.height = WindowManager.LayoutParams.MATCH_PARENT;
+        params.gravity = Gravity.CENTER;
+        params.dimAmount = 0.58f;
+        window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+        window.setAttributes(params);
+        // XML 里 root 是 wrap_content，铺满全屏必须显式改成 match_parent，
+        // 否则窗口虽然全屏、内容仍只占中间一小块。
+        ViewGroup.LayoutParams rootParams = binding.getRoot().getLayoutParams();
+        if (rootParams != null) {
+            rootParams.width = ViewGroup.LayoutParams.MATCH_PARENT;
+            rootParams.height = ViewGroup.LayoutParams.MATCH_PARENT;
+            binding.getRoot().setLayoutParams(rootParams);
+        }
+        // 电视存在 overscan，正文不能贴边。在 XML 既有 padding 之上再加一圈安全边距。
+        int inset = ResUtil.dp2px(FULLSCREEN_INSET_DP);
+        View root = binding.getRoot();
+        root.setPadding(
+                root.getPaddingLeft() + inset,
+                root.getPaddingTop() + inset,
+                root.getPaddingRight() + inset,
+                root.getPaddingBottom() + inset);
+        // 滚动区在 XML 里是 wrap_content，全屏下要改成加权填充，否则正文短时按钮会飘在中间。
+        ViewGroup.LayoutParams scrollParams = binding.contentScroll.getLayoutParams();
+        scrollParams.height = 0;
+        if (scrollParams instanceof androidx.appcompat.widget.LinearLayoutCompat.LayoutParams) {
+            ((androidx.appcompat.widget.LinearLayoutCompat.LayoutParams) scrollParams).weight = 1;
+        }
+        binding.contentScroll.setLayoutParams(scrollParams);
+        // 铺满后不再需要 maxHeight 约束，交回给 weight 决定。
+        // CustomNestedScrollView 以 maxHeight > 0 作为启用条件，所以这里必须给 0 而非 MAX_VALUE：
+        // MeasureSpec 的尺寸只有 30 位，MAX_VALUE 会溢出到 mode 位上。
+        binding.contentScroll.setMaxHeight(0);
+        return true;
+    }
+
     private static boolean configureWindow(FragmentActivity activity, Dialog dialog, DialogAboutBinding binding) {
         Window window = dialog.getWindow();
         if (window == null) return false;
+        if (Util.isLeanback()) return configureFullscreenWindow(window, binding);
         WindowManager.LayoutParams params = window.getAttributes();
         params.width = (int) (ResUtil.getScreenWidth(activity) * (ResUtil.isLand(activity) ? 0.62f : 0.92f));
         params.height = WindowManager.LayoutParams.WRAP_CONTENT;

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="tmdb_episode_still_request_key" type="id" />
+    <item name="update_fullscreen_inset" type="id" />
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -103,6 +103,29 @@
         <item name="isLightTheme">true</item>
     </style>
 
+    <!--
+        更新弹窗专用：把 Material 的对话框背景 inset 归零。
+
+        Material 的 backgroundInset* 是以 alertDialogStyle 作为 defStyleAttr 读取的
+        （MaterialAlertDialogBuilder 构造器 → MaterialDialogs.getDialogBackgroundInsets），
+        defStyleAttr 的优先级高于主题属性，所以必须覆盖 alertDialogStyle 本身，
+        写在 ThemeOverlay 上会被 MaterialAlertDialog.Material3 的值压掉。
+
+        不归零的话，res/values-h480dp-v13 会把上下 inset 提到 80dp（屏高 ≥480dp 时生效，
+        绝大多数电视命中），InsetDrawable 经 getPadding() 变成 DecorView 的上下 padding，
+        而弹窗高度是我们自己算好写死的，于是内容底部被裁掉约 240px。
+    -->
+    <style name="MaterialAlertDialog.WebHTV.NoInset" parent="MaterialAlertDialog.Material3">
+        <item name="backgroundInsetStart">0dp</item>
+        <item name="backgroundInsetTop">0dp</item>
+        <item name="backgroundInsetEnd">0dp</item>
+        <item name="backgroundInsetBottom">0dp</item>
+    </style>
+
+    <style name="ThemeOverlay.WebHTV.LightDialog.NoInset" parent="ThemeOverlay.WebHTV.LightDialog">
+        <item name="alertDialogStyle">@style/MaterialAlertDialog.WebHTV.NoInset</item>
+    </style>
+
     <style name="Widget.WebHTV" parent="@android:style/Widget" />
 
     <style name="Widget.WebHTV.LightDialog" />

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/AboutDialogLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/AboutDialogLayoutTest.java
@@ -129,22 +129,31 @@ public class AboutDialogLayoutTest {
     }
 
     @Test
-    public void githubProxyDialogUsesRoomierTvDimensions() {
-        assertEquals(1274, AboutDialog.resolveGithubProxyWidth(1920, 1080));
-        assertEquals(850, AboutDialog.resolveGithubProxyWidth(1280, 720));
-        assertEquals(994, AboutDialog.resolveGithubProxyWidth(1080, 1920));
-        assertEquals(886, AboutDialog.resolveGithubProxyHeight(1080));
-        assertEquals(259, AboutDialog.resolveGithubProxyListHeight(1080));
-    }
-
-    @Test
-    public void githubProxyDialogAppliesDedicatedTvWindowSizing() throws Exception {
+    public void githubProxyDialogFillsTheScreenOnTv() throws Exception {
         String source = read(findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "dialog", "AboutDialog.java")));
 
         assertTrue(source.contains("configureGithubProxyWindow(activity, githubDialog, binding);"));
-        assertTrue(source.contains("resolveGithubProxyWidth(screenWidth, screenHeight)"));
-        assertTrue(source.contains("resolveGithubProxyHeight(screenHeight)"));
-        assertTrue(source.contains("resolveGithubProxyListHeight(screenHeight)"));
+        // 电视端改为铺满全屏，不再按屏幕比例手算宽高——手算需要同时算对屏宽高、content
+        // 高度与各类 inset，任何一项在某些盒子上出错就会裁掉底部内容。
+        assertFalse("TV GitHub proxy dialog should no longer derive its window size from screen ratios",
+                source.contains("resolveGithubProxyWidth")
+                        || source.contains("resolveGithubProxyHeight")
+                        || source.contains("resolveGithubProxyListHeight"));
+        assertTrue("TV GitHub proxy dialog should fill the screen",
+                source.contains("params.height = WindowManager.LayoutParams.MATCH_PARENT;"));
+    }
+
+    @Test
+    public void aboutDialogFillsTheScreenOnTvButKeepsWrapContentOnPhones() throws Exception {
+        String source = read(findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "dialog", "AboutDialog.java")));
+
+        // 电视端走独立的全屏分支，手机端保持原有 wrap_content 行为不变。
+        assertTrue("TV should take a dedicated fullscreen path",
+                source.contains("if (Util.isLeanback()) return configureFullscreenWindow(window, binding);"));
+        assertTrue("The scroll area should absorb leftover space so the action buttons stay pinned",
+                source.contains("weight = 1"));
+        assertTrue("Phones must keep sizing the window to their content",
+                source.contains("params.height = WindowManager.LayoutParams.WRAP_CONTENT;"));
     }
 
 


### PR DESCRIPTION
用户反馈电视版"版本更新"弹窗在下载时看不到网速、也看不出是否在下载，
且只有部分设备复现。根因是弹窗底部的进度面板和取消按钮被裁掉。

原实现手算窗口精确高度再 window.setLayout() 写死，需要同时算对屏宽高、
content 高度、visibleFrame、systemBars inset、Material 背景 inset 和 chrome 高度共七个变量，每项都有设备差异，任何一项出错就裁掉底部内容。

其中两项确实在出错：

一是 configureWindow() 连续两次用同一组 measure spec 调 root.measure()， 中间只改 LayoutParams.height 字段而没走 setLayoutParams，不触发 requestLayout。PFLAG_FORCE_LAYOUT 在第一次 measure 末尾即被清除，第二次 命中 View.measure() 的缓存短路，窗口高度实际按"列表 1px"算出，比内容矮
整整一个列表高度（1080p 约 452px、720p 约 287px）。

二是 Material 的对话框背景 inset 有按屏高分档的资源限定符：values 下是
10dp，values-h480dp-v13 下上下各 80dp。屏高 ≥480dp 时命中后者，绝大多数 电视都在这一档，而 720p@2.0、1080p@3.0 等只拿 10dp——同一份 APK 相差
八倍，这解释了为何只有部分用户复现。原 clearWindowInset() 想用
ColorDrawable 覆盖窗口背景来清掉它，但 ColorDrawable.getPadding() 返回 false，setBackgroundDrawable 不会重置已有 padding，inset 只是变得不可见 而没有消失。

改为电视端铺满全屏，让 LinearLayout 分配空间取代手算：滚动区用
layout_weight 吃剩余空间，进度面板和按钮作为固定高子项在结构上不可能
再被裁掉。七个变量降为零。同时覆盖 alertDialogStyle 把 inset 归零——
inset 以 alertDialogStyle 作为 defStyleAttr 读取，优先级高于主题属性， 写在 ThemeOverlay 上会被 MaterialAlertDialog.Material3 压掉。

一并全屏化同样在手算尺寸的关于弹窗与 GitHub 代理弹窗。关于弹窗位于 main
源集，用 Util.isLeanback() 门控，手机端行为不变；它此前也存在同源的
measure 短路问题。代理弹窗补上缺失的 softInputMode：它有 URL 输入框，
小窗时系统还能上推窗口避让键盘，铺满后没有余量，需显式 ADJUST_RESIZE。

顺带移除因全屏而失效的逻辑：按进度面板高度重设窗口会随下载文案逐秒变长
变短而抖动；getProgressPanelHeight() 在窗口未 layout 时读到的是从未参与 measure 的 GONE 视图，只有 marginTop 而非真实高度。

未改动确认框类弹窗（如备份确认），它们只有两行字加按钮，全屏反而突兀。
AdRuleManageDialog 等虽也自行设置尺寸，但用的是 WRAP_CONTENT 而非写死 精确高度，不会踩此坑，且无用户报障，故不扩大范围。

注：本次仅通过编译与单元测试验证，尚未真机验证全屏观感（安全边距取
32dp、列表滚动步长仍为 96dp，可能需按实机调整）。UpdateDialogLayout
及其测试现已无生产代码引用，暂予保留。