### PR TITLE
修复：MPV 播放先出声后出画面

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
@@ -278,6 +278,7 @@ public class PlayerManager implements ParseCallback {
     private boolean manualPlayerSwitchPending;
     private boolean mpvAutoOutputEvaluated;
     private boolean mpvAutoOutputEvaluationScheduled;
+    private boolean mpvAutoOutputProbeGaveUp;
     private boolean mpvExplicitSubtitlePreference;
     private boolean mpvAutoGpuPinnedForSession;
     private boolean mpvSurfaceFallbackTried;
@@ -1005,11 +1006,21 @@ public class PlayerManager implements ParseCallback {
      * Keep the native player's shutter visible while automatic MPV output is
      * still being selected. This prevents a failed direct DV probe from
      * exposing a stale poster or the last frame before the GPU rebuild.
+     * The probe frame only exists when automatic output can actually reach
+     * surface direct; while the stability guard pins automatic mode to GPU —
+     * or the device guard blocks zero copy, which makes
+     * {@link MpvPerformanceSetting#resolveSurfaceDirect} refuse direct output
+     * in every mode — there is nothing to hide, so holding the shutter would
+     * only withhold the picture while audio already plays.
+     * Probing that gives up without a decision also releases the shutter,
+     * otherwise the picture would stay hidden for the rest of the item.
      */
     public boolean shouldKeepVideoShutterClosed() {
         return isMpv()
+                && MpvPerformanceSetting.isAutoSurfaceDirectEnabled()
                 && MpvPerformanceSetting.getOutputMode() == MpvPerformanceSetting.OUTPUT_AUTO
-                && !mpvAutoOutputEvaluated;
+                && !mpvAutoOutputEvaluated
+                && !mpvAutoOutputProbeGaveUp;
     }
 
     public boolean isExo() {
@@ -5130,7 +5141,7 @@ public void resetTrack(int type) {
         if (!(engine instanceof MpvPlayerEngine mpv)) return;
         boolean hwdecOverrideCleared = mpv.clearHwdecOverride();
         boolean automaticOutput = MpvPerformanceSetting.getOutputMode() == MpvPerformanceSetting.OUTPUT_AUTO;
-        if (automaticOutput) callback.onPlayerOutputPending();
+        if (shouldKeepVideoShutterClosed()) callback.onPlayerOutputPending();
         mpv.setSurfaceDirectOverride(null);
         boolean autoDirectEligible = MpvAutoOutputPolicy.canStartSurfaceDirect(
                 engine.isHard(),
@@ -5172,6 +5183,7 @@ public void resetTrack(int type) {
     private void resetMpvOutputEvaluationState() {
         mpvAutoOutputEvaluated = false;
         mpvAutoOutputEvaluationScheduled = false;
+        mpvAutoOutputProbeGaveUp = false;
         mpvAutoOutputProbeAttempts = 0;
         mpvSurfaceFallbackTried = false;
         mpvVulkanFallbackTried = false;
@@ -5197,8 +5209,17 @@ public void resetTrack(int type) {
             boolean evaluated = evaluateMpvAutoOutput();
             if (!evaluated && !mpvAutoOutputEvaluated && mpvAutoOutputProbeAttempts < MPV_AUTO_OUTPUT_PROBE_MAX_ATTEMPTS) {
                 scheduleMpvAutoOutputEvaluation();
-            } else if (!evaluated && SpiderDebug.isEnabled()) {
-                SpiderDebug.log("mpv-output", "auto probe exhausted attempts=%d size=%dx%d tracksEmpty=%s", mpvAutoOutputProbeAttempts, getVideoWidth(), getVideoHeight(), engine == null || engine.getCurrentTracks() == null || engine.getCurrentTracks().isEmpty());
+            } else if (!evaluated) {
+                // Probing gave up without a decision. Release the shutter so the
+                // picture is never withheld indefinitely; a later size or track
+                // callback can still re-run the evaluation, so this must not set
+                // mpvAutoOutputEvaluated — that would end automatic output for
+                // the whole item.
+                // Set the latch first: onPlayerOutputReady re-enters syncShutter
+                // synchronously, which re-reads shouldKeepVideoShutterClosed().
+                mpvAutoOutputProbeGaveUp = true;
+                callback.onPlayerOutputReady();
+                if (SpiderDebug.isEnabled()) SpiderDebug.log("mpv-output", "auto probe exhausted attempts=%d size=%dx%d tracksEmpty=%s", mpvAutoOutputProbeAttempts, getVideoWidth(), getVideoHeight(), engine == null || engine.getCurrentTracks() == null || engine.getCurrentTracks().isEmpty());
             }
         }, MPV_AUTO_OUTPUT_PROBE_INTERVAL_MS);
     }

--- a/app/src/test/java/com/fongmi/android/tv/player/MpvOutputShutterSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/player/MpvOutputShutterSourceTest.java
@@ -1,0 +1,98 @@
+package com.fongmi.android.tv.player;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The automatic MPV output shutter hides the direct probe frame before a GPU
+ * rebuild. That frame only exists when automatic output can actually reach
+ * surface direct, so while the stability guard pins automatic mode to GPU the
+ * shutter would only delay the first frame while audio already plays.
+ */
+public class MpvOutputShutterSourceTest {
+
+    @Test
+    public void shutterOnlyClosesWhenAutomaticOutputCanReachSurfaceDirect() throws Exception {
+        String method = methodBody(readPlayerManager(),
+                "public boolean shouldKeepVideoShutterClosed()", "public boolean isExo()");
+
+        assertTrue("a shutter that can never hide a probe frame must not close",
+                method.contains("MpvPerformanceSetting.isAutoSurfaceDirectEnabled()"));
+        assertTrue(method.contains("MpvPerformanceSetting.getOutputMode() == MpvPerformanceSetting.OUTPUT_AUTO"));
+        assertTrue(method.contains("!mpvAutoOutputEvaluated"));
+        // PlaybackActivity.syncShutter ORs this predicate with nativeOutputPending,
+        // so a released shutter has to be visible on this side too.
+        assertTrue("a probe that gave up must also open this side of the shutter",
+                method.contains("!mpvAutoOutputProbeGaveUp"));
+    }
+
+    @Test
+    public void newItemClosesShutterOnlyWhenTheShutterPolicyAgrees() throws Exception {
+        String method = methodBody(readPlayerManager(),
+                "private void prepareMpvOutputForNewItem()", "private void resetMpvOutputRuntime()");
+
+        assertFalse("the output mode alone closed the shutter even when nothing could hide behind it",
+                method.contains("if (automaticOutput) callback.onPlayerOutputPending();"));
+        assertTrue("shutter must follow the single shutter policy, not the output mode alone",
+                method.contains("shouldKeepVideoShutterClosed()"));
+        assertTrue(method.contains("callback.onPlayerOutputPending();"));
+    }
+
+    @Test
+    public void exhaustedProbeReleasesBothSidesOfTheShutter() throws Exception {
+        String source = readPlayerManager();
+        String method = methodBody(source,
+                "private void scheduleMpvAutoOutputEvaluation()", "private boolean evaluateMpvAutoOutput()");
+
+        int giveUp = method.indexOf("} else if (!evaluated) {");
+        assertTrue("probe exhaustion branch is missing", giveUp >= 0);
+        // Scope the assertions to the branch body, so moving the release out of
+        // the branch fails instead of silently passing.
+        int branchEnd = method.indexOf("}, MPV_AUTO_OUTPUT_PROBE_INTERVAL_MS", giveUp);
+        assertTrue("probe exhaustion branch is not followed by the post delay", branchEnd > giveUp);
+        String branch = method.substring(giveUp, branchEnd);
+
+        assertTrue("an exhausted probe must not withhold the picture indefinitely",
+                branch.contains("callback.onPlayerOutputReady();"));
+        assertTrue("clearing nativeOutputPending alone leaves the predicate holding the shutter",
+                branch.contains("mpvAutoOutputProbeGaveUp = true;"));
+        assertFalse("ending the evaluation would kill automatic output for the whole item",
+                branch.contains("mpvAutoOutputEvaluated = true;"));
+        // onPlayerOutputReady re-enters syncShutter synchronously, which re-reads
+        // shouldKeepVideoShutterClosed() — so the latch has to be set first.
+        assertTrue("the latch must be set before the re-entrant callback re-reads the predicate",
+                branch.indexOf("mpvAutoOutputProbeGaveUp = true;")
+                        < branch.indexOf("callback.onPlayerOutputReady();"));
+    }
+
+    @Test
+    public void newItemClearsTheGaveUpLatch() throws Exception {
+        String method = methodBody(readPlayerManager(),
+                "private void resetMpvOutputEvaluationState()", "private void scheduleMpvAutoOutputEvaluation()");
+
+        assertTrue("a stale give-up latch would suppress the shutter on later items",
+                method.contains("mpvAutoOutputProbeGaveUp = false;"));
+    }
+
+    private static String readPlayerManager() throws IOException {
+        Path root = Path.of("").toAbsolutePath();
+        Path source = root.resolve(Path.of("app", "src", "main", "java", "com", "fongmi", "android", "tv", "player", "PlayerManager.java"));
+        if (!Files.exists(source)) source = root.resolve(Path.of("src", "main", "java", "com", "fongmi", "android", "tv", "player", "PlayerManager.java"));
+        return Files.readString(source, StandardCharsets.UTF_8).replace("\r\n", "\n");
+    }
+
+    private static String methodBody(String source, String startToken, String endToken) {
+        int start = source.indexOf(startToken);
+        int end = source.indexOf(endToken, start);
+        assertTrue("Missing source token: " + startToken, start >= 0);
+        assertTrue("Missing source token after " + startToken + ": " + endToken, end > start);
+        return source.substring(start, end);
+    }
+}


### PR DESCRIPTION
上游合并 45a72e2d97 引入的「输出快门」在本仓库是纯等待：
PlaybackActivity.syncShutter() 会在自动输出决策完成前把视频
SurfaceView 的 alpha 置 0，音频不受影响，于是声画分离。

但本地 SURFACE_AUTO_STABILITY_GUARD_ENABLED 硬编码为 true， 使 isAutoSurfaceDirectEnabled() 恒为 false、自动模式恒走 GPU， 永不存在需要遮挡的「直出探测帧」；零拷贝黑名单设备同理，
resolveSurfaceDirect() 对其在所有模式下都拒绝直出。快门因此
只是白等一个结论早已注定的决策。模拟器实测 start-file 到
playback-restart 相隔 4.34s，其间音频在 37.834 就绪、画面要
等到 38.813；探测另有 attempts=20 跑满 5s 的空转。

三处改动：
- shouldKeepVideoShutterClosed() 增加 isAutoSurfaceDirectEnabled() 判据，无法抵达直出时不再关快门；guard 放开后自动恢复遮挡。
- prepareMpvOutputForNewItem() 改用同一判据。syncShutter 里 keepClosed 是 nativeOutputPending || 谓词 的或关系，只改谓词 会被 pending 旁路。
- 探测耗尽时释放快门。新增 mpvAutoOutputProbeGaveUp 让谓词与 pending 两侧同时释放——只调 onPlayerOutputReady() 仅清 pending， 谓词仍为 true，快门实际不会打开（首轮评审发现）。刻意不置 mpvAutoOutputEvaluated，否则会永久停掉本片后续自动决策。

未修复的既有问题（不属本次回归，另行处理）：硬解失败后 mpv 报
vid=no，而探测判据要求轨道就绪，导致 tracksEmpty=true 必然跑满
20 次。

验证：leanback / mobile 两变体编译通过；全量单元测试
3483(mobile) / 2725(leanback) 例中仅 MpvPreloadControllerTest 2 例失败，该失败在剥离本次改动的同一基线上同样存在，源自 08-19
上游 d41abf83c5 未同步断言，非本次引入。新增的 5 条源码断言逐条
注入回归实测有效（含 latch 与回调的顺序约束）。