### PR TITLE
修复：TMDB 详情页线路里混进站源名

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ app/signing/
 plans/
 .tokensave
 .codebase-memory
+graphify-out/

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -4205,12 +4205,15 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         int seasonNumber = currentSeasonSourceScope();
         if (item == null || !item.isTv() || item.getTmdbId() <= 0 || seasonNumber < 0) return;
         int generation = loadGeneration;
+        // 把当前站源和这次提交绑定，避免和后续换源写入的 intent 混用。
+        String currentKey = getKeyText();
         detailTasks.submit(() -> {
             List<SourceMatch> sources = findSeasonHistorySources(item, seasonNumber);
             runOnAliveUi(() -> {
                 if (generation != loadGeneration || routeGeneration != seasonSourceRouteGeneration || sources.isEmpty()) return;
+                Set<String> usedLabels = new HashSet<>();
                 for (SourceMatch source : sources) {
-                    MaterialButton button = createChipButton(source.site().getName());
+                    MaterialButton button = createChipButton(distinctChipLabel(seasonSourceRouteLabel(source, currentKey), usedLabels));
                     setChipState(button, false);
                     button.setNextFocusDownId(R.id.episodeReverse);
                     button.setOnKeyListener((view, keyCode, event) -> onDetailFlagKey(keyCode, event));
@@ -4219,6 +4222,31 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
                 }
             });
         });
