### PR TITLE
统一电视端焦点框配色为黄色，绿色只表示当前生效

### DIFF
--- a/app/src/leanback/res/drawable/selector_video_item.xml
+++ b/app/src/leanback/res/drawable/selector_video_item.xml
@@ -11,7 +11,7 @@
                 android:top="8dp" />
             <stroke
                 android:width="2dp"
-                android:color="@color/white" />
+                android:color="#FFD166" />
         </shape>
     </item>
     <item android:state_activated="true">
@@ -28,6 +28,13 @@
                 android:color="#2CC56F" />
         </shape>
     </item>
+    <!--
+        不要给 state_selected 加描边。这套 selector 的消费方（adapter_episode / adapter_flag /
+        adapter_quality）都用了 android:ellipsize="marquee"，而 Android 的跑马灯只在 View 处于
+        selected 或 focused 时滚动，所以 EpisodeAdapter 那边是 setSelected(isSelected() || hasFocus())
+        ——selected 在这里是"跑马灯开关"，不是语义上的"当前生效"。加了描边会让"标题过长正在滚动"
+        的项被误显示成当前播放。当前生效态统一走 state_activated（ArrayAdapter.setActivated）。
+    -->
     <item android:state_selected="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/black_50" />

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -8542,7 +8542,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             }
         });
         adapter.setLight(lightTheme);
-        adapter.setActiveStrokeColor(0xFF2AA46B);
+        adapter.setActiveStrokeColor(0xFF2CC56F);
         adapter.setNativeEnhanced(true);
         recycler.setAdapter(adapter);
         LinearLayout.LayoutParams recyclerParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -8696,7 +8696,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         GradientDrawable background = new GradientDrawable();
         background.setCornerRadius(ResUtil.dp2px(4));
         background.setColor(focused ? colors.control : selected ? colors.chipActive : colors.chip);
-        background.setStroke(ResUtil.dp2px(focused ? 2 : CHIP_STROKE_DP), focused ? colors.accent : selected ? colors.accent : colors.line);
+        background.setStroke(ResUtil.dp2px(focused ? FOCUS_STROKE_DP : selected ? 2 : CHIP_STROKE_DP), focused ? FOCUS_STROKE : selected ? colors.accent : colors.line);
         button.setSelected(selected);
         button.setActivated(selected);
         button.setTextColor(colors.primary);
@@ -8877,13 +8877,13 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         GradientDrawable background = new GradientDrawable();
         background.setCornerRadius(ResUtil.dp2px(6));
         if (focused) {
-            background.setColor(lightTheme ? 0x1A2196F3 : 0x552196F3);
-            background.setStroke(ResUtil.dp2px(3), 0xFF0077FF);
+            background.setColor(lightTheme ? 0x1AFFD166 : 0x55FFD166);
+            background.setStroke(ResUtil.dp2px(FOCUS_STROKE_DP), FOCUS_STROKE);
             button.setTextColor(lightTheme ? colors.primary : 0xFFFFFFFF);
         } else if (selected) {
-            background.setColor(lightTheme ? 0x1F20B866 : 0x332196F3);
-            background.setStroke(ResUtil.dp2px(2), lightTheme ? colors.accent : 0xFF2196F3);
-            button.setTextColor(lightTheme ? colors.accent : 0xFF85C7FF);
+            background.setColor(lightTheme ? 0x1F20B866 : 0x332CC56F);
+            background.setStroke(ResUtil.dp2px(2), colors.accent);
+            button.setTextColor(colors.accent);
         } else {
             background.setColor(0x00000000);
             button.setTextColor(lightTheme ? colors.secondary : 0xFFC6D0D9);
@@ -8896,8 +8896,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         GradientDrawable background = new GradientDrawable();
         background.setCornerRadius(ResUtil.dp2px(6));
         if (focused) {
-            background.setColor(0x552196F3);
-            background.setStroke(ResUtil.dp2px(3), 0xFF0077FF);
+            background.setColor(0x55FFD166);
+            background.setStroke(ResUtil.dp2px(FOCUS_STROKE_DP), FOCUS_STROKE);
         } else {
             background.setColor(0x00000000);
         }
@@ -8940,8 +8940,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         int text = focused ? (lightTheme ? colors.primary : 0xFFFFFFFF) : colors.primary;
         button.setTextColor(text);
         button.setIconTint(ColorStateList.valueOf(text));
-        button.setBackgroundTintList(ColorStateList.valueOf(focused ? (lightTheme ? 0x1A2196F3 : 0x552196F3) : colors.control));
-        button.setStrokeColor(ColorStateList.valueOf(focused ? 0xFF0077FF : colors.lineStrong));
+        button.setBackgroundTintList(ColorStateList.valueOf(focused ? (lightTheme ? 0x1AFFD166 : 0x55FFD166) : colors.control));
+        button.setStrokeColor(ColorStateList.valueOf(focused ? FOCUS_STROKE : colors.lineStrong));
         button.setStrokeWidth(ResUtil.dp2px(focused ? 2 : 1));
     }
 

