### PR TITLE
优化：手机端网格卡片备注改为满宽居中渐变遮罩

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -100,6 +100,7 @@ jobs:
             --tests 'com.fongmi.android.tv.utils.GithubProxyTest' \
             --tests 'com.fongmi.android.tv.ui.dialog.AboutDialogLayoutTest' \
             --tests 'com.fongmi.android.tv.ui.dialog.UpdateDialogChannelVisibilityTest' \
+            --tests 'com.fongmi.android.tv.ui.adapter.VodAdapterLayoutTest' \
             --no-daemon
           ./gradlew \
             :app:testLeanbackArm64_v8aDebugUnitTest \

--- a/app/src/mobile/res/drawable/shape_vod_remark_full.xml
+++ b/app/src/mobile/res/drawable/shape_vod_remark_full.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <gradient
+        android:angle="90"
+        android:centerColor="@color/black_60"
+        android:centerY="0.75"
+        android:endColor="@color/transparent"
+        android:startColor="@color/black_80" />
+
+    <padding
+        android:bottom="3dp"
+        android:left="8dp"
+        android:right="8dp"
+        android:top="6dp" />
+
+</shape>

--- a/app/src/mobile/res/layout/adapter_vod_rect.xml
+++ b/app/src/mobile/res/layout/adapter_vod_rect.xml
@@ -40,16 +40,20 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/remark"
-        android:layout_width="wrap_content"
+        style="@style/Video.ContextText"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/name"
-        android:layout_marginEnd="16dp"
-        android:background="@drawable/shape_vod_remark"
+        android:layout_alignStart="@+id/image"
+        android:layout_alignEnd="@+id/image"
+        android:layout_alignBottom="@+id/image"
+        android:background="@drawable/shape_vod_remark_full"
         android:ellipsize="marquee"
+        android:gravity="center"
+        android:includeFontPadding="false"
         android:marqueeRepeatLimit="marquee_forever"
         android:scrollHorizontally="true"
         android:singleLine="true"
