### PR TITLE
修复 TV 版历史页删除记录后焦点跳到删除按钮

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/HistoryActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/HistoryActivity.java
@@ -3,8 +3,10 @@ package com.fongmi.android.tv.ui.activity;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 
 import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewbinding.ViewBinding;
 
 import com.fongmi.android.tv.Product;
@@ -16,6 +18,7 @@ import com.fongmi.android.tv.event.RefreshEvent;
 import com.fongmi.android.tv.setting.Setting;
 import com.fongmi.android.tv.ui.adapter.HistoryAdapter;
 import com.fongmi.android.tv.ui.base.BaseActivity;
+import com.fongmi.android.tv.ui.custom.FocusRestorer;
 import com.fongmi.android.tv.ui.custom.SpaceItemDecoration;
 import com.fongmi.android.tv.ui.dialog.ViewingReportRangeDialog;
 
@@ -26,6 +29,7 @@ public class HistoryActivity extends BaseActivity implements HistoryAdapter.OnCl
 
     private ActivityHistoryBinding mBinding;
     private HistoryAdapter mAdapter;
+    private final FocusRestorer mFocusRestorer = new FocusRestorer();
 
     public static void start(Activity activity) {
         activity.startActivity(new Intent(activity, HistoryActivity.class));
@@ -72,7 +76,34 @@ public class HistoryActivity extends BaseActivity implements HistoryAdapter.OnCl
     }
 
     private void getHistory() {
-        mAdapter.setItems(History.getForDisplay(), () -> mBinding.progressLayout.showContent(true, mAdapter.getItemCount()));
+        int position = focusedPosition();
+        History focused = position < 0 || position >= mAdapter.getItemCount() ? null : mAdapter.getItem(position);
+        mAdapter.setItems(History.getForDisplay(), () -> {
+            mBinding.progressLayout.showContent(true, mAdapter.getItemCount());
+            if (mAdapter.getItemCount() == 0) mAdapter.setDelete(false);
+            else if (focused != null) restoreFocus(reposition(focused, position));
+        });
+    }
+
+    // 刷新会按 createTime 重排，优先按条目身份重新定位；条目已不在新列表里（被别处删掉）
+    // 就退回原位置，让焦点留在附近而不是掉给右上角的删除按钮
+    private int reposition(History focused, int position) {
+        int found = mAdapter.getItems().indexOf(focused);
+        if (found >= 0) return found;
+        return FocusRestorer.nextPosition(position, mAdapter.getItemCount(), Product.getColumn());
+    }
+
+    private int focusedPosition() {
+        if (isFinishing() || isDestroyed() || !mBinding.recycler.hasFocus()) return RecyclerView.NO_POSITION;
+        View focus = mBinding.recycler.getFocusedChild();
+        return focus == null ? RecyclerView.NO_POSITION : mBinding.recycler.getChildAdapterPosition(focus);
+    }
+
+    // 只在列表原本持有焦点时恢复：条目被移除时 RecyclerView 已 clearFocus，
+    // 焦点被窗口兜底给了右上角的删除按钮，需要主动交回列表
+    private void restoreFocus(int position) {
+        if (isFinishing() || isDestroyed()) return;
+        mFocusRestorer.restore(mBinding.recycler, position);
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -93,21 +124,32 @@ public class HistoryActivity extends BaseActivity implements HistoryAdapter.OnCl
     }
 
     @Override
-    public void onItemDelete(History item) {
+    public void onItemDelete(History item, int position) {
+        // diff 挂起时 holder 的绑定下标会失效，退回当前聚焦位置（遥控下点击必然带焦点）
+        int target = position >= 0 ? position : focusedPosition();
         mAdapter.remove(item.deleteDisplayItem(), () -> {
             mBinding.progressLayout.showContent(true, mAdapter.getItemCount());
             if (mAdapter.getItemCount() == 0) mAdapter.setDelete(false);
+            else restoreFocus(FocusRestorer.nextPosition(target, mAdapter.getItemCount(), Product.getColumn()));
         });
     }
 
     @Override
     public boolean onLongClick() {
+        mFocusRestorer.cancel();
         mAdapter.setDelete(!mAdapter.isDelete());
         return true;
     }
 
     @Override
+    protected void onStop() {
+        mFocusRestorer.cancel();
+        super.onStop();
+    }
+
+    @Override
     protected void onBackInvoked() {
+        mFocusRestorer.cancel();
         if (mAdapter.isDelete()) mAdapter.setDelete(false);
         else super.onBackInvoked();
     }

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/HistoryAdapter.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/adapter/HistoryAdapter.java
@@ -28,7 +28,7 @@ public class HistoryAdapter extends BaseDiffAdapter<History, HistoryAdapter.View
 
         void onItemClick(History item);
 
-        void onItemDelete(History item);
+        void onItemDelete(History item, int position);
 
         boolean onLongClick();
     }