+    }
+
+    /**
+     * 这些 chip 混在线路行里，但点下去是换源而不是切线路，所以文字必须自带来源语义。
+     * 同一站源的另一个入口（常见于按季拆条目）用条目名区分，避免和右侧“站源：X”重名。
+     */
+    private String seasonSourceRouteLabel(SourceMatch source, String currentKey) {
+        String siteName = source.site().getDisplayName();
+        if (!TextUtils.equals(source.site().getKey(), currentKey)) {
+            return getString(R.string.detail_source_route_chip, siteName);
+        }
+        String entryName = source.vod() == null ? "" : source.vod().getName();
+        if (TextUtils.isEmpty(entryName)) entryName = source.vod() == null ? "" : source.vod().getId();
+        return getString(R.string.detail_source_route_chip_entry, TextUtils.isEmpty(entryName) ? siteName : entryName);
+    }
+
+    /**
+     * 同站可能存在同名条目，重名的 chip 用户无法区分，只能盲点，所以追加序号。
+     */
+    private String distinctChipLabel(String label, Set<String> used) {
+        if (used.add(label)) return label;
+        for (int index = 2; ; index++) {
+            String candidate = label + " (" + index + ")";
+            if (used.add(candidate)) return candidate;
+        }
     }
 
     private void refreshSeasonSourceRoutes() {

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/TmdbHeaderView.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/TmdbHeaderView.java
@@ -739,7 +739,7 @@ public class TmdbHeaderView {
         }
         TextView source = headerRoot.findViewById(R.id.tmdbFusionSource);
         if (source != null) {
-            String siteName = currentSite() == null ? "" : currentSite().getName();
+            String siteName = currentSite() == null ? "" : currentSite().getDisplayName();
             source.setText(TextUtils.isEmpty(siteName) ? "" : "站源： " + siteName);
             source.setVisibility(TextUtils.isEmpty(siteName) ? View.GONE : View.VISIBLE);
         }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1955,6 +1955,8 @@
     <string name="tmdb_episode_compact_season_progress">TMDB S%1$d %2$d/%3$d 集</string>
     <string name="tmdb_episode_compact_planned">TMDB 待播</string>
     <string name="detail_source_current">站源：%1$s</string>
+    <string name="detail_source_route_chip">换源·%1$s</string>
+    <string name="detail_source_route_chip_entry">同站·%1$s</string>
     <string name="detail_source_empty">暂无可用站源</string>
     <string name="detail_source_episode_empty">暂无可用选集或站源</string>
     <string name="detail_source_searching">正在搜索站源...</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1814,6 +1814,8 @@
     <string name="tmdb_episode_compact_season_progress">TMDB S%1$d %2$d/%3$d 集</string>
     <string name="tmdb_episode_compact_planned">TMDB 待播</string>
     <string name="detail_source_current">目前站源：%1$s</string>
+    <string name="detail_source_route_chip">換源·%1$s</string>
+    <string name="detail_source_route_chip_entry">同站·%1$s</string>
     <string name="detail_source_empty">暫無可用站源</string>
     <string name="detail_source_episode_empty">暫無可用選集或站源</string>
     <string name="detail_source_searching">正在搜尋站源...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1973,6 +1973,8 @@
     <string name="tmdb_episode_compact_season_progress">TMDB S%1$d %2$d/%3$d eps</string>
     <string name="tmdb_episode_compact_planned">TMDB upcoming</string>
     <string name="detail_source_current">Current source: %1$s</string>
+    <string name="detail_source_route_chip">Switch · %1$s</string>
+    <string name="detail_source_route_chip_entry">Same site · %1$s</string>
     <string name="detail_source_empty">No available source</string>
     <string name="detail_source_episode_empty">No available episodes or source</string>
     <string name="detail_source_searching">Searching sources...</string>

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -3071,6 +3071,32 @@ public class TmdbDetailActivityLayoutTest {
     }
 
     @Test
+    public void seasonSourceRouteChipsAreDistinguishableFromRealFlags() throws Exception {
+        String source = readJava("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java");
+        String bindRoutes = javaBlockAt(source, "private void bindSeasonSourceRoutes(");
+        String label = javaBlockAt(source, "private String seasonSourceRouteLabel(");
+
+        assertTrue("route chips must be labelled as source switches, not as playback lines",
+                label.contains("R.string.detail_source_route_chip"));
+        assertTrue("a same-site route must be named by its entry so it cannot read as the header source label",
+                label.contains("R.string.detail_source_route_chip_entry"));
+        assertTrue("route chip labels must honour the user's custom site name like the header does",
+                label.contains("getDisplayName()"));
+        assertFalse("route chip labels must not fall back to the raw site name",
+                label.contains("site().getName()"));
+        assertTrue("an entry with no usable name must still get a non-empty label",
+                label.contains("TextUtils.isEmpty(entryName)"));
+        assertFalse("a same-site route stays reachable in one click, so it must not be filtered out",
+                bindRoutes.contains("currentKey)) continue"));
+        assertTrue("duplicate entry names must not produce two identical chips",
+                bindRoutes.contains("distinctChipLabel("));
+        int capture = bindRoutes.indexOf("String currentKey = getKeyText();");
+        int submit = bindRoutes.indexOf("detailTasks.submit(");
+        assertTrue("the intent site key must be bound to this submission, not read back later",
+                capture >= 0 && submit > capture);
+    }
+
+    @Test
     public void initialStandaloneFlagLoadsSeasonBindingBeforeRoutesAndEpisodes() throws Exception {
         String source = readJava("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java");
         String bindFlags = source.substring(source.indexOf("private void bindFlags()"),


### PR DESCRIPTION
线路行里会冒出别的站源名当 chip，看着像线路，点下去其实是换源。
bindFlags 先按 vod.getFlags() 渲染真线路，随后 bindSeasonSourceRoutes 把"同 TMDB ID + 同季在其他路由的历史记录"用同一个 createChipButton
追加进同一个 flagContainer，文字直接取 site.getName()。这些 chip 还 落在 flags.size() 之后，renderFlagSelection 和 focusDetailFlagButton 都遍历不到，所以永远点不亮。

改为让 chip 文字自带来源语义：异站显示"换源·站名"，同站的另一个入口
（按季拆条目时常见）显示"同站·条目名"，都不再和右侧"站源：X"重名。
条目名为空时退到 vodId 再退到站名；同名条目追加序号，避免两个一样的
chip 只能盲点。站名统一走 getDisplayName()，尊重用户改的名字，
TmdbHeaderView 的"站源"标签一并对齐。

注意没有过滤掉同站路由：聚合器的去重键是 siteKey+vodId，同站不同
条目是合法条目，过滤会让它失去一键入口。

顺带把 graphify-out/ 加进 .gitignore，它是 29MB 产物且位于 Java 源根下，git add -A 会把它提交进源码树。