### PR TITLE
新增：详情页沉浸/炫彩/直放模式补回播放器搜索按钮并支持站内快搜

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -81,6 +81,31 @@
 -keep class org.jupnp.** { *; }
 -keep class javax.xml.** { *; }
 
+# Inline quick search is reflected from the shared TMDB detail activity into each
+# flavor's own dialog. Must be -keepclassmembers, not -keepclassmembernames:
+# the latter implies allowshrinking, so R8 may delete methods only reached by
+# reflection. Losing them makes the in-page search silently fall back to the
+# global search page in release builds only.
+-keepclassmembers class com.fongmi.android.tv.ui.dialog.QuickSearchDialog {
+    public static com.fongmi.android.tv.ui.dialog.QuickSearchDialog create();
+    public void show(androidx.fragment.app.FragmentActivity);
+    public void addAll(java.util.List);
+    public void clear();
+    public *** listener(***);
+    public *** items(java.util.List);
+    public *** title(java.lang.String);
+    public *** keyword(java.lang.String);
+    public *** setProgress(int, int, boolean);
+    public *** searchListener(***);
+    public *** dismissListener(***);
+}
+-keep interface com.fongmi.android.tv.ui.dialog.QuickSearchDialog$* { *; }
+-keep interface com.fongmi.android.tv.ui.adapter.QuickAdapter$OnClickListener { *; }
+# Inherited from DialogFragment, so the rule above cannot match it.
+-keepclassmembers class * extends androidx.fragment.app.DialogFragment {
+    public void dismissAllowingStateLoss();
+}
+
 # Mobile inline cast uses reflection from the shared TMDB detail activity.
 -keepclassmembernames class com.fongmi.android.tv.ui.dialog.CastDialog {
     public static com.fongmi.android.tv.ui.dialog.CastDialog create();

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.pm.ActivityInfo;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
@@ -45,7 +46,9 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
+import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.C;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.Player;
@@ -115,8 +118,10 @@ import com.fongmi.android.tv.service.OmdbService;
 import com.fongmi.android.tv.service.PlaybackService;
 import com.fongmi.android.tv.service.TmdbService;
 import com.fongmi.android.tv.setting.BackgroundPlaybackPolicy;
+import com.fongmi.android.tv.model.SiteViewModel;
 import com.fongmi.android.tv.setting.DanmakuSetting;
 import com.fongmi.android.tv.setting.PlayerButtonSetting;
+import com.fongmi.android.tv.setting.SiteHealthStore;
 import com.fongmi.android.tv.setting.MultiThreadProxySetting;
 import com.fongmi.android.tv.setting.PlayerSetting;
 import com.fongmi.android.tv.setting.Setting;
@@ -228,6 +233,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.lang.reflect.Proxy;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.ExecutorCompletionService;
@@ -405,6 +412,11 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private int pendingManualTmdbEpisodeRebindGeneration = -1;
     private TmdbItem pendingManualTmdbEpisodeRebindItem;
     private int sourceSearchGeneration;
+    private SiteViewModel inlineSearchViewModel;
+    private Object inlineQuickSearchDialog;
+    private String inlineSearchKeyword = "";
+    private boolean inlineSearchObserved;
+    private boolean inlineSearchClosed;
     private int seasonSourceRouteGeneration;
     private int backdropSlideGeneration;
     private int backdropSlideIndex;
@@ -641,6 +653,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
     private void resetDetailState() {
         cancelAiSeasonAnalysis(false);
+        closeInlineSearch();
         tmdbConfig = TmdbConfig.objectFrom(Setting.getTmdbConfig());
         initialTmdbItem = getIntentTmdbItem();
         vod = null;
@@ -1159,6 +1172,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.playerPlaybackAction.setOnClickListener(guarded(this::toggleInlinePlayback));
         binding.playerAdFeedback.setOnClickListener(guarded(this::onInlineAdFeedback));
         binding.playerMultiThreadProxy.setOnClickListener(guarded(this::showInlineMultiThreadProxy));
+        binding.playerSearch.setOnClickListener(view -> openInlineSourceSearch());
+        binding.playerSearch.setOnLongClickListener(view -> openGlobalSourceSearch());
         inlinePlayerUi.bindInlineActions();
         setupMobileInlineControl();
         hideInlineControls();
@@ -1188,6 +1203,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         detailControlView(R.id.rotate, View.class).setOnClickListener(guarded(this::rotateInlineFullscreen));
         detailControlView(R.id.pip, View.class).setOnClickListener(guarded(() -> enterInlinePiP(true)));
         detailActionView(R.id.change2, View.class).setOnClickListener(view -> changeSource());
+        detailActionView(R.id.search, View.class).setOnClickListener(view -> openInlineSourceSearch());
+        detailActionView(R.id.search, View.class).setOnLongClickListener(view -> openGlobalSourceSearch());
         detailActionView(R.id.actionFullscreen, View.class).setOnClickListener(guarded(this::toggleInlineFullscreen));
         detailActionView(R.id.player, View.class).setOnClickListener(guarded(this::showInlinePlayerChoice));
         detailActionView(R.id.player, View.class).setOnLongClickListener(view -> showInlinePlayerChoice());
@@ -1275,6 +1292,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.playerEpisodes.setNextFocusUpId(R.id.playerEpisodes);
         binding.playerRefresh.setNextFocusUpId(R.id.playerRefresh);
         binding.playerChangeSource.setNextFocusUpId(R.id.playerChangeSource);
+        binding.playerSearch.setNextFocusUpId(R.id.playerSearch);
         binding.playerExternal.setNextFocusUpId(R.id.playerExternal);
         binding.playerDecode.setNextFocusUpId(R.id.playerDecode);
         binding.playerPlayParams.setNextFocusUpId(R.id.playerPlayParams);
@@ -1309,7 +1327,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
 
         View[] buttons = {
             binding.playerPlaybackAction, binding.playerNext, binding.playerPrev, binding.playerEpisodes,
-            binding.playerRefresh, binding.playerChangeSource, binding.playerFullscreenAction,
+            binding.playerRefresh, binding.playerChangeSource, binding.playerSearch, binding.playerFullscreenAction,
             binding.playerExternal, binding.playerDecode, binding.playerPlayParams,
             binding.playerMultiThreadProxy, binding.playerCodecCapability,
             binding.playerSpeed, binding.playerScale, binding.playerQuality,
@@ -1360,6 +1378,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         setupInlineControl(binding.playerLut);
         setupInlineControl(binding.playerRefresh);
         setupInlineControl(binding.playerChangeSource);
+        setupInlineControl(binding.playerSearch);
         setupInlineControl(binding.playerRepeat);
         setupInlineControl(binding.playerDisplay);
         setupInlineControl(binding.playerQuality);
@@ -1385,6 +1404,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.playerEpisodes.setTextColor(white);
         binding.playerRefresh.setTextColor(white);
         binding.playerChangeSource.setTextColor(white);
+        binding.playerSearch.setTextColor(white);
         binding.playerFullscreenAction.setTextColor(white);
         binding.playerExternal.setTextColor(white);
         binding.playerDecode.setTextColor(white);
@@ -7103,6 +7123,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         setButtonEnabled(binding.playerScale, hasPlayer);
         setButtonEnabled(binding.playerRefresh, hasPlayer);
         setButtonEnabled(binding.playerChangeSource, vod != null);
+        setButtonEnabled(binding.playerSearch, vod != null);
         setButtonEnabled(binding.playerRepeat, hasPlayer);
         setButtonEnabled(binding.playerDisplay, hasPlayer);
         setButtonEnabled(binding.playerDecode, hasPlayer);
@@ -7165,6 +7186,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.playerEpisodes.setTextColor(white);
         binding.playerRefresh.setTextColor(white);
         binding.playerChangeSource.setTextColor(white);
+        binding.playerSearch.setTextColor(white);
         binding.playerFullscreenAction.setTextColor(white);
         binding.playerExternal.setTextColor(white);
         binding.playerDecode.setTextColor(white);
@@ -7208,6 +7230,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         buttons.put(PlayerButtonSetting.EPISODES, binding.playerEpisodes);
         buttons.put(PlayerButtonSetting.RESET, binding.playerRefresh);
         buttons.put(PlayerButtonSetting.CHANGE, binding.playerChangeSource);
+        buttons.put(PlayerButtonSetting.SEARCH, binding.playerSearch);
         buttons.put(PlayerButtonSetting.FULLSCREEN, binding.playerFullscreenAction);
         buttons.put(PlayerButtonSetting.PLAYER, binding.playerExternal);
         buttons.put(PlayerButtonSetting.DECODE, binding.playerDecode);
@@ -7235,6 +7258,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private Map<String, View> mobileInlinePlayerButtonMap() {
         Map<String, View> buttons = new LinkedHashMap<>();
         buttons.put(PlayerButtonSetting.CHANGE, detailActionView(R.id.change2, View.class));
+        buttons.put(PlayerButtonSetting.SEARCH, detailActionView(R.id.search, View.class));
         buttons.put(PlayerButtonSetting.FULLSCREEN, detailActionView(R.id.actionFullscreen, View.class));
         buttons.put(PlayerButtonSetting.PLAYER, detailActionView(R.id.player, View.class));
         buttons.put(PlayerButtonSetting.DECODE, detailActionView(R.id.decode, View.class));
@@ -10620,6 +10644,181 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         if (vod != null && !TextUtils.isEmpty(vod.getName())) return vod.getName();
         String keyword = getTmdbSearchQuery();
         return TextUtils.isEmpty(keyword) ? getNameText() : keyword;
+    }
+
+    /**
+     * 站内快搜：复用影视原生那套增量搜索——边搜边出结果、带站点进度，同一站源的多个命中全部列出。
+     * 长按同一按钮才跳全局搜索页。
+     */
+    private void openInlineSourceSearch() {
+        String keyword = getSourceSearchKeyword();
+        if (TextUtils.isEmpty(keyword)) return;
+        // 弹窗还开着就复用它重搜，否则第二次点搜索会把新结果追加到上一轮列表后面。
+        if (inlineQuickSearchDialog != null && !inlineSearchClosed) {
+            restartInlineSourceSearch(keyword);
+            return;
+        }
+        closeInlineSearch();
+        inlineSearchKeyword = keyword;
+        inlineSearchClosed = false;
+        observeInlineSearch();
+        showInlineQuickSearchDialog(new ArrayList<>());
+        startInlineSourceSearch(keyword);
+    }
+
+    private void startInlineSourceSearch(String keyword) {
+        List<Site> sites = new ArrayList<>();
+        for (Site site : VodConfig.get().getSites()) if (isChangeSourceCandidate(site)) sites.add(site);
+        SiteHealthStore.sortSites(sites);
+        inlineSearchModel().searchContent(sites, keyword, true);
+    }
+
+    private SiteViewModel inlineSearchModel() {
+        if (inlineSearchViewModel == null) inlineSearchViewModel = new ViewModelProvider(this).get(SiteViewModel.class);
+        return inlineSearchViewModel;
+    }
+
+    private void observeInlineSearch() {
+        if (inlineSearchObserved) return;
+        inlineSearchObserved = true;
+        inlineSearchModel().getSearch().observe(this, result -> {
+            if (inlineSearchClosed || result == null) return;
+            List<Vod> items = new ArrayList<>(result.getList());
+            items.removeIf(this::inlineSearchMismatch);
+            if (!items.isEmpty()) showInlineQuickSearchDialog(items);
+        });
+        inlineSearchModel().getSearchProgress().observe(this, progress -> {
+            if (inlineSearchClosed || progress == null || inlineQuickSearchDialog == null) return;
+            invokeQuiet(inlineQuickSearchDialog, "setProgress", new Class<?>[]{int.class, int.class, boolean.class},
+                    progress.current(), progress.total(), progress.finished());
+        });
+    }
+
+    /**
+     * 站点层面的过滤（失效站源、当前站源、可否换源）已由 isChangeSourceCandidate 完成，
+     * 这里只按条目过滤：搜索期间用户可能已切源，迟到结果里的"当前条目"要排掉。
+     */
+    private boolean inlineSearchMismatch(Vod item) {
+        if (item == null || TextUtils.isEmpty(item.getSiteKey())) return true;
+        if (TextUtils.equals(item.getSiteKey(), getKeyText()) && TextUtils.equals(item.getId(), getIdText())) return true;
+        String name = item.getName();
+        return TextUtils.isEmpty(name) || !name.contains(inlineSearchKeyword);
+    }
+
+    /**
+     * QuickSearchDialog 在两个 flavor 里各有一套（TV 是卡片弹窗、手机是底部弹层），
+     * main 源集只能反射调用，与 showInlineControlDialog 保持一致。
+     */
+    private void showInlineQuickSearchDialog(List<Vod> items) {
+        if (inlineSearchClosed) return;
+        if (inlineQuickSearchDialog != null) {
+            invokeQuiet(inlineQuickSearchDialog, "addAll", new Class<?>[]{List.class}, items);
+            return;
+        }
+        try {
+            Class<?> dialogClass = Class.forName("com.fongmi.android.tv.ui.dialog.QuickSearchDialog");
+            Class<?> listenerClass = Class.forName("com.fongmi.android.tv.ui.adapter.QuickAdapter$OnClickListener");
+            Object listener = Proxy.newProxyInstance(listenerClass.getClassLoader(), new Class<?>[]{listenerClass}, (proxy, method, args) -> {
+                if (method.getDeclaringClass() == Object.class) return method.invoke(this, args);
+                if ("onItemClick".equals(method.getName()) && args != null && args.length == 1) onInlineSearchItemClick((Vod) args[0]);
+                return null;
+            });
+            Object dialog = dialogClass.getMethod("create").invoke(null);
+            dialogClass.getMethod("listener", listenerClass).invoke(dialog, listener);
+            dialogClass.getMethod("items", List.class).invoke(dialog, items);
+            wireInlineQuickSearchExtras(dialogClass, dialog);
+            dialogClass.getMethod("show", FragmentActivity.class).invoke(dialog, this);
+            inlineQuickSearchDialog = dialog;
+        } catch (Throwable e) {
+            // 弹窗起不来就只能退回全局搜索页，否则用户点了搜索毫无反应。
+            SpiderDebug.log("tmdb-inline", "quick search dialog failed errorType=%s", e.getClass().getSimpleName());
+            inlineQuickSearchDialog = null;
+            openGlobalSourceSearch();
+        }
+    }
+
+    /**
+     * 手机版弹层多一个标题栏和输入框（可在弹层里改关键词重搜），TV 版没有；
+     * 两版的 dismiss 回调类型也不同。都按"有就接、没有就跳过"处理。
+     */
+    private void wireInlineQuickSearchExtras(Class<?> dialogClass, Object dialog) {
+        invokeQuiet(dialog, "title", new Class<?>[]{String.class}, getString(R.string.play_search) + " " + inlineSearchKeyword);
+        invokeQuiet(dialog, "keyword", new Class<?>[]{String.class}, inlineSearchKeyword);
+        // 手机版：弹层内改关键词重搜 + 自有 dismiss 接口
+        bindProxyListener(dialogClass, dialog, "searchListener", dialogClass.getName() + "$OnSearchListener",
+                args -> restartInlineSourceSearch(args == null || args.length != 1 ? "" : String.valueOf(args[0])));
+        bindProxyListener(dialogClass, dialog, "dismissListener", dialogClass.getName() + "$OnDismissListener",
+                args -> closeInlineSearch());
+        // TV 版：用 android 框架的 DialogInterface.OnDismissListener
+        invokeQuiet(dialog, "dismissListener", new Class<?>[]{DialogInterface.OnDismissListener.class},
+                (DialogInterface.OnDismissListener) d -> closeInlineSearch());
+    }
+
+    private void bindProxyListener(Class<?> dialogClass, Object dialog, String setter, String callbackClassName, Consumer<Object[]> action) {
+        try {
+            Class<?> callbackClass = Class.forName(callbackClassName);
+            Object proxy = Proxy.newProxyInstance(callbackClass.getClassLoader(), new Class<?>[]{callbackClass}, (p, method, args) -> {
+                // Object 的 toString/hashCode/equals 也会转发过来，返回 null 会在拆箱时 NPE。
+                if (method.getDeclaringClass() == Object.class) return method.invoke(this, args);
+                if (method.getDeclaringClass() == callbackClass) action.accept(args);
+                return null;
+            });
+            dialogClass.getMethod(setter, callbackClass).invoke(dialog, proxy);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    /**
+     * TV 版弹窗没有 clear()，列表只能追加。所以重搜时若清不掉就整体关掉重开，
+     * 否则新一轮结果会接在上一轮后面。
+     */
+    private void restartInlineSourceSearch(String keyword) {
+        if (TextUtils.isEmpty(keyword)) return;
+        inlineSearchModel().stopSearch();
+        inlineSearchKeyword = keyword;
+        if (invokeQuiet(inlineQuickSearchDialog, "clear", new Class<?>[0])) {
+            startInlineSourceSearch(keyword);
+            return;
+        }
+        closeInlineSearch();
+        inlineSearchClosed = false;
+        showInlineQuickSearchDialog(new ArrayList<>());
+        startInlineSourceSearch(keyword);
+    }
+
+    private void onInlineSearchItemClick(Vod item) {
+        if (item == null) return;
+        closeInlineSearch();
+        Site site = VodConfig.get().getSite(item.getSiteKey());
+        if (site == null || site.isEmpty()) return;
+        switchSourceDetail(site, item, matchedTmdbItem);
+    }
+
+    private void closeInlineSearch() {
+        inlineSearchClosed = true;
+        // 先摘引用再关弹窗：dismiss 会同步回调 onDismiss -> closeInlineSearch，
+        // 留着引用就会重入一层。只置 null 不关弹窗则会让残留结果灌进下一轮。
+        Object dialog = inlineQuickSearchDialog;
+        inlineQuickSearchDialog = null;
+        invokeQuiet(dialog, "dismissAllowingStateLoss", new Class<?>[0]);
+        if (inlineSearchViewModel != null) inlineSearchViewModel.stopSearch();
+    }
+
+    /**
+     * 两个 flavor 的弹窗 API 不完全重叠（如 setProgress 只有 TV 版、clear 只有手机版），
+     * 缺方法属于预期差异，返回 false 让调用方走降级路径。
+     */
+    private static boolean invokeQuiet(Object target, String method, Class<?>[] types, Object... args) {
+        if (target == null) return false;
+        try {
+            target.getClass().getMethod(method, types).invoke(target, args);
+            return true;
+        } catch (NoSuchMethodException absent) {
+            return false;
+        } catch (Throwable e) {
+            SpiderDebug.log("tmdb-inline", "quick search %s failed errorType=%s", method, e.getClass().getSimpleName());
+            return false;
+        }
     }
 
     private void loadPersonDetail(TmdbPerson person) {

--- a/app/src/main/res/layout/activity_tmdb_detail.xml
+++ b/app/src/main/res/layout/activity_tmdb_detail.xml
@@ -1338,6 +1338,12 @@
                             android:text="@string/play_change" />
 
                         <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/playerSearch"
+                            style="@style/Control"
+                            android:layout_marginEnd="8dp"
+                            android:text="@string/play_search" />
+
+                        <com.google.android.material.textview.MaterialTextView
                             android:id="@+id/playerFullscreenAction"
                             style="@style/Control"
                             android:layout_marginEnd="8dp"

--- a/app/src/main/res/layout/view_control_vod_action_tmdb.xml
+++ b/app/src/main/res/layout/view_control_vod_action_tmdb.xml
@@ -20,6 +20,11 @@
             android:text="@string/play_change" />
 
         <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/search"
+            style="@style/Control"
+            android:text="@string/play_search" />
+
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/actionFullscreen"
             style="@style/Control"
             android:text="@string/play_fullscreen" />

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -360,14 +360,14 @@ public class TmdbDetailActivityLayoutTest {
         String nativeLayout = readLeanbackLayout("view_control_vod_action.xml");
         String fusionLayout = readLayout("activity_tmdb_detail.xml");
         List<String> nativeOrder = List.of("next", "prev", "episodes", "reset", "search", "change2", "fullscreen", "player", "decode", "playParams", "panDiagnostic", "codecCapability", "speed", "scale", "actionQuality", "lut", "karaoke", "immersiveAudio", "text", "audio", "video", "opening", "ending", "danmaku", "adFeedback", "title", "cast", "timer", "repeat");
-        List<String> fusionOrder = List.of("playerNext", "playerPrev", "playerEpisodes", "playerRefresh", "playerChangeSource", "playerFullscreenAction", "playerExternal", "playerDecode", "playerPlayParams", "playerMultiThreadProxy", "playerCodecCapability", "playerSpeed", "playerScale", "playerQuality", "playerLut", "playerParse", "playerDisplay", "playerTextTrack", "playerAudioTrack", "playerVideoTrack", "playerOpening", "playerEnding", "playerDanmaku", "playerAdFeedback", "playerChapter", "playerRepeat");
+        List<String> fusionOrder = List.of("playerNext", "playerPrev", "playerEpisodes", "playerRefresh", "playerChangeSource", "playerSearch", "playerFullscreenAction", "playerExternal", "playerDecode", "playerPlayParams", "playerMultiThreadProxy", "playerCodecCapability", "playerSpeed", "playerScale", "playerQuality", "playerLut", "playerParse", "playerDisplay", "playerTextTrack", "playerAudioTrack", "playerVideoTrack", "playerOpening", "playerEnding", "playerDanmaku", "playerAdFeedback", "playerChapter", "playerRepeat");
 
         assertAndroidIdOrder("native leanback player control order", nativeLayout, nativeOrder);
         assertAndroidIdOrder("fusion inline player control order", fusionLayout, fusionOrder);
         for (String id : List.of("actionParse", "display")) {
             assertFalse("native leanback layout must not expose unbound action " + id, nativeLayout.contains("@+id/" + id));
         }
-        for (String id : List.of("playerSearch", "playerPanDiagnostic", "playerKaraoke", "playerImmersiveAudio", "playerCastAction", "playerTimer")) {
+        for (String id : List.of("playerPanDiagnostic", "playerKaraoke", "playerImmersiveAudio", "playerCastAction", "playerTimer")) {
             assertFalse("fusion layout must not expose unsupported action " + id, fusionLayout.contains("@+id/" + id));
         }
 
@@ -409,6 +409,87 @@ public class TmdbDetailActivityLayoutTest {
                         && source.contains("new AiAdDetectionService(config).analyze(request)")
                         && source.contains("AdRulePreviewDialog.create(result).show(this, confirmedResult ->")
                         && source.contains("UserAdRuleStore.add(rule);"));
+    }
+
+    /**
+     * 内嵌快搜靠反射调用两个 flavor 各自的 QuickSearchDialog，编译器管不到。
+     * 任一方法被改名/删掉都会静默退化成"点搜索没反应"，只能在这里钉住契约。
+     */
+    @Test
+    public void inlineQuickSearchReflectionTargetsExistInBothFlavors() throws Exception {
+        String source = readJava("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java");
+
+        assertTrue("inline search must reuse the native incremental search stream, not a one-shot dialog",
+                source.contains("inlineSearchModel().searchContent(sites, keyword, true);")
+                        && source.contains("inlineSearchModel().getSearch().observe(this, result ->")
+                        && source.contains("inlineSearchModel().getSearchProgress().observe(this, progress ->"));
+
+        for (String flavor : List.of("leanback", "mobile")) {
+            String dialog = readFlavorJava(flavor, "com", "fongmi", "android", "tv", "ui", "dialog", "QuickSearchDialog.java");
+            assertTrue(flavor + " QuickSearchDialog must keep create() for inline search reflection",
+                    dialog.contains("public static QuickSearchDialog create()"));
+            assertTrue(flavor + " QuickSearchDialog must keep listener(QuickAdapter.OnClickListener) for inline search reflection",
+                    dialog.contains("public QuickSearchDialog listener(QuickAdapter.OnClickListener listener)"));
+            assertTrue(flavor + " QuickSearchDialog must keep items(List<Vod>) for inline search reflection",
+                    dialog.contains("public QuickSearchDialog items(List<Vod> items)"));
+            assertTrue(flavor + " QuickSearchDialog must keep show(FragmentActivity) for inline search reflection",
+                    dialog.contains("public void show(FragmentActivity activity)"));
+            assertTrue(flavor + " QuickSearchDialog must keep addAll(List<Vod>) for incremental inline search results",
+                    dialog.contains("public void addAll(List<Vod> items)"));
+
+            String adapter = readFlavorJava(flavor, "com", "fongmi", "android", "tv", "ui", "adapter", "QuickAdapter.java");
+            assertTrue(flavor + " QuickAdapter must keep OnClickListener.onItemClick(Vod) for the inline search proxy",
+                    adapter.contains("public interface OnClickListener") && adapter.contains("void onItemClick(Vod item);"));
+        }
+
+        String leanbackDialog = readFlavorJava("leanback", "com", "fongmi", "android", "tv", "ui", "dialog", "QuickSearchDialog.java");
+        assertTrue("leanback QuickSearchDialog must keep setProgress for the TV site-progress readout",
+                leanbackDialog.contains("public void setProgress(int current, int total, boolean finished)"));
+
+        String mobileDialog = readFlavorJava("mobile", "com", "fongmi", "android", "tv", "ui", "dialog", "QuickSearchDialog.java");
+        assertTrue("mobile QuickSearchDialog must keep the in-sheet re-search hooks used by inline search",
+                mobileDialog.contains("public interface OnSearchListener")
+                        && mobileDialog.contains("public QuickSearchDialog searchListener(OnSearchListener listener)")
+                        && mobileDialog.contains("public void clear()"));
+
+        assertTrue("inline search proxies must forward Object methods, otherwise hashCode/equals unbox a null",
+                source.contains("if (method.getDeclaringClass() == Object.class) return method.invoke(this, args);"));
+        assertTrue("closing inline search must dismiss the dialog, not just drop the reference",
+                source.contains("invokeQuiet(dialog, \"dismissAllowingStateLoss\", new Class<?>[0]);"));
+        int close = source.indexOf("private void closeInlineSearch()");
+        assertTrue("inline search must clear its dialog reference before dismissing, or onDismiss re-enters closeInlineSearch",
+                close >= 0
+                        && source.indexOf("inlineQuickSearchDialog = null;", close) < source.indexOf("invokeQuiet(dialog, \"dismissAllowingStateLoss\"", close));
+        assertTrue("reloading the detail page must tear down any open inline search",
+                source.indexOf("closeInlineSearch();", source.indexOf("private void resetDetailState()")) > source.indexOf("private void resetDetailState()"));
+    }
+
+    /**
+     * release 开启 minify 后混淆会改掉方法名，反射直接失效并静默退回全局搜索页，
+     * 而 debug 包永远复现不出来 —— 只能靠这里守住 keep 规则。
+     */
+    @Test
+    public void inlineQuickSearchReflectionTargetsSurviveMinification() throws Exception {
+        Path rulesPath = Path.of("app", "proguard-rules.pro");
+        if (!Files.exists(rulesPath)) rulesPath = Path.of("proguard-rules.pro");
+        String rules = new String(Files.readAllBytes(rulesPath), StandardCharsets.UTF_8);
+
+        // -keepclassmembernames implies allowshrinking, so reflection-only methods could still be
+        // removed. The rule must be -keepclassmembers to survive R8.
+        assertTrue("proguard must keep QuickSearchDialog members (not just names) for inline search reflection",
+                rules.contains("-keepclassmembers class com.fongmi.android.tv.ui.dialog.QuickSearchDialog {"));
+        for (String member : List.of("create()", "show(androidx.fragment.app.FragmentActivity)", "addAll(java.util.List)",
+                "clear()", "listener(***)", "items(java.util.List)",
+                "setProgress(int, int, boolean)", "searchListener(***)", "dismissListener(***)")) {
+            assertTrue("proguard QuickSearchDialog keep rule is missing " + member, rules.contains(member));
+        }
+        assertTrue("proguard must keep the inherited dismissAllowingStateLoss reached by inline search reflection",
+                rules.contains("-keepclassmembers class * extends androidx.fragment.app.DialogFragment {")
+                        && rules.contains("public void dismissAllowingStateLoss();"));
+        assertTrue("proguard must keep the QuickAdapter click interface used by the inline search proxy",
+                rules.contains("-keep interface com.fongmi.android.tv.ui.adapter.QuickAdapter$OnClickListener { *; }"));
+        assertTrue("proguard must keep QuickSearchDialog nested listener interfaces used by the inline search proxy",
+                rules.contains("-keep interface com.fongmi.android.tv.ui.dialog.QuickSearchDialog$* { *; }"));
     }
 
     @Test
@@ -3192,6 +3273,12 @@ public class TmdbDetailActivityLayoutTest {
     private static String readJava(String first, String... more) throws Exception {
         Path sourcePath = findMainJavaPath().resolve(Path.of(first, more));
         return new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+    }
+
+    private static String readFlavorJava(String flavor, String first, String... more) throws Exception {
+        Path moduleRelative = Path.of("src", flavor, "java");
+        Path base = Files.exists(moduleRelative) ? moduleRelative : Path.of("app", "src", flavor, "java");
+        return new String(Files.readAllBytes(base.resolve(Path.of(first, more))), StandardCharsets.UTF_8);
     }
 
     private static Path findLeanbackResPath() {


### PR DESCRIPTION
TMDB 三种详情模式的播放器控制栏一直没有搜索按钮，用户切过去就找不到入口。
PlayerButtonSetting.SEARCH 早已在配置层就绪，缺的是布局里的按钮本身，
所以这三种模式无法通过「播放设置-播放器按钮」统一管控搜索项。

搜索行为复刻影视原生的站内快搜：接 SiteViewModel 增量并发搜索流，
边搜边出结果、TV 端带站点进度，同一站源的多个命中全部列出，
选中即换源续播当前集；长按仍跳全局搜索页。

QuickSearchDialog 与 QuickAdapter 都在 flavor 源集、TmdbDetailActivity 在 main 源集，编译期不可见，故沿用 CastDialog 既有的反射桥接方式。
反射目标补了 proguard keep 规则并用 R8 产物核对保名，
否则只有 release 包会静默退化成跳全局搜索页。