### PR TITLE
修复：直链起播选到最低分辨率、视轨列表高亮分不清在播哪条

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/player/exo/ExoAutomaticVideoConstraintPolicy.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/exo/ExoAutomaticVideoConstraintPolicy.java
@@ -322,7 +322,10 @@ final class ExoAutomaticVideoConstraintPolicy {
     enum Fault {
         NONE("none"),
         DROPPED_FRAMES("dropped-frames"),
-        CODEC_ERROR("codec-error");
+        CODEC_ERROR("codec-error"),
+        // 起播固定选约束内最高画质后，原生 ABR 不再提供吞吐保护，带宽不足只能表现为持续重缓冲。
+        // 解码器本身没有压力，掉帧和编解码错误都不会触发，因此需要独立的吞吐不足证据来降档。
+        THROUGHPUT("throughput");
 
         private final String label;
 

--- a/app/src/main/java/com/fongmi/android/tv/player/exo/ExoUtil.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/exo/ExoUtil.java
@@ -358,7 +358,13 @@ public class ExoUtil {
         builder.setExceedVideoConstraintsIfNecessary(true);
         builder.setAllowVideoNonSeamlessAdaptiveness(true);
         builder.setAllowVideoMixedMimeTypeAdaptiveness(true);
-        builder.setForceHighestSupportedBitrate(false);
+        // 起播就选约束内画质最高的轨道，而不是把选择交给 media3 原生 ABR。原生 ABR 起播只有
+        // DefaultBandwidthMeter 的初始猜测（Wi-Fi 4.3Mbps 起、未知网络 1Mbps）可用，再乘
+        // bandwidthFraction，HLS 多码率直链必然落到最低几档；直播缓冲为 0 时还不允许向上切。
+        // 代价是同组只会选中一条轨道（eligibility 变成 FIXED），原生 ABR 不再兜底吞吐，
+        // 因此降级完全依赖 AutomaticVideoConstraintController / LegacyAdaptiveVideoProfileController
+        // 收紧上面这些 max 约束：温度、解码、网络计费之外，两者都必须自己按带宽和重缓冲降档。
+        builder.setForceHighestSupportedBitrate(true);
     }
 
     public static EnhancedVideoProfile getEnhancedVideoProfile() {
@@ -1174,6 +1180,7 @@ public class ExoUtil {
         private Format selectedFormat;
         private int playbackState;
         private boolean playing;
+        private boolean everReady;
         private boolean adaptiveVideo;
         private int selectedVideoCandidates;
         private int availableVideoFormats;
@@ -1201,7 +1208,24 @@ public class ExoUtil {
 
         @Override
         public void onPlaybackStateChanged(EventTime eventTime, @Player.State int state) {
+            // 先对齐会话再判断：everReady 由 bindSession 重置，而 bindSession 原本只在
+            // buildInput 里才发生。换片时若先读 everReady，会把上一片的起播状态带过来，
+            // 让新片的首次缓冲被误判成重缓冲而白降一档。
+            bindEventSession();
+            boolean rebuffered = state == Player.STATE_BUFFERING && everReady;
+            if (state == Player.STATE_READY) everReady = true;
             playbackState = state;
+            // 已经起播过又退回缓冲，说明当前轨道的码率超出实际可用带宽。带宽估算可能仍然偏乐观，
+            // 因此把重缓冲本身也当作吞吐不足的证据，避免弱网锁在最高档反复重缓冲。
+            if (rebuffered) {
+                applyFault(
+                        ExoAutomaticVideoConstraintPolicy.Fault.THROUGHPUT,
+                        eventTime.currentPlaybackPositionMs,
+                        0,
+                        0,
+                        "rebuffer");
+                return;
+            }
             refresh("playback-state", eventTime.currentPlaybackPositionMs);
         }
 
@@ -1256,6 +1280,25 @@ public class ExoUtil {
                     0,
                     0,
                     videoCodecError == null ? "unknown" : videoCodecError.getClass().getSimpleName());
+        }
+
+        // 起播固定选约束内最高画质后原生 ABR 不再兜底吞吐，带宽撑不住当前轨道时解码器并无压力，
+        // 只会表现为持续重缓冲，掉帧与编解码错误都不会触发。这里按实测带宽独立降档，
+        // 否则弱网锁在最高档会一直重缓冲且无法恢复。
+        @Override
+        public void onBandwidthEstimate(EventTime eventTime, int totalLoadTimeMs, long totalBytesLoaded, long bitrateEstimate) {
+            // 只比对当前轨道自己申报的码率。轨道码率未知时不能退回 appliedLimit 的上限，
+            // 那是设备能力上限（4K 档可达 20Mbps），拿它比会让码率不高的正常片源也持续误降档；
+            // 这种情况交给重缓冲证据兜底。
+            int selectedBitrate = ExoPlaybackDiagnostics.trackConstraintBitrate(selectedFormat);
+            if (selectedBitrate <= 0) return;
+            if (!ExoAdaptiveVideoBitratePolicy.shouldDowngrade(selectedBitrate, bitrateEstimate)) return;
+            applyFault(
+                    ExoAutomaticVideoConstraintPolicy.Fault.THROUGHPUT,
+                    eventTime.currentPlaybackPositionMs,
+                    0,
+                    0,
+                    "bandwidth=" + bitrateEstimate);
         }
 
         @Override
@@ -1329,6 +1372,7 @@ public class ExoUtil {
             lastDecision = null;
             lastLoggedAction = null;
             selectedFormat = null;
+            everReady = false;
             adaptiveVideo = false;
             selectedVideoCandidates = 0;
             availableVideoFormats = 0;

--- a/app/src/main/java/com/fongmi/android/tv/player/exo/TrackUtil.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/exo/TrackUtil.java
@@ -54,6 +54,59 @@ public class TrackUtil {
         return onlySelectedFormat(selected);
     }
 
+    /**
+     * 自适应选轨会把同一组里的多条轨道同时标记为已选中，轨道列表因此会高亮出多项，用户看不出
+     * 当前到底在播哪一条。这里用播放器正在解码的格式把范围收敛到一条；匹配不上时返回 null，
+     * 让调用方退回原始的选中标记，而不是让列表一项都不高亮。
+     */
+    public static Format uniqueActiveFormat(Tracks tracks, int type, Format active) {
+        if (tracks == null || tracks.isEmpty() || active == null) return null;
+        List<Format> selected = selectedFormats(tracks, type);
+        if (selected.size() < 2) return null;
+        for (Format format : selected) if (sameRendition(format, active)) return format;
+        return null;
+    }
+
+    static List<Format> selectedFormats(Tracks tracks, int type) {
+        List<Format> selected = new ArrayList<>();
+        if (tracks == null) return selected;
+        for (Tracks.Group group : tracks.getGroups()) {
+            if (group.getType() != type) continue;
+            for (int i = 0; i < group.length; i++) {
+                if (group.isTrackSelected(i)) selected.add(group.getTrackFormat(i));
+            }
+        }
+        return selected;
+    }
+
+    static boolean sameRendition(Format candidate, Format active) {
+        if (candidate == null || active == null) return false;
+        if (candidate.equals(active)) return true;
+        if (candidate.id != null && candidate.id.equals(active.id)) return true;
+        if (candidate.width != active.width || candidate.height != active.height) return false;
+        int candidateBitrate = getBitrate(candidate);
+        int activeBitrate = getBitrate(active);
+        boolean bitrateComparable = candidateBitrate > 0 && activeBitrate > 0;
+        if (bitrateComparable && candidateBitrate != activeBitrate) return false;
+        // 同一分辨率可能同时提供 H.264 和 HEVC 两条轨道，编码能比就必须一致。
+        Boolean codecMatch = codecMatch(candidate, active);
+        if (codecMatch != null) return codecMatch;
+        // 编码无从比较时只能靠码率区分；两边码率都未知就判定不匹配，
+        // 让调用方退回播放器的选中标记，而不是高亮到错的一条。
+        return bitrateComparable;
+    }
+
+    /** 返回编码是否一致，两边信息不足以比较时返回 null。 */
+    private static Boolean codecMatch(Format candidate, Format active) {
+        if (candidate.sampleMimeType != null && active.sampleMimeType != null) {
+            return candidate.sampleMimeType.equals(active.sampleMimeType);
+        }
+        if (candidate.codecs != null && active.codecs != null) {
+            return candidate.codecs.equals(active.codecs);
+        }
+        return null;
+    }
+
     static Format onlySelectedFormat(List<Format> selected) {
         return selected != null && selected.size() == 1 ? selected.get(0) : null;
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/TrackDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/TrackDialog.java
@@ -31,6 +31,7 @@ import com.fongmi.android.tv.bean.Track;
 import com.fongmi.android.tv.databinding.DialogTrackBinding;
 import com.fongmi.android.tv.player.PlayerHelper;
 import com.fongmi.android.tv.player.PlayerManager;
+import com.fongmi.android.tv.player.exo.TrackUtil;
 import com.fongmi.android.tv.service.AiSubtitleTranslationService;
 import com.fongmi.android.tv.setting.PlaybackPerformanceSetting;
 import com.fongmi.android.tv.setting.PlayerSetting;
@@ -543,7 +544,10 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
     }
 
     private void addTrack(List<Track> items) {
-        List<Tracks.Group> groups = player.getCurrentTracks().getGroups();
+        // 只取一次轨道快照：MPV/IJK 的快照由原生回调线程写入，分两次读可能拿到不同的轨道集合。
+        Tracks tracks = player.getCurrentTracks();
+        List<Tracks.Group> groups = tracks.getGroups();
+        Format active = activeVideoFormat(tracks);
         for (int i = 0; i < groups.size(); i++) {
             Tracks.Group trackGroup = groups.get(i);
             if (trackGroup.getType() != type) continue;
@@ -555,11 +559,26 @@ public final class TrackDialog extends BaseBottomSheetDialog implements TrackAda
                 // switching must target this stable id directly; the formatted description
                 // is only persisted for restoring a preference on the next playback.
                 Track item = new Track(type, name, PlayerHelper.describeFormat(format)).playerId(format.id);
-                item.setSelected(secondarySubtitle ? player.isSecondarySubtitleSelected(format) : trackGroup.isTrackSelected(j));
+                item.setSelected(isSelected(trackGroup, j, format, active));
                 items.add(item);
             }
         }
         addPendingSubtitleTrack(items);
+    }
+
+    private boolean isSelected(Tracks.Group trackGroup, int trackIndex, Format format, Format active) {
+        if (secondarySubtitle) return player.isSecondarySubtitleSelected(format);
+        // 自适应选轨会同时选中同组里的多条轨道，列表因此会高亮出多项。已经确认当前正在解码的
+        // 那一条时只高亮它，其余情况仍沿用播放器的选中标记。
+        // 这里按引用比对：uniqueActiveFormat 返回的就是轨道列表里的那个实例，而字段完全相同的
+        // 两条轨道用 equals 会同时命中，反而又变成多项高亮。media3 的 TrackGroup.indexOf 同样按引用定位。
+        if (active != null) return format == active;
+        return trackGroup.isTrackSelected(trackIndex);
+    }
+
+    private Format activeVideoFormat(Tracks tracks) {
+        if (secondarySubtitle || type != C.TRACK_TYPE_VIDEO) return null;
+        return TrackUtil.uniqueActiveFormat(tracks, type, player.getVideoFormat());
     }
 
     private void addPendingSubtitleTrack(List<Track> items) {

--- a/app/src/test/java/com/fongmi/android/tv/player/exo/ExoAutomaticVideoConstraintPolicyTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/player/exo/ExoAutomaticVideoConstraintPolicyTest.java
@@ -352,6 +352,68 @@ public class ExoAutomaticVideoConstraintPolicyTest {
     }
 
     @Test
+    public void throughputFaultStepsDownTheLadderAndRecoversLikeOtherFaults() {
+        // 起播固定选最高画质后原生 ABR 不再兜底吞吐，带宽不足/重缓冲要靠 THROUGHPUT 证据降档。
+        ExoAutomaticVideoConstraintPolicy.SelectedTrack selected =
+                new ExoAutomaticVideoConstraintPolicy.SelectedTrack(3840, 2160, 60, 18_000_000);
+        ExoAutomaticVideoConstraintPolicy.Input input = input(
+                ExoAutomaticVideoConstraintPolicy.Environment.unknown(), true,
+                selected, ExoAutomaticVideoConstraintPolicy.ResourceMode.ADAPTIVE_VARIANTS, 1_000);
+
+        ExoAutomaticVideoConstraintPolicy.Decision first =
+                ExoAutomaticVideoConstraintPolicy.onFault(
+                        ExoAutomaticVideoConstraintPolicy.initial(BASELINE), input,
+                        ExoAutomaticVideoConstraintPolicy.Fault.THROUGHPUT);
+        // 带宽回调很频繁，冷却期内的重复证据不能继续往下踩。
+        ExoAutomaticVideoConstraintPolicy.Decision repeated =
+                ExoAutomaticVideoConstraintPolicy.onFault(
+                        first.state(), input(first.state(), selected, 5_000),
+                        ExoAutomaticVideoConstraintPolicy.Fault.THROUGHPUT);
+        // 冷却结束后仍然吞吐不足则继续降一档。
+        ExoAutomaticVideoConstraintPolicy.Decision stepped =
+                ExoAutomaticVideoConstraintPolicy.onFault(
+                        repeated.state(),
+                        input(repeated.state(),
+                                new ExoAutomaticVideoConstraintPolicy.SelectedTrack(2560, 1440, 60, 11_000_000),
+                                17_000),
+                        ExoAutomaticVideoConstraintPolicy.Fault.THROUGHPUT);
+
+        assertEquals(TIERS.get(1), first.state().effective());
+        assertTrue(first.faultStepped());
+        assertTrue(first.faultActive());
+        assertEquals(TIERS.get(1), repeated.state().effective());
+        assertFalse(repeated.faultStepped());
+        assertEquals(ExoAutomaticVideoConstraintPolicy.Action.FAULT_COOLDOWN, repeated.action());
+        assertEquals(TIERS.get(2), stepped.state().effective());
+        assertTrue(stepped.faultStepped());
+    }
+
+    @Test
+    public void throughputFaultNeverFallsBelowTheLowestTier() {
+        // 反复吞吐不足时必须停在最低档，不能越降越低把画面降没了。
+        ExoAutomaticVideoConstraintPolicy.State state =
+                ExoAutomaticVideoConstraintPolicy.initial(BASELINE);
+        ExoAutomaticVideoConstraintPolicy.Limit lowest = TIERS.get(TIERS.size() - 1);
+        long now = 1_000;
+        for (int i = 0; i < TIERS.size() + 3; i++) {
+            ExoAutomaticVideoConstraintPolicy.Limit effective = state.effective();
+            ExoAutomaticVideoConstraintPolicy.Decision decision =
+                    ExoAutomaticVideoConstraintPolicy.onFault(
+                            state,
+                            input(state,
+                                    new ExoAutomaticVideoConstraintPolicy.SelectedTrack(
+                                            effective.width(), effective.height(),
+                                            effective.frameRate(), effective.maxVideoBitrate()),
+                                    now),
+                            ExoAutomaticVideoConstraintPolicy.Fault.THROUGHPUT);
+            state = decision.state();
+            now += ExoAutomaticVideoConstraintPolicy.FAULT_STEP_COOLDOWN_MS + 1;
+        }
+
+        assertEquals(lowest, state.effective());
+    }
+
+    @Test
     public void progressiveModeNeverReportsABandwidthDowngradeAction() {
         ExoAutomaticVideoConstraintPolicy.Decision decision = evaluate(
                 ExoAutomaticVideoConstraintPolicy.initial(BASELINE),

--- a/app/src/test/java/com/fongmi/android/tv/player/exo/ExoUtilTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/player/exo/ExoUtilTest.java
@@ -94,6 +94,53 @@ public class ExoUtilTest {
     }
 
     @Test
+    public void videoLimits_startFromTheHighestTrackInsideTheConstraints() throws Exception {
+        String source = readMainSource("player/exo/ExoUtil.java");
+        int start = source.indexOf("private static void applyVideoLimit(");
+        int end = source.indexOf("public static EnhancedVideoProfile getEnhancedVideoProfile()", start);
+        assertTrue(start >= 0 && end > start);
+        String limit = source.substring(start, end);
+
+        assertTrue("起播必须选约束内画质最高的轨道，否则 HLS 多码率直链会停在最低档",
+                limit.contains("builder.setForceHighestSupportedBitrate(true)"));
+        assertFalse(limit.contains("builder.setForceHighestSupportedBitrate(false)"));
+    }
+
+    @Test
+    public void automaticConstraintController_downgradesOnThroughputShortfall() throws Exception {
+        String source = readMainSource("player/exo/ExoUtil.java");
+        int start = source.indexOf("private static class AutomaticVideoConstraintController");
+        int end = source.indexOf("private static class LegacyAdaptiveVideoProfileController", start);
+        assertTrue(start >= 0 && end > start);
+        String controller = source.substring(start, end);
+
+        // 固定选最高画质后原生 ABR 不再兜底吞吐，这个自动档控制器必须自己按带宽和重缓冲降档，
+        // 否则弱网会锁在最高档一直重缓冲且无法恢复。
+        assertTrue("自动档必须监听带宽估算",
+                controller.contains("public void onBandwidthEstimate("));
+        assertTrue("带宽不足要走吞吐降档",
+                controller.contains("ExoAdaptiveVideoBitratePolicy.shouldDowngrade(selectedBitrate, bitrateEstimate)")
+                        && controller.contains("ExoAutomaticVideoConstraintPolicy.Fault.THROUGHPUT"));
+        // appliedLimit 是设备能力上限（4K 档可达 20Mbps），拿它当轨道码率比对会让正常片源持续误降档。
+        assertTrue("轨道码率未知时必须放弃带宽判断，而不是退回设备上限",
+                controller.contains("if (selectedBitrate <= 0) return;")
+                        && !controller.contains("selectedBitrate = appliedLimit.maxVideoBitrate()"));
+        assertTrue("起播后再次进入缓冲同样是吞吐不足的证据",
+                controller.contains("state == Player.STATE_BUFFERING && everReady")
+                        && controller.contains("\"rebuffer\""));
+        assertTrue("换片要重置起播标记，避免上一片的状态误触发降档",
+                controller.contains("everReady = false;"));
+        // bindSession 才会重置 everReady，若先读 everReady 再对齐会话，换片后的首次缓冲会被
+        // 当成重缓冲而白降一档。
+        int stateChanged = controller.indexOf("public void onPlaybackStateChanged(");
+        int bindFirst = controller.indexOf("bindEventSession();", stateChanged);
+        int readsEverReady = controller.indexOf(
+                "boolean rebuffered = state == Player.STATE_BUFFERING && everReady;", stateChanged);
+        assertTrue("重缓冲判断前必须先对齐会话",
+                stateChanged >= 0 && bindFirst > stateChanged && readsEverReady > bindFirst);
+    }
+
+    @Test
     public void ffmpegRendererPolicy_usesFullNextLibRenderersInNextLibMode() {
         assertTrue(ExoUtil.useFfmpegAudioFallback(PlayerSetting.FFMPEG_MODE_NEXTLIB));
         assertTrue(ExoUtil.useFfmpegVideoRenderer(PlayerSetting.FFMPEG_MODE_NEXTLIB));

--- a/app/src/test/java/com/fongmi/android/tv/player/exo/TrackUtilTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/player/exo/TrackUtilTest.java
@@ -1,13 +1,19 @@
 package com.fongmi.android.tv.player.exo;
 
+import androidx.media3.common.C;
 import androidx.media3.common.Format;
+import androidx.media3.common.TrackGroup;
+import androidx.media3.common.Tracks;
 
 import org.junit.Test;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class TrackUtilTest {
 
@@ -24,6 +30,116 @@ public class TrackUtilTest {
         Format high = video("video/avc", 3840, 2160);
 
         assertNull(TrackUtil.onlySelectedFormat(List.of(low, high)));
+    }
+
+    @Test
+    public void uniqueActiveFormat_narrowsAdaptiveSelectionToTheDecodedTrack() {
+        Format low = variant("1", "video/avc", 256, 144, 290_000);
+        Format high = variant("2", "video/avc", 1920, 1080, 5_420_000);
+        Tracks tracks = videoTracks(new Format[]{low, high}, new boolean[]{true, true});
+        // 解码格式与清单里的 variant 是两个不同实例，字段也不完全一致，必须走 sameRendition 而不是 equals。
+        Format decoded = new Format.Builder().setSampleMimeType("video/avc").setWidth(1920).setHeight(1080).setAverageBitrate(5_420_000).build();
+
+        assertSame(high, TrackUtil.uniqueActiveFormat(tracks, C.TRACK_TYPE_VIDEO, decoded));
+    }
+
+    @Test
+    public void uniqueActiveFormat_doesNotConfuseSameResolutionCodecVariants() {
+        Format avc = variant("3", "video/avc", 1920, 1080, Format.NO_VALUE);
+        Format hevc = variant("4", "video/hevc", 1920, 1080, Format.NO_VALUE);
+        Tracks tracks = videoTracks(new Format[]{avc, hevc}, new boolean[]{true, true});
+        Format decodedHevc = new Format.Builder().setSampleMimeType("video/hevc").setWidth(1920).setHeight(1080).build();
+
+        assertSame(hevc, TrackUtil.uniqueActiveFormat(tracks, C.TRACK_TYPE_VIDEO, decodedHevc));
+    }
+
+    @Test
+    public void uniqueActiveFormat_staysUnknownWhenNothingDistinguishesSameResolutionTracks() {
+        Format first = variant("5", null, 1920, 1080, Format.NO_VALUE);
+        Format second = variant("6", null, 1920, 1080, Format.NO_VALUE);
+        Tracks tracks = videoTracks(new Format[]{first, second}, new boolean[]{true, true});
+        Format decoded = new Format.Builder().setWidth(1920).setHeight(1080).build();
+
+        assertNull(TrackUtil.uniqueActiveFormat(tracks, C.TRACK_TYPE_VIDEO, decoded));
+    }
+
+    @Test
+    public void uniqueActiveFormat_keepsPlayerFlagsWhenOnlyOneTrackIsSelected() {
+        Format low = video("video/avc", 256, 144);
+        Format high = video("video/avc", 1920, 1080);
+        Tracks tracks = videoTracks(new Format[]{low, high}, new boolean[]{false, true});
+
+        assertNull(TrackUtil.uniqueActiveFormat(tracks, C.TRACK_TYPE_VIDEO, high));
+    }
+
+    @Test
+    public void uniqueActiveFormat_keepsPlayerFlagsWhenDecodedTrackIsUnknown() {
+        Format low = variant("1", "video/avc", 256, 144, 290_000);
+        Format high = variant("2", "video/avc", 1920, 1080, 5_420_000);
+        Tracks tracks = videoTracks(new Format[]{low, high}, new boolean[]{true, true});
+
+        assertNull("播放器还没报出解码格式时必须退回原始选中标记",
+                TrackUtil.uniqueActiveFormat(tracks, C.TRACK_TYPE_VIDEO, null));
+    }
+
+    @Test
+    public void uniqueActiveFormat_staysUnknownWhenDecodedResolutionMatchesNoTrack() {
+        Format low = variant("1", "video/avc", 256, 144, 290_000);
+        Format high = variant("2", "video/avc", 1920, 1080, 5_420_000);
+        Tracks tracks = videoTracks(new Format[]{low, high}, new boolean[]{true, true});
+        Format decoded = new Format.Builder().setSampleMimeType("video/avc").setWidth(1280).setHeight(720).setAverageBitrate(2_970_000).build();
+
+        assertNull(TrackUtil.uniqueActiveFormat(tracks, C.TRACK_TYPE_VIDEO, decoded));
+    }
+
+    @Test
+    public void sameRendition_matchesTheManifestVariantBehindTheDecodedFormat() {
+        Format manifest = variant("2", "video/avc", 1920, 1080, 5_420_000);
+        Format decoded = new Format.Builder().setSampleMimeType("video/avc").setWidth(1920).setHeight(1080).build();
+
+        assertTrue(TrackUtil.sameRendition(manifest, decoded));
+    }
+
+    @Test
+    public void sameRendition_rejectsADifferentCodecAtTheSameResolution() {
+        Format avc = variant("3", "video/avc", 1920, 1080, Format.NO_VALUE);
+        Format decodedHevc = new Format.Builder().setSampleMimeType("video/hevc").setWidth(1920).setHeight(1080).build();
+
+        assertFalse("同分辨率的 H.264 与 HEVC 是两条轨道，不能互相当成同一条",
+                TrackUtil.sameRendition(avc, decodedHevc));
+    }
+
+    @Test
+    public void sameRendition_rejectsADifferentCodecEvenWhenBitratesAgree() {
+        Format avc = variant("3", "video/avc", 1920, 1080, 5_420_000);
+        Format decodedHevc = new Format.Builder().setSampleMimeType("video/hevc").setWidth(1920).setHeight(1080).setAverageBitrate(5_420_000).build();
+
+        // 码率相同也不能靠码率判定同一条，编码不同就是两条轨道。
+        assertFalse(TrackUtil.sameRendition(avc, decodedHevc));
+    }
+
+    @Test
+    public void sameRendition_rejectsWhenBothBitratesAreUnknown() {
+        Format manifest = variant("5", null, 1920, 1080, Format.NO_VALUE);
+        Format decoded = new Format.Builder().setWidth(1920).setHeight(1080).build();
+
+        assertFalse(TrackUtil.sameRendition(manifest, decoded));
+    }
+
+    private static Tracks videoTracks(Format[] formats, boolean[] selected) {
+        int[] support = new int[formats.length];
+        for (int i = 0; i < support.length; i++) support[i] = C.FORMAT_HANDLED;
+        return new Tracks(List.of(new Tracks.Group(new TrackGroup("video", formats), true, support, selected)));
+    }
+
+    private static Format variant(String id, String mimeType, int width, int height, int averageBitrate) {
+        return new Format.Builder()
+                .setId(id)
+                .setSampleMimeType(mimeType)
+                .setWidth(width)
+                .setHeight(height)
+                .setAverageBitrate(averageBitrate)
+                .build();
     }
 
     private static Format video(String mimeType, int width, int height) {

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/TrackDialogTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/TrackDialogTest.java
@@ -133,6 +133,25 @@ public class TrackDialogTest {
                         && adapter.contains("mItems.add(0, item)"));
     }
 
+    @Test
+    public void videoTrackListHighlightsOnlyTheDecodedAdaptiveTrack() throws Exception {
+        Path root = moduleRoot();
+        String dialog = read(root.resolve(Path.of("src", "main", "java", "com", "fongmi", "android", "tv", "ui", "dialog", "TrackDialog.java")));
+
+        assertTrue("track list must resolve the selected flag through the adaptive-aware helper",
+                dialog.contains("item.setSelected(isSelected(trackGroup, j, format, active))"));
+        assertTrue("the decoded video format must narrow a multi-track adaptive selection",
+                dialog.contains("TrackUtil.uniqueActiveFormat(tracks, type, player.getVideoFormat())"));
+        assertTrue("字段完全相同的两条轨道用 equals 会同时高亮，必须按引用比对",
+                dialog.contains("if (active != null) return format == active;")
+                        && !dialog.contains("return format.equals(active);"));
+        assertTrue("without a resolved decoded format the player flags must still win",
+                dialog.contains("return trackGroup.isTrackSelected(trackIndex);"));
+        assertTrue("轨道快照只能读一次，MPV/IJK 的快照由原生线程写入，两次读可能不一致",
+                dialog.contains("Tracks tracks = player.getCurrentTracks();")
+                        && dialog.contains("Format active = activeVideoFormat(tracks);"));
+    }
+
     private static String read(Path path) throws Exception {
         return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
起播画质：applyVideoLimit 之前关掉了 setForceHighestSupportedBitrate，把选轨 完全交给 media3 原生 ABR。原生 ABR 起播时只有 DefaultBandwidthMeter 的初始猜测 （Wi-Fi 4.3Mbps 起、未知网络 1Mbps）可用，再乘 bandwidthFraction，直播缓冲为 0 时又不允许向上切档，HLS 多码率直链必然停在最低几档。改为在设备与网络约束内固定
选画质最高的轨道，恢复上游 fongmi 的行为，setMaxVideoSize/Bitrate/FrameRate 等 约束一并保留。

代价是同组只会选中一条轨道（eligibility 变为 FIXED），原生 ABR 不再兜底吞吐。 而默认档位（PROFILE_AUTO + 轨道限制开启）用的 AutomaticVideoConstraintController 只监听掉帧和编解码错误，对带宽零感知——弱网锁在最高档时解码器并无压力，掉帧不会
触发，会一直重缓冲且无法恢复。为此新增 Fault.THROUGHPUT，并给该控制器补上带宽
估算与重缓冲两个降档触发，降档步进仍由已有的 15 秒冷却限流。带宽判断只比对轨道
自己申报的码率，未知时直接放弃（不能退回 appliedLimit，那是设备能力上限，会让
码率不高的正常片源持续误降档），交给重缓冲兜底。重缓冲判断前先对齐会话，避免把
上一集的起播状态带到新一集而白降一档。

视轨高亮：media3 的 Tracks.Group.isTrackSelected 会把自适应候选集里的所有轨道 都标为已选中，所以列表会同时高亮多项，且与实际在解码的那条无关。改为用
player.getVideoFormat() 收敛到唯一一条，匹配不上时退回播放器原始标记，不会出现 一项都不高亮。匹配按引用比对（字段完全相同的两条轨道用 equals 会同时命中），
并拒绝同分辨率的不同编码，避免把 H.264 当成正在解码的 HEVC。轨道快照只读一次，
MPV/IJK 的快照由原生回调线程写入，分两次读可能拿到不同集合。

音轨与字幕行为未变。