### PR TITLE
修复：播放失败回退后设置弹窗的解码标签不刷新

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -24,6 +24,7 @@ import androidx.leanback.widget.ArrayObjectAdapter;
 import androidx.leanback.widget.HorizontalGridView;
 import androidx.leanback.widget.ItemBridgeAdapter;
 import androidx.appcompat.widget.LinearLayoutCompat;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.leanback.widget.OnChildViewHolderSelectedListener;
 import androidx.leanback.widget.VerticalGridView;
@@ -4769,6 +4770,14 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
     protected void onPlayerRebuilt() {
         setPlayerKernel();
         setDecode();
+        refreshControlDialog();
+    }
+
+    // 设置弹窗自己不会跟着引擎重建刷新，回退期间开着弹窗就会一直显示旧的内核/解码。
+    private void refreshControlDialog() {
+        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+            if (fragment instanceof ControlDialog dialog) dialog.setPlayer();
+        }
     }
 
     @Override
@@ -4776,11 +4785,14 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         refreshLyrics();
         setTrackVisible();
         mClock.setCallback(this);
+        // 轨道要等新引擎 prepare 完才回来，重建那一刻按钮还是隐藏态，弹窗必须在这里再抄一次。
+        refreshControlDialog();
     }
 
     @Override
     protected void onTitlesChanged() {
         setTitleVisible();
+        refreshControlDialog();
     }
 
     @Override

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/ControlDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/ControlDialog.java
@@ -385,11 +385,15 @@ public class ControlDialog extends BaseBottomSheetDialog implements ParseAdapter
         binding.reset.setText(parent.control.action.reset.getText());
         setLut();
         setEpisodeColumn();
+        // 播放失败回退会同时改内核和软硬解，两个标签都得跟着宿主刷新，否则弹窗里只有内核在变。
+        binding.decode.setText(parent.control.action.decode.getText());
         binding.decode.setVisibility(parent.control.action.decode.getVisibility());
         binding.danmaku.setVisibility(parent.control.action.danmaku.getVisibility());
         setKaraokeVisible();
         setImmersiveAudioVisible();
-        setTrackVisible();
+        // setTitleVisible 会带上 setTrackVisible；章节可见性也参与轨道行的计算，
+        // 只抄轨道不抄章节的话，回退后弹窗会拿旧章节状态算出错的轨道行。
+        setTitleVisible();
     }
 
     public void setLut() {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -9883,6 +9883,37 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         hideInlineGestureOverlays();
     }
 
+    /**
+     * 播放失败回退（软解后切核心）在引擎侧换内核/解码后只发 onPlayerRebuild，
+     * 不走 onPrepare，内嵌播放器的内核与解码标签必须在这里补刷，否则会一直停在起播时的值。
+     *
+     * 必须放在 onPrepare 之前：TmdbDetailActivityLayoutTest 用
+     * [onPrepare, getInlineResumePosition) 的源码切片断言 onPrepare 的内容，
+     * 插在两者之间会把本方法并进那段切片里。
+     */
+    @Override
+    protected void onPlayerRebuilt() {
+        if (!isInlinePlayerMode() || !inlineStarted || !isOwner()) return;
+        updateInlineButtons(service() != null && !player().isEmpty() && player().isPlaying());
+        refreshInlineControlDialog();
+    }
+
+    /**
+     * 内嵌设置弹窗只在 initView 时从宿主抄一次标签，回退期间开着弹窗就会一直显示旧的内核/解码。
+     * 弹窗在 mobile flavor 里，main 源集只能反射调用，与 showInlineControlDialog 保持一致。
+     */
+    private void refreshInlineControlDialog() {
+        try {
+            Class<?> dialogClass = Class.forName("com.fongmi.android.tv.ui.dialog.ControlDialog");
+            for (androidx.fragment.app.Fragment fragment : getSupportFragmentManager().getFragments()) {
+                if (dialogClass.isInstance(fragment)) dialogClass.getMethod("setPlayer").invoke(fragment);
+            }
+        } catch (Throwable e) {
+            // 只是标签刷新，失败不该影响播放；但要留痕，否则将来 setPlayer 抛异常会被永久静默成"标签不刷新"。
+            SpiderDebug.log("tmdb-inline", "refresh control dialog failed errorType=%s", e.getClass().getSimpleName());
+        }
+    }
+
     @Override
     protected void onPrepare() {
         if (!isInlinePlayerMode() || !inlineStarted || !isOwner()) return;
@@ -10023,6 +10054,9 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         if (!isInlinePlayerMode() || !inlineStarted || !isOwner()) return;
         updateInlineButtons(service() != null && !player().isEmpty() && player().isPlaying());
         updateInlineDisplayPanel();
+        // 轨道要等新引擎 prepare 完才回来，重建那一刻宿主的音轨/字幕按钮是 GONE，
+        // 弹窗抄到的是这个中间态，必须在轨道就绪后再抄一次。
+        refreshInlineControlDialog();
     }
 
     @Override

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -5414,6 +5414,8 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         refreshLyrics();
         setTrackVisible();
         mClock.setCallback(this);
