### PR TITLE
修复发布构建的 Maven 仓库顺序

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        maven { url = "https://maven.aliyun.com/repository/gradle-plugin" }
-        maven { url = "https://maven.aliyun.com/repository/public" }
         gradlePluginPortal()
         mavenCentral()
         google()
+        maven { url = "https://maven.aliyun.com/repository/gradle-plugin" }
+        maven { url = "https://maven.aliyun.com/repository/public" }
     }
 }
 
@@ -16,10 +16,10 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         maven { url = uri("$rootDir/third_party/maven") }
-        maven { url = "https://maven.aliyun.com/repository/public" }
-        maven { url = "https://maven.aliyun.com/repository/google" }
         mavenCentral()
         google()
+        maven { url = "https://maven.aliyun.com/repository/public" }
+        maven { url = "https://maven.aliyun.com/repository/google" }
         flatDir { dirs "$rootDir/app/libs" }
         maven { url = "https://jitpack.io" }
     }


### PR DESCRIPTION
官方 Maven Central/Google 仓库优先，阿里云镜像退为兜底，避免镜像 502 阻塞 AndroidX/Kotlin 依赖解析。修复提交：a9f7e5c0073b41589c8dcb4283525e0a49b2bbad。