--- a/app/src/main/res/drawable/shape_episode_photo_focused.xml
+++ b/app/src/main/res/drawable/shape_episode_photo_focused.xml
@@ -6,6 +6,6 @@
 
     <stroke
         android:width="3dp"
-        android:color="#FFD700" />
+        android:color="#FFD166" />
 
 </shape>

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -1621,7 +1621,7 @@ public class TmdbDetailActivityLayoutTest {
                         && activity.contains("button.setMinWidth(ResUtil.dp2px(64));")
                         && activity.contains("ThemeColors colors = currentThemeColors();")
                         && activity.contains("background.setColor(focused ? colors.control : selected ? colors.chipActive : colors.chip);")
-                        && activity.contains("background.setStroke(ResUtil.dp2px(focused ? 2 : CHIP_STROKE_DP), focused ? colors.accent : selected ? colors.accent : colors.line);")
+                        && activity.contains("background.setStroke(ResUtil.dp2px(focused ? FOCUS_STROKE_DP : selected ? 2 : CHIP_STROKE_DP), focused ? FOCUS_STROKE : selected ? colors.accent : colors.line);")
                         && activity.contains("button.setTextColor(colors.primary);")
                         && activity.contains("button.setBackground(background);")
                         && activity.contains("button.setActivated(selected);")


### PR DESCRIPTION
电视端详情页与选集浮层此前有六套并存的焦点配色：详情页 chip 走 applyChipFocus
的黄框，选集浮层的线路/季度/分段按钮走 selector_video_item 的白框，沉浸融合与 详情直放模式的浮层焦点态和生效态同用 colors.accent 绿色、根本分不出焦点在哪，
手机端弹层则是另一套蓝色系。用户反馈黄绿白混搭，无法判断哪个是焦点、哪个是
当前播放。

统一约定：焦点框 #FFD166 黄，当前生效 #2CC56F 绿。

改动：
- selector_video_item 焦点描边由 @color/white 改为 #FFD166，覆盖选集浮层的 线路、季度、分段、文本选集与清晰度按钮
- applyNativeEnhancedInlineChipState 焦点描边由 colors.accent 改为 FOCUS_STROKE， 修复沉浸融合/详情直放浮层焦点态与生效态同色无法区分的问题
- applyEpisodeDialogPageState、applyEpisodeDialogIconState、 applyInlineEpisodeModeButtonState 三处蓝色焦点框改为黄色
- setActiveStrokeColor 由 0xFF2AA46B 归一到 0xFF2CC56F
- shape_episode_photo_focused 由 #FFD700 归一到 #FFD166

未改 selector_video_item 的 state_selected：该 selector 的消费方布局都带 ellipsize="marquee"，而跑马灯只在 selected 或 focused 时滚动，EpisodeAdapter 因此写成 setSelected(isSelected() || hasFocus())，VideoActivity 的 shortDisplay 也用它表达"精简标题"开关态。给这个状态加描边会把正在滚动的长标题和开关态误标
成当前播放，已在文件内注释说明。生效态统一走 state_activated。

未改 @color/text 的黄色生效态文字：被直播频道、分组、EPG、站点弹窗等 12 个布局
共用，超出播放器域，需要时应另建一份 color selector。

selector_episode_dialog_page 与 selector_episode_dialog_item 的蓝色系保持原样： 唯一消费者 EpisodeDialog 无外部调用点，属死代码，清理另行处理。

验证：合并 origin/beta 后 leanback 变体编译通过，mobile 3483 项、leanback 2725 项 单测均仅 MpvPreloadControllerTest 的 2 项失败，在合并前的干净基线上重跑为同样 2 项 失败，属既有问题。TmdbDetailActivityLayoutTest 的配色断言已同步。实机效果尚未确认， 其中 leanback 侧焦点与生效态的叠加表现需上机复核。