### PR TITLE
修复：音频播放页顶部间距缺失、进入音频页先闪一下视频页

### DIFF
--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -1364,6 +1364,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         setAnimator();
         initNightModeOverlay();
         if (isShortDramaSource()) enterShortDramaFullscreen();
+        if (hasPendingImmersiveAudioLaunch()) setAudioStageVisible(true);
         setupIntroSkipConfirmListener();
     }
 
@@ -1473,10 +1474,11 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
 
     private WindowInsetsCompat setStatusBar(WindowInsetsCompat insets) {
         int top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top;
-        int bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
-        ViewGroup.LayoutParams lp = mBinding.statusBar.getLayoutParams();
-        lp.height = top;
-        mBinding.statusBar.setLayoutParams(lp);
+        Insets nav = insets.getInsets(WindowInsetsCompat.Type.navigationBars());
+        int bottom = nav.bottom;
+        mStatusBarInset = top;
+        mNavigationRightInset = nav.right;
+        applyStatusBarSpacer();
         setEpisodeBottomInset(bottom);
         return insets;
     }
@@ -1485,6 +1487,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         mEpisodeBottomInset = bottom;
         int padding = ResUtil.dp2px(12);
         mBinding.episode.setPaddingRelative(mBinding.episode.getPaddingStart(), mBinding.episode.getPaddingTop(), mBinding.episode.getPaddingEnd(), padding);
+        applyAudioStageInsets();
         mBinding.episode.post(this::updateEpisodeViewportHeight);
     }
 
@@ -5480,6 +5483,8 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         mAudioStageVisible = visible;
         syncPiPForPlaybackMode();
         if (!visible) mAudioLightEffectAnimated = false;
+        applyStatusBarSpacer();
+        applyAudioStageInsets();
         mBinding.audioStage.setVisibility(visible ? View.VISIBLE : View.GONE);
         if (visible) mBinding.audioStage.bringToFront();
         if (visible) applyAudioBackground();
@@ -9011,6 +9016,11 @@ private boolean consumePendingPlaybackResult() {
 private AudioPlaybackResolver.Resolved takeImmersiveAudioLaunch() {
         String cacheKey = Objects.toString(getIntent().getStringExtra(EXTRA_IMMERSIVE_AUDIO_CACHE_KEY), "");
         return TextUtils.isEmpty(cacheKey) ? null : IMMERSIVE_AUDIO_LAUNCHES.remove(cacheKey);
+    }
+
+    private boolean hasPendingImmersiveAudioLaunch() {
+        String cacheKey = Objects.toString(getIntent().getStringExtra(EXTRA_IMMERSIVE_AUDIO_CACHE_KEY), "");
+        return !TextUtils.isEmpty(cacheKey) && IMMERSIVE_AUDIO_LAUNCHES.containsKey(cacheKey);
     }
 
 private boolean consumeImmersiveAudioLaunch() {

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/AudioPlaybackStyleRoutingTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/AudioPlaybackStyleRoutingTest.java
@@ -78,6 +78,19 @@ public class AudioPlaybackStyleRoutingTest {
                 launch.contains("dispatchCancelPendingInputEvents"));
     }
 
+    @Test
+    public void immersiveAudioStageOpensBeforeTheServiceBindsSoTheVideoPageNeverFlashes() throws Exception {
+        String mobile = read(findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java")));
+
+        assertTrue("mobile must be able to detect a pending immersive audio launch without consuming it",
+                mobile.contains("private boolean hasPendingImmersiveAudioLaunch()")
+                        && mobile.contains("IMMERSIVE_AUDIO_LAUNCHES.containsKey(cacheKey)"));
+        assertTrue("mobile must raise the audio stage during initView so the video detail page never renders first",
+                mobile.contains("if (hasPendingImmersiveAudioLaunch()) setAudioStageVisible(true);")
+                        && mobile.indexOf("if (hasPendingImmersiveAudioLaunch()) setAudioStageVisible(true);")
+                                < mobile.indexOf("protected void initEvent()"));
+    }
+
     private static void assertImmersiveAudioDirectLaunch(String variant, String source) {
         assertTrue(variant + " must expose a direct immersive audio site launcher",
                 source.contains("static boolean startImmersiveAudioSite(Activity activity, String key, String id, String name, String pic, String mark)"));


### PR DESCRIPTION
1. 顶部间距不对（与直播页一样高） applyStatusBarSpacer() 和 applyAudioStageInsets() 在 mobile VideoActivity 里定义了却从未被调用，mStatusBarInset 永远是 0，audioStage 只吃到 XML 写死 的 paddingTop=18dp，唱片封面被顶到状态栏底下。现在 setStatusBar 记录 inset 并接上这两个方法，切换音频态时重算，与上游 fongmi-sync 的调用链一致。

2. 会先进入视频播放页再跳到音频播放页 consumeImmersiveAudioLaunch() 挂在 onServiceConnected 上，要等播放服务绑定 完成，中间几百毫秒会把视频详情页骨架先铺出来。改为在 initView 末尾用 hasPendingImmersiveAudioLaunch() 探测待处理的沉浸式音频启动，探到就立刻立起 audioStage，不再等服务绑定。该方法只读不消费缓存，旋转重建时不会误触发。

补充 AudioPlaybackStyleRoutingTest 源码不变量测试锁定第 2 项。