### PR TITLE
修复：TV选源网格边缘左右键翻组跳错组或翻不动

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/SiteAdapter.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/SiteAdapter.java
@@ -50,6 +50,8 @@ public class SiteAdapter extends RecyclerView.Adapter<SiteAdapter.ViewHolder> {
         void onItemClick(Site item);
 
         boolean onItemKeyUp(int position);
+
+        boolean onItemKeyHorizontal(int position, boolean left);
     }
 
     public void setType(int type) {
@@ -242,10 +244,16 @@ public class SiteAdapter extends RecyclerView.Adapter<SiteAdapter.ViewHolder> {
         }
 
         private boolean onKey(int keyCode, android.view.KeyEvent event) {
-            if (event.getAction() != android.view.KeyEvent.ACTION_DOWN) return false;
-            if (keyCode != android.view.KeyEvent.KEYCODE_DPAD_UP) return false;
+            boolean left = keyCode == android.view.KeyEvent.KEYCODE_DPAD_LEFT;
+            boolean right = keyCode == android.view.KeyEvent.KEYCODE_DPAD_RIGHT;
+            if (keyCode != android.view.KeyEvent.KEYCODE_DPAD_UP && !left && !right) return false;
             int position = getBindingAdapterPosition();
             if (position == RecyclerView.NO_POSITION) return false;
+            if (left || right) {
+                if (event.getAction() != android.view.KeyEvent.ACTION_DOWN) return false;
+                return listener.onItemKeyHorizontal(position, left);
+            }
+            if (event.getAction() != android.view.KeyEvent.ACTION_DOWN) return false;
             return listener.onItemKeyUp(position);
         }
 

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/SiteDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/SiteDialog.java
@@ -63,6 +63,7 @@ public class SiteDialog extends BaseAlertDialog implements SiteAdapter.OnClickLi
     private long reorderStartedAt;
     private long showStart;
     private boolean groupReordering;
+    private boolean groupSwitching;
     private boolean action;
     private boolean listLoaded;
     private int type;
@@ -304,6 +305,67 @@ public class SiteDialog extends BaseAlertDialog implements SiteAdapter.OnClickLi
         return true;
     }
 
+    @Override
+    public boolean onItemKeyHorizontal(int position, boolean left) {
+        if (binding == null || adapter == null || groupReordering) return false;
+        // 仅在该方向没有其它可聚焦目标时才翻组：action 模式下右侧有按钮列，右键让位给它
+        if (!left && binding.action.getVisibility() == View.VISIBLE) return false;
+        if (!isRowEdge(position, left)) return false;
+        if (binding.groupList.getChildCount() == 0) return true;
+        moveGroupFocus(left ? -1 : 1);
+        return true;
+    }
+
+    private boolean isRowEdge(int position, boolean left) {
+        int count = getCount();
+        if (left) return position % count == 0;
+        return position % count == count - 1 || position == adapter.getItemCount() - 1;
+    }
+
+    private void moveGroupFocus(int direction) {
+        int current = indexOfGroup(selectedGroup);
+        if (current < 0) return;
+        int target = current + direction;
+        if (target < 0 || target >= binding.groupList.getChildCount()) return;
+        View view = binding.groupList.getChildAt(target);
+        if (view == null) return;
+        groupSwitching = true;
+        selectGroup((String) view.getTag(), view);
+        focusFirstSite();
+    }
+
+    private int indexOfGroup(String group) {
+        for (int i = 0; i < binding.groupList.getChildCount(); i++) {
+            if (TextUtils.equals(group, (String) binding.groupList.getChildAt(i).getTag())) return i;
+        }
+        return -1;
+    }
+
+    private void focusFirstSite() {
+        DialogSiteBinding current = binding;
+        if (current == null) {
+            groupSwitching = false;
+            return;
+        }
+        current.recycler.post(() -> {
+            if (binding != current || adapter == null || adapter.getItemCount() == 0) {
+                groupSwitching = false;
+                if (binding == current) requestGroupFocus();
+                return;
+            }
+            current.recycler.post(() -> {
+                if (binding != current) {
+                    groupSwitching = false;
+                    return;
+                }
+                RecyclerView.ViewHolder holder = current.recycler.findViewHolderForLayoutPosition(0);
+                boolean focused = holder != null && holder.itemView.requestFocus();
+                if (!focused) requestGroupFocus();
+                groupSwitching = false;
+            });
+        });
+    }
+
     private void loadConfig(FragmentActivity activity, Config config) {
         if (config.getUrl().equals(VodConfig.getUrl())) return;
         VodConfig.load(config, new Callback() {
@@ -430,7 +492,7 @@ public class SiteDialog extends BaseAlertDialog implements SiteAdapter.OnClickLi
         button.setClickable(true);
         button.setNextFocusDownId(binding.recycler.getId());
         button.setOnFocusChangeListener((v, hasFocus) -> {
-            if (hasFocus) selectGroup(group, button);
+            if (hasFocus && !groupSwitching) selectGroup(group, button);
         });
         button.setOnClickListener(v -> onGroupClick(group, v));
         button.setOnKeyListener((v, keyCode, event) -> onGroupKey(group, keyCode, event));
@@ -503,6 +565,7 @@ public class SiteDialog extends BaseAlertDialog implements SiteAdapter.OnClickLi
 
     private void resetGroupReorderState() {
         groupReordering = false;
+        groupSwitching = false;
         reorderingGroup = "";
         originalGroups = null;
         reorderStartedAt = 0;
@@ -545,7 +608,7 @@ public class SiteDialog extends BaseAlertDialog implements SiteAdapter.OnClickLi
         adapter.filter(selectedGroup, "");
         setRecyclerHeight(adapter.getItemCount());
         scrollRecyclerToTop();
-        if (!TextUtils.isEmpty(selectedGroup)) centerGroup(view);
+        centerGroup(view);
     }
 
     private void scrollRecyclerToTop() {


### PR DESCRIPTION
网格 item 原先只处理 DPAD_UP，左右键落到系统默认 focusSearch，
按几何位置在视图树里找最近可聚焦 View，往往命中分组标签行里偏右
的标签并触发其 focus 监听换组，表现为跳到无关分组（综合→有声）；
另一侧找不到目标则事件被丢弃，表现为翻不动。

改为由 SiteAdapter 新增 onItemKeyHorizontal 回调交给 SiteDialog 处理：按 position % 3 判断行边缘（右边缘含末行不满时的最后一项），
命中后按分组标签的索引顺序前后移动一格，再把焦点落到新列表首项。

- 新增 groupSwitching 标志，在换组期间抑制分组标签的 focus 监听， 避免 notifyDataSetChanged 回收持焦 item 时焦点中转引发二次换组； 该标志在 focusFirstSite 各早退分支及 resetGroupReorderState 中复位。
- focusFirstSite 用嵌套两层 post + findViewHolderForLayoutPosition， 绕开 mDataSetHasChangedAfterLayout 期间 findViewHolderForAdapterPosition 必返 null 的问题；取不到 holder 时回退聚焦分组标签而非 recycler 自身。
- selectGroup 中 centerGroup 改为无条件调用，保证左翻回“全部”时标签行 仍会滚动；moveGroupFocus 中重复的 centerGroup 调用一并删除。
- 长按进入分组排序模式时不接管左右键；action 模式下右侧有按钮列， 右键仍让位给按钮列。