+        // 轨道要等新引擎 prepare 完才回来，重建那一刻按钮还是隐藏态，弹窗必须在这里再抄一次。
+        refreshControlDialog();
     }
 
     private void updateAudioOnlyState() {
@@ -6547,6 +6549,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
     @Override
     protected void onTitlesChanged() {
         setTitleVisible();
+        refreshControlDialog();
     }
 
     @Override

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/ControlDialog.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/ControlDialog.java
@@ -487,10 +487,14 @@ if (binding == null || controls == null || player == null) return;
         binding.reset.setText(controls.reset.getText());
         setLut();
         setEpisodeColumn();
+        // 播放失败回退会同时改内核和软硬解，两个标签都得跟着宿主刷新，否则弹窗里只有内核在变。
+        binding.decode.setText(controls.decode.getText());
         binding.decode.setVisibility(controls.decode.getVisibility());
         binding.danmaku.setVisibility(controls.danmaku.getVisibility());
         setImmersiveAudioVisible();
-        setTrackVisible();
+        // setTitleVisible 会带上 setTrackVisible；章节可见性也参与轨道行的计算，
+        // 只抄轨道不抄章节的话，回退后弹窗会拿旧章节状态算出错的轨道行。
+        setTitleVisible();
     }
 
     public void setLut() {

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/FallbackDecodeLabelSyncTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/FallbackDecodeLabelSyncTest.java
@@ -1,0 +1,160 @@
+package com.fongmi.android.tv.ui.dialog;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * 播放失败回退（软解后切核心）只发 onPlayerRebuild，不走 onPrepare。三条播放链路的
+ * 「解码」标签都必须挂在 rebuild 回调上，否则内核在变、软硬解一直停在起播时的值。
+ */
+public class FallbackDecodeLabelSyncTest {
+
+    @Test
+    public void controlDialogSyncsDecodeTextNotOnlyItsVisibility() throws Exception {
+        assertMethodContains(read(dialog("mobile")), "public void setPlayer()",
+                "binding.decode.setText(controls.decode.getText());",
+                "binding.decode.setVisibility(controls.decode.getVisibility());");
+        assertMethodContains(read(dialog("leanback")), "public void setPlayer()",
+                "binding.decode.setText(parent.control.action.decode.getText());",
+                "binding.decode.setVisibility(parent.control.action.decode.getVisibility());");
+    }
+
+    /** 两个 flavor 的原生播放页都必须刷主控制栏，并且把设置弹窗一起带上。 */
+    @Test
+    public void nativePlaybackRefreshesKernelDecodeAndTheOpenDialogOnRebuild() throws Exception {
+        for (String flavor : List.of("mobile", "leanback")) {
+            String source = read(videoActivity(flavor));
+            assertMethodContains(source, "protected void onPlayerRebuilt()",
+                    "setPlayerKernel();", "setDecode();", "refreshControlDialog();");
+            assertMethodContains(source, "private void refreshControlDialog()",
+                    "if (fragment instanceof ControlDialog dialog) dialog.setPlayer();");
+        }
+    }
+
+    /** 内嵌播放器要同时刷宿主标签和开着的弹窗，弹窗在 mobile 源集所以只能反射。 */
+    @Test
+    public void fusionInlinePlaybackRefreshesItsLabelsAndDialogOnRebuild() throws Exception {
+        String source = read(tmdbDetailActivity());
+        assertMethodContains(source, "protected void onPlayerRebuilt()",
+                "updateInlineButtons(", "refreshInlineControlDialog();");
+        assertMethodContains(source, "private void refreshInlineControlDialog()",
+                "com.fongmi.android.tv.ui.dialog.ControlDialog", "getMethod(\"setPlayer\").invoke(fragment)");
+    }
+
+    /** 宿主的解码标签必须来自引擎实时值，否则弹窗抄到的仍是旧文字。 */
+    @Test
+    public void hostDecodeLabelsReadTheLiveEngineValue() throws Exception {
+        for (String flavor : List.of("mobile", "leanback")) {
+            assertMethodContains(read(videoActivity(flavor)), "private void setDecode()",
+                    "player().getDecodeText()");
+        }
+        assertMethodContains(read(tmdbDetailActivity()), "private CharSequence inlineDecodeText(boolean hasPlayer)",
+                "player().getDecodeText()");
+    }
+
+    /** updateInlineButtons 是内嵌链路刷解码标签的唯一入口，断言里不能只认方法名。 */
+    @Test
+    public void fusionInlineButtonRefreshActuallyWritesTheDecodeLabel() throws Exception {
+        String source = read(tmdbDetailActivity());
+        assertMethodContains(source, "private void updateInlineButtons(boolean playing)",
+                "setInlineDecodeText(inlineDecodeText(hasPlayer));");
+        assertMethodContains(source, "private void setInlineDecodeText(CharSequence text)",
+                "binding.playerDecode.setText(text);");
+    }
+
+    /**
+     * 本方法必须排在 [onPrepare, getInlineResumePosition) 之外：TmdbDetailActivityLayoutTest
+     * 用这段源码切片断言 onPrepare 的内容，插在中间会把本方法并进那段切片里。
+     */
+    @Test
+    public void fusionRebuildHookStaysOutsideThePrepareSourceSlice() throws Exception {
+        String source = read(tmdbDetailActivity());
+        int rebuild = source.indexOf("protected void onPlayerRebuilt()");
+        int prepare = source.indexOf("protected void onPrepare()");
+        int resume = source.indexOf("private long getInlineResumePosition()");
+        assertTrue("missing onPlayerRebuilt()", rebuild >= 0);
+        assertTrue("missing onPrepare()", prepare >= 0);
+        assertTrue("missing getInlineResumePosition()", resume > prepare);
+        assertTrue("onPlayerRebuilt() must sit either before onPrepare() or after getInlineResumePosition(),"
+                        + " otherwise it pollutes the source slice TmdbDetailActivityLayoutTest uses for onPrepare",
+                rebuild < prepare || rebuild > resume);
+    }
+
+    /** 轨道要等新引擎 prepare 完才回来，三条链路都得在轨道/标题就绪后再刷一次弹窗。 */
+    @Test
+    public void openDialogIsAlsoRefreshedOnceTracksAndTitlesSettle() throws Exception {
+        for (String flavor : List.of("mobile", "leanback")) {
+            String source = read(videoActivity(flavor));
+            assertMethodContains(source, "protected void onTracksChanged()", "refreshControlDialog();");
+            assertMethodContains(source, "protected void onTitlesChanged()", "refreshControlDialog();");
+        }
+        assertMethodContains(read(tmdbDetailActivity()), "protected void onTracksChanged()",
+                "refreshInlineControlDialog();");
+    }
+
+    /**
+     * setPlayer 必须走 setTitleVisible 而不是直接 setTrackVisible：章节可见性参与轨道行计算，
+     * 只抄轨道会让 onTitlesChanged 那次刷新对章节完全无效。
+     */
+    @Test
+    public void dialogRefreshCoversTheTitleChipNotOnlyTheTrackRow() throws Exception {
+        for (String flavor : List.of("mobile", "leanback")) {
+            String source = read(dialog(flavor));
+            assertMethodContains(source, "public void setPlayer()", "setTitleVisible();");
+            assertMethodContains(source, "public void setTitleVisible()", "setTrackVisible();");
+        }
+    }
+
+    private static Path dialog(String flavor) {
+        return moduleRoot().resolve(Path.of("src", flavor, "java", "com", "fongmi",
+                "android", "tv", "ui", "dialog", "ControlDialog.java"));
+    }
+
+    private static Path videoActivity(String flavor) {
+        return moduleRoot().resolve(Path.of("src", flavor, "java", "com", "fongmi",
+                "android", "tv", "ui", "activity", "VideoActivity.java"));
+    }
+
+    private static Path tmdbDetailActivity() {
+        return moduleRoot().resolve(Path.of("src", "main", "java", "com", "fongmi",
+                "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
+    }
+
+    private static String read(Path path) throws Exception {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static void assertMethodContains(String source, String signature, String... snippets) {
+        int start = source.indexOf(signature);
+        assertTrue("missing method " + signature, start >= 0);
+        int open = source.indexOf('{', start);
+        assertTrue("missing method body for " + signature, open >= 0);
+        int depth = 0;
+        int end = -1;
+        for (int i = open; i < source.length(); i++) {
+            char value = source.charAt(i);
+            if (value == '{') depth++;
+            else if (value == '}' && --depth == 0) {
+                end = i + 1;
+                break;
+            }
+        }
+        assertTrue("unterminated method " + signature, end > open);
+        String method = source.substring(start, end);
+        for (String snippet : snippets) {
+            assertTrue(signature + " must contain " + snippet, method.contains(snippet));
+        }
+    }
+
+    private static Path moduleRoot() {
+        Path moduleRelative = Path.of("src", "main", "java");
+        if (Files.exists(moduleRelative)) return Path.of(".");
+        return Path.of("app");
+    }
+}


### PR DESCRIPTION
现象：手机版遇到播放失败回退（软解后切核心）时，内核标签会变，
软硬解标签一直停在起播时的值。TV 版看起来正常。

根因不在引擎侧。日志确认回退链在引擎侧是完整执行的
（IJK 硬解→IJK 软解→系统硬解→系统软解→MPV），失败原因始终是
片源 m3u8 连接超时，换内核和解码都救不回来。真正的问题是
UI 标签漏刷，三条播放链路各有一处独立缺口：

- ControlDialog.setPlayer() 只刷了 decode 的可见性、没刷文字， 两个 flavor 都是。这是"内核会变、解码不变"的直接原因。
- leanback VideoActivity.onPlayerRebuilt() 没有刷新弹窗， 所以 TV 版弹窗同样会显示旧值（此前未暴露是因为没有调用方）。
- TmdbDetailActivity 完全没有 onPlayerRebuilt() 覆写，融合详情页 内嵌播放器的内核和解码标签回退后都不刷新。

另外补上轨道就绪后的二次刷新：onPlayerRebuild 触发时新引擎还没有
轨道，宿主的音轨/字幕/画质按钮此刻是隐藏态，弹窗若只在这一刻抄一次
会把中间态固化下来，因此在 onTracksChanged/onTitlesChanged 再抄一次。 setPlayer() 末尾改调 setTitleVisible()（内部会带上 setTrackVisible()）， 否则章节可见性抄不到，而它参与轨道行的计算。

新增 FallbackDecodeLabelSyncTest 用源码断言锁住三条链路的刷新点，
含一条守卫：新覆写必须排在 TmdbDetailActivityLayoutTest 用于断言
onPrepare 的源码切片之外。

验证：两个 flavor 编译通过；mobile 3541 / leanback 2779 项单测通过， 仅 MpvPreloadControllerTest 2 项失败，stash 后可复现，属既有失败。 回退流程本身未在真机验证。