### PR TITLE
修复：TV版设置视频壁纸后播放视频卡顿

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -518,6 +518,11 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         return true;
     }
 
+    @Override
+    protected boolean customWallMotion() {
+        return false;
+    }
+
     public static void file(FragmentActivity activity, String path) {
         file(activity, path, "");
     }

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/base/BaseActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/base/BaseActivity.java
@@ -56,7 +56,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     private void addCustomWall() {
-        ((ViewGroup) findViewById(android.R.id.content)).addView(new CustomWallView(this, null), 0, new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT));
+        ((ViewGroup) findViewById(android.R.id.content)).addView(new CustomWallView(this, null).setMotionEnabled(customWallMotion()), 0, new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT));
     }
 
     protected FragmentActivity getActivity() {
@@ -64,6 +64,14 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     protected boolean customWall() {
+        return true;
+    }
+
+    /**
+     * 动态壁纸（视频/GIF）是否允许在本页面播放。返回 false 时壁纸降级为首帧静态图，
+     * 避免与页面自身的播放器争抢 MediaCodec 硬解实例并按壁纸帧率重绘整个界面。
+     */
+    protected boolean customWallMotion() {
         return true;
     }
 

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -590,6 +590,11 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     @Override
+    protected boolean customWallMotion() {
+        return false;
+    }
+
+    @Override
     protected PlaybackService.NavigationCallback getNavigationCallback() {
         return mNavigationCallback;
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/CustomWallView.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/CustomWallView.java
@@ -45,9 +45,7 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
     private static final int DEFAULT_WALL_COLOR = Setting.getBuiltInWallColor(Setting.WALL_DREAM_PURPLE);
     private static final int GREEN_WALL_COLOR = 0xFF40C090;
     private static final int MAX_WALL_BITMAP_SIDE = 1920;
-    private static final int TYPE_RES = 0;
-    private static final int TYPE_GIF = 1;
-    private static final int TYPE_VIDEO = 2;
+    private static final int TYPE_RES = WallMotionPolicy.TYPE_RES;
     private ViewWallBinding binding;
     private GifDrawable drawable;
     private PlayerView video;
@@ -55,6 +53,8 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
     private final Runnable refreshRunnable = this::refresh;
     private boolean observerAdded;
     private boolean motionEnabled = true;
+    private boolean videoRestorePending;
+    private boolean started;
 
     public CustomWallView(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
@@ -109,7 +109,9 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
     }
 
     private void stop() {
-        if (player != null && player.isPlaying()) {
+        // 不能用 isPlaying() 做前置条件：壁纸视频在 buffering 时 isPlaying() 为 false，
+        // 此时切换壁纸配置会把旧的 MediaItem 留在播放器里。
+        if (player != null) {
             player.stop();
             player.clearMediaItems();
         }
@@ -130,8 +132,8 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
         if (isBuiltInColor(wall, type)) loadColor(Setting.getBuiltInWallColor(wall));
         else if (isBuiltInDesign(wall, type)) loadDesign(wall);
         else if (isGreen(wall, type)) loadRes(R.drawable.wallpaper_1);
-        else if (motionEnabled && type == TYPE_VIDEO) loadVideo(FileUtil.getWall(wall));
-        else if (motionEnabled && type == TYPE_GIF) loadGif(FileUtil.getWall(wall));
+        else if (WallMotionPolicy.isVideoMotion(motionEnabled, type)) loadVideo(FileUtil.getWall(wall));
+        else if (WallMotionPolicy.isGifMotion(motionEnabled, type)) loadGif(FileUtil.getWall(wall));
         else loadImage();
     }
 
@@ -214,11 +216,28 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
 
     private void loadVideo(File file) {
         if (!isReady()) return;
+        // 静态底图兜住起播前的空窗和解码失败；缓存缺失时退到默认色，别把 ImageView 清空。
+        Drawable cache = cache();
+        binding.image.setImageDrawable(cache != null ? cache : new ColorDrawable(DEFAULT_WALL_COLOR));
+        // 页面已 onStop（例如后台收到换壁纸事件）时不要建解码器，留给 onResume 补上。
+        if (WallMotionPolicy.shouldDeferVideo(motionEnabled, Setting.getWallType(), started)) {
+            videoRestorePending = true;
+            return;
+        }
+        startVideo(file);
+    }
+
+    /**
+     * 起播壁纸视频，但不重新解码首帧静态底图——从后台返回时底图还在，
+     * 省掉一次主线程上的全屏 Bitmap 解码。
+     */
+    private void startVideo(File file) {
+        if (!isReady()) return;
+        videoRestorePending = false;
         ensurePlayer();
         ensureVideoView();
         video.setPlayer(player);
         video.setVisibility(VISIBLE);
-        binding.image.setImageDrawable(cache());
         player.setMediaItem(MediaItem.fromUri(Uri.fromFile(file)));
         player.prepare();
     }
@@ -335,14 +354,28 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
         return isBuiltInColor(wall, type) || isBuiltInDesign(wall, type) || isGreen(wall, type);
     }
 
+    /** 与 {@link #load()} 里走 loadVideo 的条件保持一致；内置色/设计壁纸的 type 恒为 TYPE_RES，故无需再排除。 */
+    private boolean isVideoWall() {
+        return WallMotionPolicy.isVideoMotion(motionEnabled, Setting.getWallType());
+    }
+
     @Override
     public void onCreate(@NonNull LifecycleOwner owner) {
         EventBus.getDefault().register(this);
     }
 
     @Override
+    public void onStart(@NonNull LifecycleOwner owner) {
+        started = true;
+    }
+
+    @Override
     public void onResume(@NonNull LifecycleOwner owner) {
         if (drawable != null) drawable.start();
+        if (videoRestorePending) {
+            restoreVideo();
+            return;
+        }
         if (!hasVideo()) return;
         video.setPlayer(player);
         player.play();
@@ -357,6 +390,33 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
     }
 
     @Override
+    public void onStop(@NonNull LifecycleOwner owner) {
+        // 释放而非仅暂停：壁纸播放器占着一路 MediaCodec 硬解实例，返回栈里的页面
+        // 一直留着它会挤占前台播放器的解码器配额。下次 onResume 重新 prepare。
+        started = false;
+        releasePlayer();
+    }
+
+    private void releasePlayer() {
+        if (player == null) return;
+        videoRestorePending = isVideoWall();
+        if (video != null) {
+            video.setPlayer(null);
+            video.setVisibility(GONE);
+        }
+        player.release();
+        player = null;
+    }
+
+    private void restoreVideo() {
+        // 尚未 ready 时保留标志，等下一次 onResume 再试；否则这次恢复机会就丢了。
+        if (!isReady()) return;
+        videoRestorePending = false;
+        if (!isVideoWall()) return;
+        startVideo(FileUtil.getWall(Setting.getWall()));
+    }
+
+    @Override
     public void onDestroy(@NonNull LifecycleOwner owner) {
         removeCallbacks(refreshRunnable);
         EventBus.getDefault().unregister(this);
@@ -364,6 +424,8 @@ public class CustomWallView extends FrameLayout implements DefaultLifecycleObser
         if (video != null) removeView(video);
         if (player != null) player.release();
         observerAdded = false;
+        videoRestorePending = false;
+        started = false;
         drawable = null;
         binding = null;
         player = null;

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/WallMotionPolicy.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/WallMotionPolicy.java
@@ -1,0 +1,33 @@
+package com.fongmi.android.tv.ui.custom;
+
+/**
+ * 动态壁纸（视频/GIF）的起播决策。抽成纯 Java 是为了能直接单测——动态壁纸多占一路
+ * MediaCodec 硬解实例并按壁纸帧率触发全窗口重绘，在电视盒子上会拖慢前台播放器。
+ */
+public final class WallMotionPolicy {
+
+    public static final int TYPE_RES = 0;
+    public static final int TYPE_GIF = 1;
+    public static final int TYPE_VIDEO = 2;
+
+    private WallMotionPolicy() {
+    }
+
+    /** 视频壁纸是否该起播。motion 关闭时降级为首帧静态图，不建解码器。 */
+    public static boolean isVideoMotion(boolean motionEnabled, int wallType) {
+        return motionEnabled && wallType == TYPE_VIDEO;
+    }
+
+    /** GIF 壁纸是否该动起来。 */
+    public static boolean isGifMotion(boolean motionEnabled, int wallType) {
+        return motionEnabled && wallType == TYPE_GIF;
+    }
+
+    /**
+     * 页面已 onStop（例如后台收到换壁纸事件）时是否要记下"回来后重建视频壁纸"。
+     * 此时不建解码器——白占的一路 MediaCodec 要等用户回到该页面才用得上。
+     */
+    public static boolean shouldDeferVideo(boolean motionEnabled, int wallType, boolean started) {
+        return isVideoMotion(motionEnabled, wallType) && !started;
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/ui/custom/VideoWallPlaybackCostTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/custom/VideoWallPlaybackCostTest.java
@@ -1,0 +1,168 @@
+package com.fongmi.android.tv.ui.custom;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * 动态壁纸（视频/GIF）会额外占一路 MediaCodec 硬解实例，并按壁纸帧率重绘整个界面。
+ * 这些测试锁住「播放类页面必须关掉动效」以及「后台页面必须交还解码器」两条约束——
+ * 缺了它们在电视盒子上会表现为播放卡顿。
+ */
+public class VideoWallPlaybackCostTest {
+
+    @Test
+    public void bothFlavorsGateMotionWallpaperPerActivity() throws Exception {
+        for (String flavor : new String[]{"leanback", "mobile"}) {
+            String base = readSource(flavor, "ui/base/BaseActivity.java");
+            assertTrue(flavor + " BaseActivity must expose a per-activity motion wallpaper switch",
+                    base.contains("protected boolean customWallMotion()"));
+            assertTrue(flavor + " BaseActivity must pass the motion switch into CustomWallView",
+                    base.contains("new CustomWallView(this, null).setMotionEnabled(customWallMotion())"));
+        }
+    }
+
+    @Test
+    public void playbackScreensDisableMotionWallpaper() throws Exception {
+        assertMotionDisabled(readSource("leanback", "ui/activity/VideoActivity.java"), "leanback VideoActivity");
+        assertMotionDisabled(readSource("mobile", "ui/activity/VideoActivity.java"), "mobile VideoActivity");
+        assertMotionDisabled(readSource("mobile", "ui/activity/LiveActivity.java"), "mobile LiveActivity");
+        assertMotionDisabled(readMainSource("ui/activity/TmdbDetailActivity.java"), "TmdbDetailActivity");
+    }
+
+    @Test
+    public void wallpaperReleasesDecoderWhileBackgrounded() throws Exception {
+        String source = readMainSource("ui/custom/CustomWallView.java");
+        int onStop = source.indexOf("public void onStop(@NonNull LifecycleOwner owner)");
+        assertTrue("CustomWallView must handle onStop to free its decoder", onStop >= 0);
+        assertTrue("onStop must release the wallpaper player, not merely pause it",
+                source.substring(onStop, source.indexOf("\n    }", onStop)).contains("releasePlayer();"));
+
+        int release = source.indexOf("private void releasePlayer()");
+        assertTrue("CustomWallView is missing releasePlayer", release >= 0);
+        String body = source.substring(release, source.indexOf("\n    }", release));
+        assertTrue("releasePlayer must remember to restore a video wall on resume",
+                body.contains("videoRestorePending = isVideoWall();"));
+        assertTrue("releasePlayer must actually release the ExoPlayer", body.contains("player.release();"));
+        assertTrue("releasePlayer must drop the released instance", body.contains("player = null;"));
+
+        int resume = source.indexOf("public void onResume(@NonNull LifecycleOwner owner)");
+        assertTrue("CustomWallView is missing onResume", resume >= 0);
+        assertTrue("onResume must re-prepare a wallpaper released while backgrounded",
+                source.substring(resume, source.indexOf("\n    }", resume)).contains("restoreVideo();"));
+    }
+
+    @Test
+    public void backgroundedWallpaperChangeDefersDecoderCreation() throws Exception {
+        String source = readMainSource("ui/custom/CustomWallView.java");
+        int load = source.indexOf("private void loadVideo(File file)");
+        assertTrue("CustomWallView is missing loadVideo", load >= 0);
+        String body = source.substring(load, source.indexOf("\n    }", load));
+        // 后台收到换壁纸事件时建解码器会白占一路 MediaCodec，直到用户回到该页面。
+        assertTrue("loadVideo must defer starting the player while the host is stopped",
+                body.contains("WallMotionPolicy.shouldDeferVideo(motionEnabled, Setting.getWallType(), started)"));
+        assertTrue("the deferred wall must be remembered so onResume can rebuild it",
+                body.contains("videoRestorePending = true;"));
+    }
+
+    @Test
+    public void deferredWallpaperKeepsItsStaticBackdrop() throws Exception {
+        String source = readMainSource("ui/custom/CustomWallView.java");
+        int load = source.indexOf("private void loadVideo(File file)");
+        assertTrue("CustomWallView is missing loadVideo", load >= 0);
+        // startVideo 不再设置底图，缓存缺失时若直接 setImageDrawable(null) 壁纸会全空。
+        assertTrue("loadVideo must fall back to a solid colour when the frame cache is missing",
+                source.substring(load, source.indexOf("\n    }", load)).contains("cache != null ? cache : new ColorDrawable(DEFAULT_WALL_COLOR)"));
+
+        int restore = source.indexOf("private void restoreVideo()");
+        assertTrue("CustomWallView is missing restoreVideo", restore >= 0);
+        String body = source.substring(restore, source.indexOf("\n    }", restore));
+        // 尚未 ready 时清掉标志会丢掉这次恢复机会，视频壁纸要等下一次换壁纸事件才回来。
+        // 守卫缺失时 indexOf 返回 -1 会让顺序断言空洞通过，所以先断言它存在。
+        int guard = body.indexOf("if (!isReady()) return;");
+        int clear = body.indexOf("videoRestorePending = false;");
+        assertTrue("restoreVideo must bail out before touching the pending flag when not ready", guard >= 0);
+        assertTrue("restoreVideo must clear the pending flag once it is ready", clear >= 0);
+        assertTrue("restoreVideo must keep the pending flag until the view is ready", guard < clear);
+        // 后台把视频壁纸换成图片后回到前台，不能再去 prepare 一个已经不是视频的文件。
+        assertTrue("restoreVideo must not rebuild a decoder once the wall is no longer a video",
+                body.contains("if (!isVideoWall()) return;"));
+    }
+
+    @Test
+    public void wallpaperLoadRoutesMotionThroughPolicy() throws Exception {
+        String source = readMainSource("ui/custom/CustomWallView.java");
+        int load = source.indexOf("private void load()");
+        assertTrue("CustomWallView is missing load", load >= 0);
+        String body = source.substring(load, source.indexOf("\n    }", load));
+        // 门控丢了 motionEnabled，播放页就会重新起播壁纸视频——本次修复的核心就在这两行。
+        assertTrue("video wall must be gated by the per-activity motion switch",
+                body.contains("WallMotionPolicy.isVideoMotion(motionEnabled, type)"));
+        assertTrue("gif wall must be gated by the per-activity motion switch",
+                body.contains("WallMotionPolicy.isGifMotion(motionEnabled, type)"));
+    }
+
+    @Test
+    public void wallpaperTracksStartedState() throws Exception {
+        String source = readMainSource("ui/custom/CustomWallView.java");
+        int onStart = source.indexOf("public void onStart(@NonNull LifecycleOwner owner)");
+        assertTrue("CustomWallView must observe onStart to know when a decoder may be built", onStart >= 0);
+        assertTrue("onStart must mark the host as started, otherwise video walls never start",
+                source.substring(onStart, source.indexOf("\n    }", onStart)).contains("started = true;"));
+
+        int onStop = source.indexOf("public void onStop(@NonNull LifecycleOwner owner)");
+        assertTrue("onStop must clear the started flag",
+                source.substring(onStop, source.indexOf("\n    }", onStop)).contains("started = false;"));
+    }
+
+    @Test
+    public void wallpaperResetClearsBufferingMediaItem() throws Exception {
+        String source = readMainSource("ui/custom/CustomWallView.java");
+        int stop = source.indexOf("private void stop()");
+        assertTrue("CustomWallView is missing stop", stop >= 0);
+        String body = source.substring(stop, source.indexOf("\n    }", stop));
+        // buffering 时 isPlaying() 为 false，用它当前置条件会把旧 MediaItem 留在播放器里。
+        assertFalse("stop must not gate clearMediaItems on isPlaying", body.contains("player.isPlaying()"));
+        assertTrue("stop must still halt the wallpaper player", body.contains("player.stop();"));
+        assertTrue("stop must still drop the old media item", body.contains("player.clearMediaItems();"));
+    }
+
+    @Test
+    public void playerOnlyScreensKeepTheWallpaperLayerOff() throws Exception {
+        // 这些页面靠 customWall()==false 完全不建壁纸视图，所以没有 customWallMotion 覆写。
+        // 一旦有人把它们改回 true，动效会无声地回来，故在此加锁。
+        assertWallDisabled(readSource("leanback", "ui/activity/LiveActivity.java"), "leanback LiveActivity");
+        assertWallDisabled(readSource("leanback", "ui/activity/CastActivity.java"), "leanback CastActivity");
+        assertWallDisabled(readMainSource("ui/activity/AudioActivity.java"), "AudioActivity");
+    }
+
+    private static void assertWallDisabled(String source, String label) {
+        int method = source.indexOf("protected boolean customWall()");
+        assertTrue(label + " is missing customWall", method >= 0);
+        String body = source.substring(method, source.indexOf("\n    }", method));
+        assertTrue(label + " must keep the wallpaper layer off, or it needs customWallMotion() == false too",
+                body.contains("return false;"));
+    }
+
+    private static void assertMotionDisabled(String source, String label) {
+        int method = source.indexOf("protected boolean customWallMotion()");
+        assertTrue(label + " must override customWallMotion to spare the decoder", method >= 0);
+        assertTrue(label + " must disable motion wallpaper while a player is on screen",
+                source.substring(method, source.indexOf("\n    }", method)).contains("return false;"));
+    }
+
+    private static String readMainSource(String file) throws Exception {
+        return readSource("main", file);
+    }
+
+    private static String readSource(String sourceSet, String file) throws Exception {
+        Path app = Files.exists(Path.of("src", "main")) ? Path.of(".") : Path.of("app");
+        Path path = app.resolve(Path.of("src", sourceSet, "java", "com", "fongmi", "android", "tv", file));
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/ui/custom/WallMotionPolicyTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/custom/WallMotionPolicyTest.java
@@ -1,0 +1,39 @@
+package com.fongmi.android.tv.ui.custom;
+
+import static com.fongmi.android.tv.ui.custom.WallMotionPolicy.TYPE_GIF;
+import static com.fongmi.android.tv.ui.custom.WallMotionPolicy.TYPE_RES;
+import static com.fongmi.android.tv.ui.custom.WallMotionPolicy.TYPE_VIDEO;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class WallMotionPolicyTest {
+
+    @Test
+    public void motionOffKeepsVideoWallStatic() {
+        assertFalse("播放页关掉动效后视频壁纸不能起播，否则会抢前台播放器的硬解实例",
+                WallMotionPolicy.isVideoMotion(false, TYPE_VIDEO));
+        assertFalse(WallMotionPolicy.isGifMotion(false, TYPE_GIF));
+    }
+
+    @Test
+    public void motionOnAnimatesMatchingWallTypeOnly() {
+        assertTrue(WallMotionPolicy.isVideoMotion(true, TYPE_VIDEO));
+        assertTrue(WallMotionPolicy.isGifMotion(true, TYPE_GIF));
+        assertFalse("GIF 壁纸不该走视频解码器", WallMotionPolicy.isVideoMotion(true, TYPE_GIF));
+        assertFalse("视频壁纸不该走 GIF 解码", WallMotionPolicy.isGifMotion(true, TYPE_VIDEO));
+        assertFalse(WallMotionPolicy.isVideoMotion(true, TYPE_RES));
+        assertFalse(WallMotionPolicy.isGifMotion(true, TYPE_RES));
+    }
+
+    @Test
+    public void stoppedPageDefersVideoUntilResume() {
+        assertTrue("后台收到换壁纸事件应记下待恢复，而不是白占一路解码器",
+                WallMotionPolicy.shouldDeferVideo(true, TYPE_VIDEO, false));
+        assertFalse("前台页面不需要延迟", WallMotionPolicy.shouldDeferVideo(true, TYPE_VIDEO, true));
+        assertFalse("动效关闭时没有要恢复的视频", WallMotionPolicy.shouldDeferVideo(false, TYPE_VIDEO, false));
+        assertFalse("GIF 壁纸不走视频恢复通道", WallMotionPolicy.shouldDeferVideo(true, TYPE_GIF, false));
+        assertFalse("图片壁纸不走视频恢复通道", WallMotionPolicy.shouldDeferVideo(true, TYPE_RES, false));
+    }
+}


### PR DESCRIPTION
视频壁纸是独立的 ExoPlayer + TextureView，全屏铺在 Activity content 最底层。 它在播放页背后继续解码，既多占一路 MediaCodec 硬解实例，又按壁纸帧率触发整个
界面重绘，在电视盒子上表现为播放卡顿。手机版早有 customWallMotion() 开关在
播放页把动态壁纸降级为首帧静态图，TV 版漏了这个机制。

- leanback BaseActivity 补上 customWallMotion() 钩子并传入 CustomWallView， VideoActivity 覆写为 false，与手机版对齐
- TmdbDetailActivity 同样关闭动效，该页自带内嵌播放器且两个 flavor 共用
- CustomWallView 改为在 onStop 释放播放器而非仅暂停，返回栈里的页面不再占着 硬解实例；onResume 通过 videoRestorePending 重新 prepare
- 页面已 onStop 时收到换壁纸事件不再立即建解码器，避免白占到用户回来
- 修 stop() 用 isPlaying() 做前置条件的漏判：壁纸 buffering 时该值为 false， 此时切换壁纸会把旧 MediaItem 留在播放器里
- loadVideo() 给首帧缓存加兜底色，避免缓存缺失时把底图清空
- 动效决策抽成 WallMotionPolicy 纯 Java 类以便单测，并补两个 flavor 的回归锁