@@ -56,10 +56,11 @@ public class HistoryAdapter extends BaseDiffAdapter<History, HistoryAdapter.View
         History.deleteForDisplay();
     }
 
-    private void setClickListener(View root, History item) {
+    private void setClickListener(ViewHolder holder, History item) {
+        View root = holder.itemView;
         root.setOnLongClickListener(view -> listener.onLongClick());
         root.setOnClickListener(view -> {
-            if (isDelete()) listener.onItemDelete(item);
+            if (isDelete()) listener.onItemDelete(item, holder.getBindingAdapterPosition());
             else listener.onItemClick(item);
         });
     }
@@ -78,7 +79,7 @@ public class HistoryAdapter extends BaseDiffAdapter<History, HistoryAdapter.View
         History item = getItem(position);
         String remark = item.getVodRemarks();
         boolean same = item.getVodName().equals(remark);
-        setClickListener(holder.itemView, item);
+        setClickListener(holder, item);
         holder.binding.name.setText(item.getVodName());
         holder.binding.site.setText(item.getSiteName());
         holder.binding.remark.setText(remark);

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/FocusRestorer.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/FocusRestorer.java
@@ -1,0 +1,66 @@
+package com.fongmi.android.tv.ui.custom;
+
+import androidx.core.view.OneShotPreDrawListener;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * 条目被移除后把 D-pad 焦点交回列表。
+ * RecyclerView 自身的焦点恢复救不了这种场景：移除 scrap 时已经先 clearFocus()，
+ * 焦点被窗口兜底给了布局里第一个可聚焦控件（历史页是右上角的删除按钮），
+ * 等到 recoverFocusFromState() 时 hasFocus() 已为 false 直接返回；
+ * 适配器也没有 stable id，基于 id 的恢复路径同样是死的。
+ */
+public final class FocusRestorer {
+
+    private OneShotPreDrawListener pending;
+    private int generation;
+
+    /**
+     * 网格中移除 position 后焦点应落到哪一项。
+     * 原位仍有条目就留在原位（后面的条目补位）；原位已越界说明删的是末位，
+     * 此时同行还有条目就退到新末位，整行被删空则上移一行保持同列。
+     */
+    public static int nextPosition(int position, int count, int spanCount) {
+        if (position < 0 || count <= 0) return RecyclerView.NO_POSITION;
+        if (position < count) return position;
+        int span = Math.max(1, spanCount);
+        int last = count - 1;
+        if (last / span == position / span) return last;
+        return Math.min(last, Math.max(0, position - span));
+    }
+
+    public void restore(RecyclerView recycler, int position) {
+        cancel();
+        if (recycler == null || position < 0) return;
+        schedule(recycler, position, generation, true);
+    }
+
+    /** 取消排队中的恢复，包含已经进入滚动重试阶段的那一次。 */
+    public void cancel() {
+        generation++;
+        if (pending != null) pending.removeListener();
+        pending = null;
+    }
+
+    private void schedule(RecyclerView recycler, int position, int scheduled, boolean retry) {
+        pending = OneShotPreDrawListener.add(recycler, () -> {
+            if (scheduled != generation) return;
+            pending = null;
+            if (!recycler.isShown()) return;
+            if (focus(recycler, position)) return;
+            if (!retry) {
+                recycler.requestFocus();
+                return;
+            }
+            // 目标行尚未 layout（列表已滚动过）时先滚过去；scrollToPosition 只是 requestLayout，
+            // 必须再等一次 pre-draw 才能拿到 holder，用 post 会跑在这次 layout 之前
+            recycler.scrollToPosition(position);
+            schedule(recycler, position, scheduled, false);
+        });
+    }
+
+    private static boolean focus(RecyclerView recycler, int position) {
+        RecyclerView.ViewHolder holder = recycler.findViewHolderForAdapterPosition(position);
+        return holder != null && holder.itemView.requestFocus();
+    }
+}

--- a/app/src/test/java/com/fongmi/android/tv/ui/custom/FocusRestorerTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/custom/FocusRestorerTest.java
@@ -1,0 +1,147 @@
+package com.fongmi.android.tv.ui.custom;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FocusRestorerTest {
+
+    @Test
+    public void removedItemKeepsFocusOnTheSameSlotWhenLaterItemsShiftUp() {
+        // 3 列，删掉第 0 行第 1 列（下标 1），后面的条目补位，焦点留在原位
+        assertEquals(1, FocusRestorer.nextPosition(1, 5, 3));
+        assertEquals(0, FocusRestorer.nextPosition(0, 5, 3));
+    }
+
+    @Test
+    public void removedLastItemOfARowFallsBackWithinTheSameRow() {
+        // 3 列 5 条：删掉下标 4（第 1 行第 1 列，行内末位）后剩 4 条，退到新末位 3——仍在第 1 行
+        assertEquals(3, FocusRestorer.nextPosition(4, 4, 3));
+    }
+
+    @Test
+    public void removedOnlyItemOfTheLastRowMovesUpOneRowKeepingTheColumn() {
+        // 3 列 4 条：下标 3 是第 1 行唯一条目，删除后整行消失。
+        // 一维 clamp 会给出 2（第 0 行第 2 列，横跨整屏），正确目标是同列上一行的 0
+        assertEquals(0, FocusRestorer.nextPosition(3, 3, 3));
+        // 3 列 7 条：下标 6 独占第 2 行第 0 列，删除后回到第 1 行第 0 列
+        assertEquals(3, FocusRestorer.nextPosition(6, 6, 3));
+    }
+
+    @Test
+    public void nextPositionNeverEscapesTheNewListBounds() {
+        // 不只覆盖「删一条」，也覆盖聚合删除后一次少掉多条的情况
+        for (int span = 1; span <= 6; span++) {
+            for (int position = 0; position <= 40; position++) {
+                for (int count = 0; count <= 40; count++) {
+                    int next = FocusRestorer.nextPosition(position, count, span);
+                    if (count == 0) {
+                        assertEquals("空列表必须返回 NO_POSITION", RecyclerView.NO_POSITION, next);
+                        continue;
+                    }
+                    assertTrue("span=" + span + " count=" + count + " position=" + position
+                            + " 返回了越界下标 " + next, next >= 0 && next < count);
+                    // 焦点只允许留在原位或往前退，绝不能往后跳到用户没去过的条目
+                    assertTrue("span=" + span + " count=" + count + " position=" + position
+                            + " 让焦点前进到了 " + next, next <= position);
+                    boolean clamped = position >= count && position - span > count - 1;
+                    if (position >= count && !clamped && (count - 1) / span != position / span) {
+                        assertEquals("span=" + span + " count=" + count + " position=" + position
+                                + " 整行删空后必须保持同列", position % span, next % span);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void emptyOrUnknownPositionYieldsNoPosition() {
+        assertEquals(RecyclerView.NO_POSITION, FocusRestorer.nextPosition(RecyclerView.NO_POSITION, 5, 3));
+        assertEquals(RecyclerView.NO_POSITION, FocusRestorer.nextPosition(0, 0, 3));
+    }
+
+    @Test
+    public void singleColumnListBehavesLikeALinearList() {
+        assertEquals(2, FocusRestorer.nextPosition(2, 5, 1));
+        assertEquals(3, FocusRestorer.nextPosition(4, 4, 1));
+    }
+
+    @Test
+    public void restoreGuardsAgainstHiddenListsAndScrollsToUnlaidOutTargets() throws Exception {
+        String source = read(findMainJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "custom", "FocusRestorer.java")));
+        assertTrue("恢复焦点前必须确认列表可见，否则 requestFocus 会被 INVISIBLE 的祖先拒绝",
+                source.contains("!recycler.isShown()"));
+        assertTrue("目标行未 layout 时必须先滚动，并再等一次 pre-draw 才能拿到 holder（post 会跑在 layout 之前）",
+                source.contains("recycler.scrollToPosition(position);")
+                        && source.contains("schedule(recycler, position, scheduled, false);"));
+        assertFalse("不能用 post 做滚动重试：它的消息会在重新 layout 之前执行，重试必然拿不到 holder",
+                source.contains("recycler.post("));
+        assertTrue("重试仍失败时必须把焦点兜底交回列表本身",
+                source.contains("recycler.requestFocus()"));
+        assertTrue("必须检查 requestFocus 的返回值，而不是假定成功",
+                source.contains("return holder != null && holder.itemView.requestFocus();"));
+        assertTrue("排队的恢复必须可取消，避免退出删除模式或离开页面后抢焦点",
+                source.contains("public void cancel()")
+                        && source.contains("pending.removeListener();"));
+        assertTrue("滚动重试不受 removeListener 管辖，必须用代际号让 cancel 也能作废它",
+                source.contains("if (scheduled != generation) return;"));
+    }
+
+    @Test
+    public void leanbackHistoryPageRestoresFocusByItemIdentityAndCancelsOnExit() throws Exception {
+        String source = read(findLeanbackJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "activity", "HistoryActivity.java")));
+        assertTrue("删除单条后必须按网格规则恢复焦点，而不是一维 clamp",
+                source.contains("FocusRestorer.nextPosition(target, mAdapter.getItemCount(), Product.getColumn())"));
+        assertFalse("不能对网格下标做一维 clamp——列删空时会把焦点甩到上一行另一端",
+                source.contains("mAdapter.getItemCount() - 1)"));
+        assertTrue("删除位置必须来自 holder 的绑定下标，而不是重新 indexOf 扫描",
+                source.contains("public void onItemDelete(History item, int position)"));
+        assertTrue("去抖刷新会重排列表，恢复焦点必须按条目身份重新定位",
+                source.contains("indexOf(focused)"));
+        assertTrue("聚焦条目已不在新列表时必须退回原位置，而不是放弃恢复让焦点掉给删除按钮",
+                source.contains("reposition(focused, position)")
+                        && source.contains("if (found >= 0) return found;"));
+        assertTrue("holder 绑定下标失效时必须退回当前聚焦位置",
+                source.contains("position >= 0 ? position : focusedPosition()"));
+        assertTrue("恢复焦点前必须做生命周期守卫",
+                source.contains("if (isFinishing() || isDestroyed()) return;"));
+        assertTrue("退出删除模式、返回与 onStop 都必须取消排队中的恢复",
+                source.contains("mFocusRestorer.cancel();")
+                        && source.contains("protected void onStop()"));
+    }
+
+    @Test
+    public void leanbackHistoryAdapterPassesTheBoundPositionOnDelete() throws Exception {
+        String source = read(findLeanbackJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "adapter", "HistoryAdapter.java")));
+        assertTrue("删除回调必须带上 holder 的绑定下标",
+                source.contains("void onItemDelete(History item, int position);")
+                        && source.contains("listener.onItemDelete(item, holder.getBindingAdapterPosition());"));
+    }
+
+    private static String read(Path path) throws Exception {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static Path findMainJavaPath() {
+        Path moduleRelative = Path.of("src", "main", "java");
+        if (Files.exists(moduleRelative)) return moduleRelative;
+        return Path.of("app", "src", "main", "java");
+    }
+
+    private static Path findLeanbackJavaPath() {
+        Path moduleRelative = Path.of("src", "leanback", "java");
+        if (Files.exists(moduleRelative)) return moduleRelative;
+        return Path.of("app", "src", "leanback", "java");
+    }
+}


### PR DESCRIPTION
删除模式下每删一条记录，D-pad 焦点都会跳到右上角的「删除」按钮。
根因是 RecyclerView 移除 scrap 时先 clearFocus()，窗口兜底把焦点给了 布局里第一个可聚焦控件；等到 recoverFocusFromState() 时 hasFocus() 已为 false 直接返回，加上适配器没有 stable id，框架自身的焦点恢复
两条路径都是死的，必须由页面主动接管。

新增共享的 FocusRestorer：
- 按网格规则计算恢复位置，原位仍有条目就留在原位，整行被删空则 上移一行保持同列（一维 clamp 会把焦点甩到上一行另一端）
- 目标行未 layout 时先 scrollToPosition 再等一次 pre-draw 重试， 用 post 会跑在这次 layout 之前而必然拿不到 holder
- 用代际号让 cancel() 同时作废已进入重试阶段的那一次

历史页两处刷新都接上焦点恢复：单条删除用 holder 的绑定下标；
去抖刷新会按 createTime 重排，按条目身份重新定位，条目已不在新
列表里则退回原位置。退出删除模式、返回和 onStop 都取消排队中的恢复。

验证：leanback 与 mobile 两个 flavor 编译通过；新增 FocusRestorerTest 9 个测试在两个 flavor 均通过，其中穷举用例覆盖 position/count 全组合，
暴露并修掉了聚合删除一次少掉多条时的越界。