### PR TITLE
修复：影视原生模式选集名称修改按钮无作用，改为等同短显

### DIFF
--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -2774,6 +2774,11 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         if (mBinding.episodeFileName == null || mBinding.episodeFileName.getVisibility() != View.VISIBLE) {
             return;
         }
+        // 影视原生模式没有 TMDB 刮削标题，切换刮削/原文件名不会有任何变化，改为等同「短显」
+        if (shouldUseUpstreamNativeEpisodeModule()) {
+            onShortDisplay();
+            return;
+        }
         boolean showScraped = !Setting.getTmdbEpisodeShowScrapedName();
         android.util.Log.d("VideoActivity", "toggleEpisodeFileName - showScraped=" + showScraped + ", mTmdbControlsMoved=" + mTmdbControlsMoved);
         Setting.putTmdbEpisodeShowScrapedName(showScraped);
@@ -2802,6 +2807,11 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
 
     private void updateEpisodeFileNameButton() {
         if (mBinding.episodeFileName == null) return;
+        if (shouldUseUpstreamNativeEpisodeModule()) {
+            mBinding.episodeFileName.setContentDescription(getString(R.string.play_short_display));
+            applyTmdbPlaybackControlColors();
+            return;
+        }
         boolean showScraped = Setting.getTmdbEpisodeShowScrapedName();
         mBinding.episodeFileName.setContentDescription(getString(showScraped ? R.string.detail_episode_file_name_original_action : R.string.detail_episode_file_name_scraped_action));
         applyTmdbPlaybackControlColors();


### PR DESCRIPTION
手机端详情页选集区的铅笔按钮（episodeFileName）原本只翻转
tmdb_episode_show_scraped_name，而该开关仅在剧集带 TMDB 数据时
才参与标题生成，影视原生模式不加载 TMDB，导致点击毫无反应。

改为在影视原生模式下走 onShortDisplay()，效果与「短显」按钮一致，
并把无障碍描述同步改为「短显」。其余 TMDB 模式逻辑不变。