-        android:textColor="@color/text_remark"
+        android:textColor="@color/white"
         android:textSize="12sp"
         tools:text="1080p" />
 

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/adapter/VodAdapterLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/adapter/VodAdapterLayoutTest.java
@@ -8,20 +8,77 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class VodAdapterLayoutTest {
 
     private static final String ANDROID_NS = "http://schemas.android.com/apk/res/android";
+    private static final List<String> VERTICAL_ANGLES = List.of("90", "270");
+    /** Roboto's default line height at includeFontPadding="false", as a multiple of the text size. */
+    private static final float LINE_HEIGHT_RATIO = 1.172f;
+    /** Alpha a black scrim needs for white text to clear WCAG AA 4.5:1 over a white poster pixel. */
+    private static final float MIN_ALPHA = 0.535f;
 
     @Test
     public void mobileCategoryTitlesMarqueeOnlyWhenOverflowing() throws Exception {
         assertTitleMarquee("list", "adapter_vod_list.xml", "VodListHolder.java");
         assertTitleMarquee("rect", "adapter_vod_rect.xml", "VodRectHolder.java");
         assertTitleMarquee("oval", "adapter_vod_oval.xml", "VodOvalHolder.java");
+    }
+
+    @Test
+    public void mobileRectRemarkIsFullWidthAndCentredOnThePoster() throws Exception {
+        Element remark = findById(parseLayout(read(findMobileResPath().resolve(Path.of("layout", "adapter_vod_rect.xml")))), "@+id/remark");
+
+        assertEquals("rect remark must start at the poster's start edge", "@+id/image", androidAttribute(remark, "layout_alignStart"));
+        assertEquals("rect remark must end at the poster's end edge", "@+id/image", androidAttribute(remark, "layout_alignEnd"));
+        assertEquals("rect remark must anchor to the poster, not to the title, which is GONE for unnamed items",
+                "@+id/image", androidAttribute(remark, "layout_alignBottom"));
+        assertEquals("rect remark must centre its text", "center", androidAttribute(remark, "gravity"));
+    }
+
+    @Test
+    public void mobileRectRemarkStaysLegibleOverTheScrim() throws Exception {
+        Element remark = rectRemark();
+        Element gradient = directChild(rectScrim(), "gradient");
+
+        assertEquals("rect remark must sit on the full-width scrim", "@drawable/shape_vod_remark_full", androidAttribute(remark, "background"));
+        assertEquals("rect remark must use light text over the scrim", "@color/white", androidAttribute(remark, "textColor"));
+        assertEquals("rect remark must reuse the shared text-shadow contract instead of inline shadow attributes",
+                "@style/Video.ContextText", remark.getAttribute("style"));
+        assertTrue("scrim must be a vertical gradient so the text band can sit on its dark end, was angle=" + androidAttribute(gradient, "angle"),
+                VERTICAL_ANGLES.contains(androidAttribute(gradient, "angle")));
+        assertEquals("scrim must fade out completely at its top so it never masks the poster",
+                0f, scrimAlphaAt(gradient, 1f), 0.001f);
+    }
+
+    /**
+     * The scrim only earns its keep if the glyphs land on the dark part of the ramp. Assert that as
+     * arithmetic over the real geometry (shape padding + text size + gradient stops) rather than by
+     * pinning the literals, so any equivalent rewrite stays green and any change that actually walks
+     * the text into the transparent half fails.
+     */
+    @Test
+    public void mobileRectRemarkTextBandKeepsAContrastFloor() throws Exception {
+        Element remark = rectRemark();
+        Element scrim = rectScrim();
+        Element gradient = directChild(scrim, "gradient");
+        Element padding = directChild(scrim, "padding");
+
+        float textHeight = LINE_HEIGHT_RATIO * dimension(androidAttribute(remark, "textSize"));
+        float bottom = dimension(androidAttribute(padding, "bottom"));
+        float band = dimension(androidAttribute(padding, "top")) + textHeight + bottom;
+        float alphaAtGlyphTops = scrimAlphaAt(gradient, (bottom + textHeight) / band);
+
+        assertTrue("white " + androidAttribute(remark, "textSize") + " text needs the scrim at >= " + MIN_ALPHA
+                        + " alpha where the glyph tops sit to clear 4.5:1 over a bright poster, but the "
+                        + band + "dp band only reaches " + alphaAtGlyphTops,
+                alphaAtGlyphTops >= MIN_ALPHA);
     }
 
     private static void assertTitleMarquee(String style, String layoutName, String holderName) throws Exception {
@@ -55,6 +112,64 @@ public class VodAdapterLayoutTest {
         throw new AssertionError("Missing layout view " + id);
     }
 
+    private static Element directChild(Element parent, String tag) {
+        NodeList nodes = parent.getChildNodes();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            if (nodes.item(i) instanceof Element element && tag.equals(element.getTagName())) return element;
+        }
+        throw new AssertionError("Missing <" + tag + "> directly inside <" + parent.getTagName() + ">");
+    }
+
+    private static Element rectRemark() throws Exception {
+        return findById(parseLayout(read(findMobileResPath().resolve(Path.of("layout", "adapter_vod_rect.xml")))), "@+id/remark");
+    }
+
+    private static Element rectScrim() throws Exception {
+        return parseLayout(read(findMobileResPath().resolve(Path.of("drawable", "shape_vod_remark_full.xml"))));
+    }
+
+    /**
+     * Alpha of the scrim at {@code fromBottom} (0 = the band's bottom edge, 1 = its top edge),
+     * mirroring GradientDrawable: angle 90 puts startColor at the bottom and 270 flips it, and a
+     * centerColor sits at centerX when that is overridden, otherwise at centerY.
+     */
+    private static float scrimAlphaAt(Element gradient, float fromBottom) throws Exception {
+        float offset = "90".equals(androidAttribute(gradient, "angle")) ? fromBottom : 1f - fromBottom;
+        float start = colorAlpha(androidAttribute(gradient, "startColor"));
+        float end = colorAlpha(androidAttribute(gradient, "endColor"));
+        String center = androidAttribute(gradient, "centerColor");
+        if (center.isEmpty()) return start + (end - start) * offset;
+        float centerX = fraction(androidAttribute(gradient, "centerX"));
+        float middle = centerX == 0.5f ? fraction(androidAttribute(gradient, "centerY")) : centerX;
+        float centerAlpha = colorAlpha(center);
+        if (offset <= middle) return start + (centerAlpha - start) * (offset / middle);
+        return centerAlpha + (end - centerAlpha) * ((offset - middle) / (1f - middle));
+    }
+
+    private static float colorAlpha(String reference) throws Exception {
+        String argb = reference.startsWith("#") ? reference : namedColour(reference.substring(reference.indexOf('/') + 1));
+        if (argb.length() != 9) throw new AssertionError("Expected an #AARRGGBB colour for " + reference + ", was " + argb);
+        return Integer.parseInt(argb.substring(1, 3), 16) / 255f;
+    }
+
+    private static String namedColour(String name) throws Exception {
+        Element colours = parseLayout(read(findMainResPath().resolve(Path.of("values", "colors.xml"))));
+        NodeList nodes = colours.getElementsByTagName("color");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Element colour = (Element) nodes.item(i);
+            if (name.equals(colour.getAttribute("name"))) return colour.getTextContent().trim();
+        }
+        throw new AssertionError("Missing colour @color/" + name);
+    }
+
+    private static float fraction(String value) {
+        return value.isEmpty() ? 0.5f : Float.parseFloat(value);
+    }
+
+    private static float dimension(String value) {
+        return Float.parseFloat(value.replaceAll("[a-z]+$", ""));
+    }
+
     private static String androidAttribute(Element element, String name) {
         return element.getAttributeNS(ANDROID_NS, name);
     }
@@ -73,5 +188,11 @@ public class VodAdapterLayoutTest {
         Path moduleRelative = Path.of("src", "mobile", "res");
         if (Files.exists(moduleRelative)) return moduleRelative;
         return Path.of("app", "src", "mobile", "res");
+    }
+
+    private static Path findMainResPath() {
+        Path moduleRelative = Path.of("src", "main", "res");
+        if (Files.exists(moduleRelative)) return moduleRelative;
+        return Path.of("app", "src", "main", "res");
     }
 }


### PR DESCRIPTION
把分类页与搜索结果网格卡片底部的备注标签（第15集 / 更新至…）从左下角的
不透明主题色药丸改成跨海报满宽、文字居中、由暗到透明的渐变遮罩，透出海报
画面同时保证文字可读。年份与站源角标保持原样，TV 端不改。

- 新增 shape_vod_remark_full.xml：angle=90 自底向上 black_80 → black_60 → transparent，centerY=0.75 把暗区抬到文字带高度，使 12sp 白字在亮海报上 仍高于 4.5:1 对比度
- remark 锚点改为 layout_alignBottom=@id/image：原先的 layout_above=@id/name 在片名为空（getNameVisible 返回 GONE）时会被 RelativeLayout 丢弃，满宽遮罩 会跑到海报顶部压住年份/站源角标
- 文字阴影复用共享的 @style/Video.ContextText，不再内联一套；补 includeFontPadding=false 收窄遮罩条高度
- 测试按几何与渐变色标计算文字带处的遮罩 alpha 并断言下限，而非钉死字面量； 在 CI 的发布关键测试白名单中注册 VodAdapterLayoutTest

Verification: :app:testMobileArm64_v8aDebugUnitTest VodAdapterLayoutTest 4/4 通过（含对比度不变量测试，已用去掉 centerY 的变异验证证明其会失败）；processMobile/processLeanbackArm64_v8aDebugResources 均通过
Task-Guard: vod-remark-full-width