### PR TITLE
修复：播放器里切内核不再全局生效，改回按剧集记住

### DIFF
--- a/app/schemas/com.fongmi.android.tv.db.AppDatabase/44.json
+++ b/app/schemas/com.fongmi.android.tv.db.AppDatabase/44.json
@@ -1,0 +1,690 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 44,
+    "identityHash": "2868d4276f9718c3102b142c99dfd3e3",
+    "entities": [
+      {
+        "tableName": "Keep",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `siteName` TEXT, `vodName` TEXT, `vodPic` TEXT, `createTime` INTEGER NOT NULL, `type` INTEGER NOT NULL, `cid` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteName",
+            "columnName": "siteName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vodName",
+            "columnName": "vodName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vodPic",
+            "columnName": "vodPic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createTime",
+            "columnName": "createTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "Site",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `searchable` INTEGER, `changeable` INTEGER, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchable",
+            "columnName": "searchable",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "changeable",
+            "columnName": "changeable",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "Live",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `keep` TEXT, `boot` INTEGER NOT NULL, `pass` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "boot",
+            "columnName": "boot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pass",
+            "columnName": "pass",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "Track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `key` TEXT, `name` TEXT, `format` TEXT, `selected` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selected",
+            "columnName": "selected",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Track_key_type",
+            "unique": true,
+            "columnNames": [
+              "key",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Track_key_type` ON `${TABLE_NAME}` (`key`, `type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "Config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `time` INTEGER NOT NULL, `url` TEXT, `json` TEXT, `name` TEXT, `logo` TEXT, `home` TEXT, `parse` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "logo",
+            "columnName": "logo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "home",
+            "columnName": "home",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parse",
+            "columnName": "parse",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Config_url_type",
+            "unique": true,
+            "columnNames": [
+              "url",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Config_url_type` ON `${TABLE_NAME}` (`url`, `type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "Device",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `uuid` TEXT, `name` TEXT, `ip` TEXT, `type` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ip",
+            "columnName": "ip",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Device_uuid_name",
+            "unique": true,
+            "columnNames": [
+              "uuid",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Device_uuid_name` ON `${TABLE_NAME}` (`uuid`, `name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "History",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `vodPic` TEXT, `wallPic` TEXT, `vodName` TEXT, `vodFlag` TEXT, `vodRemarks` TEXT, `episodeUrl` TEXT, `revSort` INTEGER NOT NULL, `revPlay` INTEGER NOT NULL, `createTime` INTEGER NOT NULL, `opening` INTEGER NOT NULL, `ending` INTEGER NOT NULL, `position` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `speed` REAL NOT NULL, `speedOverride` INTEGER NOT NULL DEFAULT 0, `scale` INTEGER NOT NULL, `cid` INTEGER NOT NULL, `typeName` TEXT, `area` TEXT, `actor` TEXT, `director` TEXT, `year` TEXT, `tmdbId` INTEGER NOT NULL DEFAULT 0, `mediaType` TEXT DEFAULT '', `legacyKey` TEXT DEFAULT '', `tmdbSeasonNumber` INTEGER NOT NULL DEFAULT 0, `tmdbEpisodeNumber` INTEGER NOT NULL DEFAULT 0, `player` INTEGER NOT NULL DEFAULT -1, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vodPic",
+            "columnName": "vodPic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "wallPic",
+            "columnName": "wallPic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vodName",
+            "columnName": "vodName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vodFlag",
+            "columnName": "vodFlag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "vodRemarks",
+            "columnName": "vodRemarks",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeUrl",
+            "columnName": "episodeUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "revSort",
+            "columnName": "revSort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revPlay",
+            "columnName": "revPlay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createTime",
+            "columnName": "createTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opening",
+            "columnName": "opening",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ending",
+            "columnName": "ending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedOverride",
+            "columnName": "speedOverride",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "scale",
+            "columnName": "scale",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "typeName",
+            "columnName": "typeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "area",
+            "columnName": "area",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "actor",
+            "columnName": "actor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "director",
+            "columnName": "director",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "legacyKey",
+            "columnName": "legacyKey",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "tmdbSeasonNumber",
+            "columnName": "tmdbSeasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "tmdbEpisodeNumber",
+            "columnName": "tmdbEpisodeNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "player",
+            "columnName": "player",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaybackDeleteTombstone",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `configKey` TEXT NOT NULL, `scope` TEXT NOT NULL, `historyKey` TEXT NOT NULL, `siteKey` TEXT NOT NULL, `vodId` TEXT NOT NULL, `mediaType` TEXT NOT NULL DEFAULT '', `tmdbId` INTEGER NOT NULL DEFAULT 0, `seasonNumber` INTEGER NOT NULL DEFAULT -1, `deletedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configKey",
+            "columnName": "configKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "historyKey",
+            "columnName": "historyKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteKey",
+            "columnName": "siteKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vodId",
+            "columnName": "vodId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PlaybackDeleteTombstone_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaybackDeleteTombstone_deletedAt` ON `${TABLE_NAME}` (`deletedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "TmdbSeasonProgress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cid` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `tmdbId` INTEGER NOT NULL, `seasonNumber` INTEGER NOT NULL, `episodeNumber` INTEGER NOT NULL, `position` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `sourceFlag` TEXT NOT NULL, `sourceEpisodeName` TEXT NOT NULL, `sourceEpisodeUrl` TEXT NOT NULL, `sourceHistoryKey` TEXT NOT NULL, `sourceBindingKey` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`cid`, `mediaType`, `tmdbId`, `seasonNumber`))",
+        "fields": [
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceFlag",
+            "columnName": "sourceFlag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceEpisodeName",
+            "columnName": "sourceEpisodeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceEpisodeUrl",
+            "columnName": "sourceEpisodeUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceHistoryKey",
+            "columnName": "sourceHistoryKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceBindingKey",
+            "columnName": "sourceBindingKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cid",
+            "mediaType",
+            "tmdbId",
+            "seasonNumber"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TmdbSeasonProgress_cid_mediaType_tmdbId_sourceHistoryKey_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "cid",
+              "mediaType",
+              "tmdbId",
+              "sourceHistoryKey",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TmdbSeasonProgress_cid_mediaType_tmdbId_sourceHistoryKey_updatedAt` ON `${TABLE_NAME}` (`cid`, `mediaType`, `tmdbId`, `sourceHistoryKey`, `updatedAt`)"
+          },
+          {
+            "name": "index_TmdbSeasonProgress_cid_sourceHistoryKey",
+            "unique": false,
+            "columnNames": [
+              "cid",
+              "sourceHistoryKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TmdbSeasonProgress_cid_sourceHistoryKey` ON `${TABLE_NAME}` (`cid`, `sourceHistoryKey`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2868d4276f9718c3102b142c99dfd3e3')"
+    ]
+  }
+}

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -447,6 +447,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
     private boolean tmdbHistoryResumePending;
     private boolean pendingLutImport;
     private boolean playerKernelSwitchRefreshing;
+    private int mPendingPlayerKernel = PlayerSetting.NONE;
 
     private final ActivityResultLauncher<Intent> mLutDir = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
         if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null || result.getData().getData() == null) return;
@@ -1245,6 +1246,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         SpiderDebug.log("video-flow", "service ready sinceLaunch=%dms key=%s id=%s", getLaunchCost(System.currentTimeMillis()), getKey(), getId());
         player().setDanmakuController(mBinding.exo.getDanmakuController());
         player().setDanmakuEnabled(DanmakuSetting.isShow());
+        applyPendingPlayerKernel();
         setPlayerKernel();
         setDecode();
         setLut();
@@ -1556,7 +1558,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
     }
 
     private void setPlayer() {
-        mBinding.control.action.player.setText(service() == null ? ResUtil.getStringArray(R.array.select_player)[PlayerSetting.getPlayer()] : player().getPlayerText());
+        mBinding.control.action.player.setText(service() == null ? ResUtil.getStringArray(R.array.select_player)[PlayerSetting.getActivePlayer()] : player().getPlayerText());
     }
 
     private void setupActionButtons() {
@@ -1647,6 +1649,50 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
 
     private void setPlayerKernel() {
         mBinding.control.action.player.setText(player().getPlayerText());
+    }
+
+    /**
+     * 起播前把内核切到本剧记住的选择，并返回该内核给取址用——取播放地址要按内核区分线路。
+     * 没有记录时 getPlayerOrDefault 会退回设置页的全局默认。
+     * 播放服务还没连上时先只记会话内核（取址在工作线程上读它），引擎由 onServiceConnected 补齐。
+     */
+    private int applyHistoryPlayerKernel() {
+        int kernel = mHistory == null ? PlayerSetting.getPlayer() : mHistory.getPlayerOrDefault();
+        PlayerSetting.putActivePlayer(kernel);
+        if (service() == null) {
+            mPendingPlayerKernel = kernel;
+            return kernel;
+        }
+        mPendingPlayerKernel = PlayerSetting.NONE;
+        player().preparePlayer(kernel);
+        setPlayerKernel();
+        setDecode();
+        return kernel;
+    }
+
+    /**
+     * 服务连上后补齐本页在等的内核。
+     * 服务可能是上一次播放留活下来的，它建 PlayerManager 时读到的还是上一部剧的内核，
+     * 所以本页在服务就绪前定下的选择要在这里落到引擎上；没有待办时不动引擎。
+     */
+    private void applyPendingPlayerKernel() {
+        int kernel = mPendingPlayerKernel;
+        mPendingPlayerKernel = PlayerSetting.NONE;
+        if (!PlayerSetting.isPlayer(kernel)) return;
+        player().preparePlayer(kernel);
+    }
+
+    /**
+     * 把用户刚选定的内核写回本剧历史并落盘。
+     * 只在用户显式换内核时调用，且用用户选的值而不是会话/引擎状态：
+     * 播放页可能重叠存在（上一部剧的 Activity 还没销毁），若挂在每次存历史上，
+     * 上一部剧的收尾存档会用别人的会话内核覆盖本剧记住的选择；
+     * 而引擎类型还会被播放失败后的自动回退改掉，也不代表用户改了选择。
+     */
+    private void rememberPlayerKernel(int type) {
+        if (mHistory == null || !PlayerSetting.isPlayer(type)) return;
+        mHistory.setPlayer(type);
+        syncHistory();
     }
 
     private void setScale(int scale) {
@@ -1810,7 +1856,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         beginPlayHealth();
         prepareFastTmdbPlaybackHistory(item, flag, episode);
         SpiderDebug.log("video-flow", "fast tmdb playback start cost=%dms key=%s flag=%s episode=%s url=%s", System.currentTimeMillis() - start, getKey(), flag.getFlag(), episode.getName(), episode.getUrl());
-        mViewModel.playerContent(getKey(), flag.getFlag(), episode.getUrl());
+        mViewModel.playerContent(getKey(), flag.getFlag(), episode.getUrl(), applyHistoryPlayerKernel());
         mBinding.getRoot().post(() -> hydrateFastTmdbPlaybackDetail(item));
         applyFastTmdbPlaybackFullDetailNextFrame(item);
     }
@@ -2583,7 +2629,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         clearLyrics();
         clearKaraokeState();
         if (shouldUseImmersiveAudio()) setAudioStageVisible(true);
-        mViewModel.playerContent(getKey(), playFlag, episode.getUrl());
+        mViewModel.playerContent(getKey(), playFlag, episode.getUrl(), applyHistoryPlayerKernel());
         mBinding.widget.title.setSelected(true);
         updateHistory(episode);
         showProgress();
@@ -3909,6 +3955,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
         player().switchPlayer(type);
         setPlayerKernel();
         setDecode();
+        rememberPlayerKernel(type);
     }
 
     private boolean onPlayerKernelLong() {
@@ -3955,6 +4002,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
             Notify.show(result != null && result.hasMsg() ? result.getMsg() : getString(R.string.error_play_url));
         } else {
             player().switchPlayer(type, result, getHistoryKey(), metadata, isUseParse(), position, speed, repeat);
+            rememberPlayerKernel(type);
         }
         setPlayerKernel();
         setDecode();

--- a/app/src/main/java/com/fongmi/android/tv/api/SiteApi.java
+++ b/app/src/main/java/com/fongmi/android/tv/api/SiteApi.java
@@ -178,7 +178,7 @@ public class SiteApi {
 
     @NonNull
     public static Result playerContent(@NonNull String key, @NonNull String flag, @NonNull String id) throws Exception {
-        return playerContent(key, flag, id, PlayerSetting.getPlayer());
+        return playerContent(key, flag, id, PlayerSetting.getActivePlayer());
     }
 
     @NonNull
@@ -188,7 +188,7 @@ public class SiteApi {
 
     @NonNull
     public static Result playerContentIsolated(@NonNull String key, @NonNull String flag, @NonNull String id) throws Exception {
-        return playerContentIsolated(key, flag, id, PlayerSetting.getPlayer());
+        return playerContentIsolated(key, flag, id, PlayerSetting.getActivePlayer());
     }
 
     @NonNull

--- a/app/src/main/java/com/fongmi/android/tv/bean/History.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/History.java
@@ -115,7 +115,9 @@ public class History implements Diffable<History> {
     @ColumnInfo(defaultValue = "0")
     private int tmdbEpisodeNumber;
 
-    private transient int player = PlayerSetting.NONE;
+    @SerializedName("player")
+    @ColumnInfo(defaultValue = "-1")
+    private int player = PlayerSetting.NONE;
     private transient long updateTime;
     private transient String playbackSourceKey;
     @Ignore

--- a/app/src/main/java/com/fongmi/android/tv/db/AppDatabase.java
+++ b/app/src/main/java/com/fongmi/android/tv/db/AppDatabase.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Database(entities = {Keep.class, Site.class, Live.class, Track.class, Config.class, Device.class, History.class, PlaybackDeleteTombstone.class, TmdbSeasonProgress.class}, version = AppDatabase.VERSION)
 public abstract class AppDatabase extends RoomDatabase {
 
-    public static final int VERSION = 43;
+    public static final int VERSION = 44;
     public static final String NAME = "tv";
     public static final String SYMBOL = "@@@";
     private static final int BACKUP_KEEP_COUNT = 7;
@@ -177,6 +177,7 @@ public abstract class AppDatabase extends RoomDatabase {
                 .addMigrations(Migrations.MIGRATION_40_41)
                 .addMigrations(Migrations.MIGRATION_41_42)
                 .addMigrations(Migrations.MIGRATION_42_43)
+                .addMigrations(Migrations.MIGRATION_43_44)
                 .fallbackToDestructiveMigration(true)
                 .allowMainThreadQueries().build();
     }

--- a/app/src/main/java/com/fongmi/android/tv/db/Migrations.java
+++ b/app/src/main/java/com/fongmi/android/tv/db/Migrations.java
@@ -130,6 +130,18 @@ public class Migrations {
         }
     };
 
+    /**
+     * 播放内核回到「按剧集记住」：History 新增 player 列。
+     * -1 表示这条记录没有自己的内核偏好，播放时沿用设置页的全局默认。
+     */
+    public static final Migration MIGRATION_43_44 = new Migration(43, 44) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            addColumnIfMissing(database, "History", "player",
+                    "ALTER TABLE History ADD COLUMN `player` INTEGER NOT NULL DEFAULT -1");
+        }
+    };
+
     private static void addColumnIfMissing(
             SupportSQLiteDatabase database,
             String table,

--- a/app/src/main/java/com/fongmi/android/tv/model/SiteViewModel.java
+++ b/app/src/main/java/com/fongmi/android/tv/model/SiteViewModel.java
@@ -142,6 +142,11 @@ public class SiteViewModel extends ViewModel {
         execute(TaskType.PLAYER, player, () -> SiteApi.playerContent(key, flag, id));
     }
 
+    /** 按指定内核取播放地址：取址要按内核区分线路，所以内核必须显式传入而不是读全局默认。 */
+    public void playerContent(String key, String flag, String id, int playerType) {
+        execute(TaskType.PLAYER, player, () -> SiteApi.playerContent(key, flag, id, playerType));
+    }
+
     public void searchContent(Site site, String keyword, boolean quick, String page) {
         long start = System.currentTimeMillis();
         execute(TaskType.RESULT, result, SearchTask.create(site, keyword, quick, page),

--- a/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
@@ -400,7 +400,10 @@ public class PlayerManager implements ParseCallback {
                 onNativeAudioBecomingNoisy();
             }
         };
-        this.playerType = PlayerSetting.getPlayer();
+        // 播放页可能在服务起来之前就定好了本次要用的内核（按剧集记住的选择），
+        // 所以这里读会话内核；没有会话时它自然退回设置页的全局默认。
+        this.playerType = PlayerSetting.getActivePlayer();
+        PlayerSetting.putActivePlayer(this.playerType);
         this.playerFallbackTried = new boolean[PLAYER_COUNT];
         clearFfmpegModeFallbackState();
         this.adAudioRuntime = new AdAudioRuntimeController(
@@ -417,6 +420,7 @@ public class PlayerManager implements ParseCallback {
 
     public void release() {
         mediaSession.beforeRelease();
+        PlayerSetting.clearActivePlayer();
         adAudioRuntime.close();
         prepareSeq++;
         exoSpeedRestoreState.clear();
@@ -904,7 +908,7 @@ public class PlayerManager implements ParseCallback {
     }
 
     public String getAudioPassThroughText() {
-        if (!PlayerSetting.isAudioPassThrough()) return "关";
+        if (!PlayerSetting.isAudioPassThrough(playerType)) return "关";
         if (!isMpv()) return "开";
         String codecs = engine == null ? "" : engine.getAudioSpdifCodecs();
         return TextUtils.isEmpty(codecs) ? "开/PCM" : "开/" + codecs;
@@ -1889,11 +1893,38 @@ public void resetTrack(int type) {
     }
 
     public void switchPlayer(int type) {
-        switchPlayer(type, true, false);
+        switchPlayer(type, false);
     }
 
     public void switchPlayerManually(int type) {
-        switchPlayer(type, true, true);
+        switchPlayer(type, true);
+    }
+
+    /**
+     * 为即将开始的一次播放切到指定内核（通常来自历史记录里记住的选择）。
+     * 与 switchPlayer 不同：这里不保留旧 spec 的进度、也不重新起播旧地址，
+     * 因为调用方紧接着就会 start/parse 新地址；只换引擎并记下本次会话内核。
+     */
+    public void preparePlayer(int type) {
+        int next = resolveAvailablePlayer(PlayerSetting.sanitizePlayer(type));
+        PlayerSetting.putActivePlayer(next);
+        if (engine == null || player == null || next == playerType) return;
+        int decode = engine.getDecode();
+        resetPlayerFallback();
+        manualPlayerSwitchPending = false;
+        beginPlaybackTrace("prepare-player");
+        prepareSeq++;
+        resetLutRuntimeState("prepare_player", true);
+        stopNativeAudioSession();
+        stopParse();
+        engine.release();
+        playerType = next;
+        spec = null;
+        clearPendingSwitchRestore();
+        if (SpiderDebug.isEnabled()) SpiderDebug.log("player", "prepare player type=%d decode=%d", next, decode);
+        engine = buildEngine(playerType, sanitizeDecode(decode));
+        player = engine.getPlayer();
+        callback.onPlayerRebuild(player, false);
     }
 
     public void switchPlayer(int type, PlaySpec freshSpec, long position, float speed, boolean repeat) {
@@ -1908,7 +1939,7 @@ public void resetTrack(int type) {
         stopNativeAudioSession();
         engine.release();
         playerType = type;
-        PlayerSetting.putPlayer(type);
+        PlayerSetting.putActivePlayer(type);
         spec = freshSpec;
         bindPlaybackTrace();
         playWhenReady = wasPlayWhenReady;
@@ -1936,7 +1967,7 @@ public void resetTrack(int type) {
         stopParse();
         engine.release();
         playerType = type;
-        PlayerSetting.putPlayer(type);
+        PlayerSetting.putActivePlayer(type);
         engine = buildEngine(playerType, decode);
         player = engine.getPlayer();
         playWhenReady = wasPlayWhenReady;
@@ -1961,11 +1992,7 @@ public void resetTrack(int type) {
         }
     }
 
-    private void switchPlayer(int type, boolean persist) {
-        switchPlayer(type, persist, false);
-    }
-
-    private void switchPlayer(int type, boolean persist, boolean manual) {
+    private void switchPlayer(int type, boolean manual) {
         if (engine == null || player == null) return;
         type = PlayerSetting.sanitizePlayer(type);
         type = manual ? resolveManualPlayer(type) : resolveAvailablePlayer(type);
@@ -1974,32 +2001,35 @@ public void resetTrack(int type) {
         manualPlayerSwitchPending = manual;
         if (manual) beginIjkRuntimeManualOverride();
         beginPlaybackTrace("switch-player");
-        switchEngine(type, persist, true, true);
+        switchEngine(type, true, true, true);
     }
 
-    private void switchEngine(int type, boolean persist, boolean preserveState, boolean notifyPrepare) {
+    /**
+     * chosen 区分「用户为本次播放选定的内核」与「当前实际在跑的引擎」：
+     * 手动切换要更新会话内核（供取播放地址、写历史使用），
+     * 而播放失败后的自动回退只换引擎，不能改写用户的选择。
+     */
+    private void switchEngine(int type, boolean chosen, boolean preserveState, boolean notifyPrepare) {
         int decode = engine.getDecode();
-        switchEngine(type, persist, preserveState, notifyPrepare, decode);
+        switchEngine(type, chosen, preserveState, notifyPrepare, decode);
     }
 
-    private void switchEngine(int type, boolean persist, boolean preserveState, boolean notifyPrepare, int decode) {
+    private void switchEngine(int type, boolean chosen, boolean preserveState, boolean notifyPrepare, int decode) {
         long position = preserveState ? getPosition() : 0;
         float speed = preserveState ? getSpeed() : 1f;
         boolean repeat = preserveState && isRepeatOne();
         boolean wasPlayWhenReady = preserveState && player != null ? player.getPlayWhenReady() : playWhenReady;
-        switchEngine(type, persist, notifyPrepare, decode, position, speed, repeat, wasPlayWhenReady);
+        switchEngine(type, chosen, notifyPrepare, decode, position, speed, repeat, wasPlayWhenReady);
     }
 
-    private void switchEngine(int type, boolean persist, boolean notifyPrepare, int decode, long position, float speed, boolean repeat, boolean wasPlayWhenReady) {
+    private void switchEngine(int type, boolean chosen, boolean notifyPrepare, int decode, long position, float speed, boolean repeat, boolean wasPlayWhenReady) {
         prepareSeq++;
         resetLutRuntimeState("switch_player", true);
         stopNativeAudioSession();
         engine.release();
         playerType = type;
-        if (persist) {
-            PlayerSetting.putPlayer(type);
-        }
-        if (SpiderDebug.isEnabled()) SpiderDebug.log("player", "switch player type=%d persist=%s position=%d spec=%s", type, persist, position, debugSpec());
+        if (chosen) PlayerSetting.putActivePlayer(type);
+        if (SpiderDebug.isEnabled()) SpiderDebug.log("player", "switch player type=%d chosen=%s position=%d spec=%s", type, chosen, position, debugSpec());
         engine = buildEngine(playerType, sanitizeDecode(decode));
         player = engine.getPlayer();
         callback.onPlayerRebuild(player, false);
@@ -3625,7 +3655,7 @@ public void resetTrack(int type) {
                 || !playbackAutoSession.active()
                 || playerType != PlayerSetting.IJK
                 || !PlaybackPerformanceSetting.isAuto(PlayerSetting.IJK)
-                || PlayerSetting.getPlayer() != PlayerSetting.IJK) return;
+                || PlayerSetting.getActivePlayer() != PlayerSetting.IJK) return;
         long now = Math.max(0, nowElapsedMs);
         IjkRuntimeProfileController.Facts facts = currentIjkRuntimeFacts(now);
         IjkRuntimeProfileController.RuntimeSample sample =
@@ -3645,7 +3675,7 @@ public void resetTrack(int type) {
 
     private IjkRuntimeProfileController.Facts currentIjkRuntimeFacts(
             long nowElapsedMs) {
-        boolean automatic = PlayerSetting.getPlayer() == PlayerSetting.IJK
+        boolean automatic = PlayerSetting.getActivePlayer() == PlayerSetting.IJK
                 && PlaybackPerformanceSetting.isAuto(PlayerSetting.IJK)
                 && !ijkRuntimeManualOverride;
         return IjkRuntimeProfileController.Facts.fromContext(
@@ -4020,7 +4050,7 @@ public void resetTrack(int type) {
         ijkRuntimeManualOverride = false;
         pendingIjkRuntimeFallbackReparse = false;
         if (!ijkRuntimeTemporaryFallback) return;
-        if (PlayerSetting.getPlayer() != PlayerSetting.IJK
+        if (PlayerSetting.getActivePlayer() != PlayerSetting.IJK
                 || !PlaybackPerformanceSetting.isAuto(PlayerSetting.IJK)) {
             ijkRuntimeTemporaryFallback = false;
             return;
@@ -6571,7 +6601,7 @@ public void resetTrack(int type) {
         if (spec != null && spec.getDrm() != null) return false;
         if (PlayerSetting.isTunnel()) return false;
         if (engine.getDecode() == PlayerEngine.SOFT) return false;
-        if (PlayerSetting.isVideoPrefer()) return false;
+        if (PlayerSetting.isVideoPrefer(playerType)) return false;
         return true;
     }
 
@@ -8294,7 +8324,7 @@ public void resetTrack(int type) {
                 List<Track> savedTracks = Track.find(getKey());
                 setTrack(savedTracks);
                 if (RealtimeSubtitleController.get().isEnabled()) disableSubtitleTrackForRealtime();
-                if (PlayerSetting.isPreferAAC() && !TrackUtil.hasTrack(player, savedTracks, C.TRACK_TYPE_AUDIO)) TrackUtil.preferAAC(player);
+                if (PlayerSetting.isPreferAAC(playerType) && !TrackUtil.hasTrack(player, savedTracks, C.TRACK_TYPE_AUDIO)) TrackUtil.preferAAC(player);
                 callback.onTracksChanged();
                 initTrack = true;
             }

--- a/app/src/main/java/com/fongmi/android/tv/player/Source.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/Source.java
@@ -85,7 +85,7 @@ public class Source {
     }
 
     public String fetch(Result result) throws Exception {
-        return fetch(result, PlayerSetting.getPlayer());
+        return fetch(result, PlayerSetting.getActivePlayer());
     }
 
     public String fetch(Result result, int playerType) throws Exception {

--- a/app/src/main/java/com/fongmi/android/tv/player/lut/LutEligibility.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/lut/LutEligibility.java
@@ -32,7 +32,7 @@ public class LutEligibility {
         if (spec != null && spec.getDrm() != null) return ResUtil.getString(R.string.lut_unavailable_drm);
         if (!engine.supportsNativeLut() && PlayerSetting.isTunnel()) return ResUtil.getString(R.string.lut_unavailable_tunnel);
         if (!engine.supportsNativeLut() && engine.getDecode() == PlayerEngine.SOFT) return ResUtil.getString(R.string.lut_unavailable_soft_decode);
-        if (!engine.supportsNativeLut() && PlayerSetting.isVideoPrefer()) return ResUtil.getString(R.string.lut_unavailable_video_prefer);
+        if (!engine.supportsNativeLut() && PlayerSetting.isVideoPrefer(PlayerSetting.getActivePlayer())) return ResUtil.getString(R.string.lut_unavailable_video_prefer);
         if (isHdr(engine.getVideoFormat()) || isHdr(engine.getCurrentTracks())) return ResUtil.getString(R.string.lut_unavailable_hdr);
         if (isKnownAudioOnly(engine.getCurrentTracks())) return ResUtil.getString(R.string.lut_unavailable_no_video);
         return null;

--- a/app/src/main/java/com/fongmi/android/tv/setting/PlaybackPerformanceSetting.java
+++ b/app/src/main/java/com/fongmi/android/tv/setting/PlaybackPerformanceSetting.java
@@ -206,10 +206,14 @@ public class PlaybackPerformanceSetting {
     }
 
     public static String getProfileName() {
-        int profile = getProfile();
+        return getProfileName(PlayerSetting.getPlayer());
+    }
+
+    public static String getProfileName(int kernel) {
+        int profile = getProfile(kernel);
         return switch (profile) {
             case PROFILE_AUTO -> {
-                int count = getOverrideCount(PlayerSetting.getPlayer());
+                int count = getOverrideCount(kernel);
                 yield count == 0 ? "自动" : "自动（已覆盖" + count + "项）";
             }
             case PROFILE_COMPATIBLE,

--- a/app/src/main/java/com/fongmi/android/tv/setting/PlayerSetting.java
+++ b/app/src/main/java/com/fongmi/android/tv/setting/PlayerSetting.java
@@ -81,6 +81,12 @@ public class PlayerSetting {
     private static final String KEY_OSD_MINI = "player_osd_mini";
     private static boolean legacyOsdMigrated;
     private static boolean legacyBrightnessMigrated;
+    /**
+     * 当前播放会话正在使用的内核（NONE 表示没有会话，按全局默认）。
+     * 只存在于内存：进程内所有「现在用的是哪个内核」的判断都读它，退出播放后清空。
+     * 由 PlayerManager 在建引擎/切引擎时写入，volatile 以便工作线程（取播放地址）读到最新值。
+     */
+    private static volatile int activePlayer = NONE;
 
     public static int getPlayer() {
         int player = Prefers.getInt("player", EXO);
@@ -91,6 +97,25 @@ public class PlayerSetting {
 
     public static void putPlayer(int player) {
         Prefers.put("player", sanitizePlayer(player));
+    }
+
+    /**
+     * 当前实际在跑的内核，与全局默认内核解耦。
+     * 播放器里切内核只影响本次播放（并由 History 按剧集记住），不再回写全局默认，
+     * 因此运行期凡是问「现在用的是哪个内核」的地方都要读这里，而不是 getPlayer()；
+     * getPlayer() 只代表设置页里的全局默认值，也是没有播放会话时的兜底。
+     */
+    public static int getActivePlayer() {
+        int player = activePlayer;
+        return isPlayer(player) ? player : getPlayer();
+    }
+
+    public static void putActivePlayer(int player) {
+        activePlayer = isPlayer(player) ? player : NONE;
+    }
+
+    public static void clearActivePlayer() {
+        activePlayer = NONE;
     }
 
     public static boolean isImmersiveAudioMode() {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
@@ -427,7 +427,7 @@ public abstract class PlaybackActivity extends BaseActivity implements MediaCont
     }
 
     private boolean isSelectedMpvPlayer() {
-        return mService != null ? player().isMpv() : PlayerSetting.getPlayer() == PlayerSetting.MPV;
+        return mService != null ? player().isMpv() : PlayerSetting.getActivePlayer() == PlayerSetting.MPV;
     }
 
     private void bindPlaybackService() {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -6857,12 +6857,13 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         String key = getKeyText();
         String flag = selectedFlag.getFlag();
         String episodeUrl = selectedEpisode.getUrl();
+        int playerKernel = inlineHistoryPlayerKernel();
         stopInlinePlayerForReload();
         showInlineLoading();
         updateInlineDisplayPanel();
         detailTasks.submit(() -> {
             try {
-                Result result = SiteApi.playerContent(key, flag, episodeUrl);
+                Result result = SiteApi.playerContent(key, flag, episodeUrl, playerKernel);
                 runOnAliveUi(() -> {
                     if (!isInlinePlaybackRequestCurrent(generation, key, flag, episodeUrl)) return;
                     String resolvedUrl = result.getUrl() == null ? "" : result.getUrl().v();
@@ -6950,8 +6951,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         if (resumePosition == C.TIME_UNSET) resetInlineHistoryIfNearEnding();
         inlineStartPosition = resumePosition == C.TIME_UNSET ? getInlineResumePosition() : Math.max(0, resumePosition);
         inlineStartPositionApplied = false;
-        player().switchPlayer(PlayerSetting.getPlayer());
-        updateInlineHistoryPlayer();
+        player().preparePlayer(inlineHistoryPlayerKernel());
         setInlineSpeed(getInlinePlaybackSpeed());
         updateInlineButtons(false);
         Site site = getCurrentSite();
@@ -8226,6 +8226,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
                         useParse = result.shouldUseParse();
                         inlinePlayerSwitchLoading = false;
                         player().switchPlayer(playerType, result, getHistoryKey(), metadata, useParse, position, speed, repeat);
+                        rememberInlinePlayerKernel(playerType);
                     }
                     finishInlinePlayerSwitch();
                 });
@@ -8265,7 +8266,6 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     private void finishInlinePlayerSwitch() {
-        updateInlineHistoryPlayer();
         syncInlineHistory();
         binding.playerExternal.setText(player().getPlayerText());
         setInlineDecodeText(inlineDecodeText(true));
@@ -10477,10 +10477,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     }
 
     private void updateInlineHistoryProgress() {
-        if (history == null || service() == null || player() == null || player().isReleased() || !isOwner()) {
-            updateInlineHistoryPlayer();
-            return;
-        }
+        if (history == null || service() == null || player() == null || player().isReleased() || !isOwner()) return;
         updateInlineHistoryProgress(System.currentTimeMillis(), player().getPosition(), player().getDuration());
     }
 
@@ -10489,11 +10486,22 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         history.setCreateTime(time);
         if (position > 0) history.setPosition(position);
         if (duration > 0) history.setDuration(duration);
-        updateInlineHistoryPlayer();
     }
 
-    private void updateInlineHistoryPlayer() {
-        if (history != null && service() != null && player() != null && !player().isReleased()) history.setPlayer(player().getPlayerType());
+    /**
+     * 用户显式换内核后记住选定值。
+     * 记的是用户选的值而不是引擎状态：引擎会被播放失败后的自动回退改掉，
+     * 那不代表用户改了选择；例行的进度同步也一律不碰这个字段，
+     * 否则上一部剧遗留的会话内核会覆盖本剧记住的选择。
+     */
+    private void rememberInlinePlayerKernel(int type) {
+        if (history == null || !PlayerSetting.isPlayer(type)) return;
+        history.setPlayer(type);
+    }
+
+    /** 本剧记住的内核；没有记录时退回设置页的全局默认。 */
+    private int inlineHistoryPlayerKernel() {
+        return history == null ? PlayerSetting.getPlayer() : history.getPlayerOrDefault();
     }
 
     private void requestIntroSkipPlan() {
@@ -10543,7 +10551,6 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             updateInlineHistoryProgress(time, position, duration);
         } else {
             history.setCreateTime(time);
-            updateInlineHistoryPlayer();
         }
         if (canUpdateProgress) PlaybackEventCollector.get().onProgress(history, player());
         if (canUpdateProgress && history.canSave() && history.canSync()) syncInlineHistory();

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerOsdController.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerOsdController.java
@@ -438,9 +438,9 @@ public class PlayerOsdController {
         String audioText = summarizeAudio(audio, audioTrack, snapshot.audioDecoderName());
         String render = PlayerSetting.getRender() == PlayerSetting.RENDER_SURFACE ? "Surface" : "Texture";
         String tunnel = switchText(PlayerSetting.isTunnelingEnabled());
-        String performance = PlaybackPerformanceSetting.getProfileName();
+        String performance = PlaybackPerformanceSetting.getProfileName(player.getPlayerType());
         String passThrough = player.getAudioPassThroughText();
-        String preload = "预载" + switchText(PreloadSetting.isPreload());
+        String preload = "预载" + switchText(PreloadSetting.isPreload(player.getPlayerType()));
         String frameRateMatch = player.isExo() ? "帧率匹配 开" : "";
         String softTune = getSoftDecodeTuneText(player);
         String playerText = join(" / ", player.getPlayerText(), player.getDecodeText(), render, "隧道" + tunnel, "性能" + performance, frameRateMatch, preload, "直通" + passThrough, softTune, player.isExo() ? "兜底开" : "");

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -393,6 +393,7 @@ private int mAudioBackgroundRandomNonce;
     private boolean mNativePersonalDoubanLoading;
     private boolean mEpisodeGridMode = Setting.getTmdbEpisodeGridMode();
     private int playerKernelSwitchRequestId;
+    private int mPendingPlayerKernel = PlayerSetting.NONE;
     private boolean decodeSwitchRefreshing;
     private int deferredFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
     private int mEpisodeSpanCount;
@@ -1289,6 +1290,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
     @Override
     protected void onServiceConnected() {
         player().setDanmakuController(mBinding.exo.getDanmakuController());
+        applyPendingPlayerKernel();
         syncDesktopLyricsAudioContent();
         setPlayerKernel();
         setDecode();
@@ -1703,7 +1705,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
     }
 
     private void setPlayer() {
-        mBinding.control.action.player.setText(service() == null ? ResUtil.getStringArray(R.array.select_player)[PlayerSetting.getPlayer()] : player().getPlayerText());
+        mBinding.control.action.player.setText(service() == null ? ResUtil.getStringArray(R.array.select_player)[PlayerSetting.getActivePlayer()] : player().getPlayerText());
     }
 
     private void setupActionButtons() {
@@ -1872,6 +1874,50 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
 
     private void setPlayerKernel() {
         mBinding.control.action.player.setText(player().getPlayerText());
+    }
+
+    /**
+     * 起播前把内核切到本剧记住的选择，并返回该内核给取址用——取播放地址要按内核区分线路。
+     * 没有记录时 getPlayerOrDefault 会退回设置页的全局默认。
+     * 播放服务还没连上时先只记会话内核（取址在工作线程上读它），引擎由 onServiceConnected 补齐。
+     */
+    private int applyHistoryPlayerKernel() {
+        int kernel = mHistory == null ? PlayerSetting.getPlayer() : mHistory.getPlayerOrDefault();
+        PlayerSetting.putActivePlayer(kernel);
+        if (service() == null) {
+            mPendingPlayerKernel = kernel;
+            return kernel;
+        }
+        mPendingPlayerKernel = PlayerSetting.NONE;
+        player().preparePlayer(kernel);
+        setPlayerKernel();
+        setDecode();
+        return kernel;
+    }
+
+    /**
+     * 服务连上后补齐本页在等的内核。
+     * 服务可能是上一次播放留活下来的，它建 PlayerManager 时读到的还是上一部剧的内核，
+     * 所以本页在服务就绪前定下的选择要在这里落到引擎上；没有待办时不动引擎。
+     */
+    private void applyPendingPlayerKernel() {
+        int kernel = mPendingPlayerKernel;
+        mPendingPlayerKernel = PlayerSetting.NONE;
+        if (!PlayerSetting.isPlayer(kernel)) return;
+        player().preparePlayer(kernel);
+    }
+
+    /**
+     * 把用户刚选定的内核写回本剧历史并落盘。
+     * 只在用户显式换内核时调用，且用用户选的值而不是会话/引擎状态：
+     * 播放页可能重叠存在（上一部剧的 Activity 还没销毁），若挂在每次存历史上，
+     * 上一部剧的收尾存档会用别人的会话内核覆盖本剧记住的选择；
+     * 而引擎类型还会被播放失败后的自动回退改掉，也不代表用户改了选择。
+     */
+    private void rememberPlayerKernel(int type) {
+        if (mHistory == null || !PlayerSetting.isPlayer(type)) return;
+        mHistory.setPlayer(type);
+        syncHistory();
     }
 
     private void setScale(int scale) {
@@ -2293,7 +2339,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         clearLyrics();
         clearKaraokeState();
         if (shouldUseImmersiveAudio()) setAudioStageVisible(true);
-        mViewModel.playerContent(getKey(), playFlag, episode.getUrl());
+        mViewModel.playerContent(getKey(), playFlag, episode.getUrl(), applyHistoryPlayerKernel());
         mBinding.control.title.setSelected(true);
         updateHistory(episode);
         showProgress();
@@ -4373,6 +4419,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
                     player().switchPlayerManually(which);
                     setPlayer();
                     setDecode();
+                    rememberPlayerKernel(which);
                 }
             } else {
                 playerKernelSwitchRequestId++;
@@ -4431,6 +4478,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
             Notify.show(result != null && result.hasMsg() ? result.getMsg() : getString(R.string.error_play_url));
         } else {
             player().switchPlayer(type, result, getHistoryKey(), metadata, isUseParse(), position, speed, repeat);
+            rememberPlayerKernel(type);
         }
         setPlayerKernel();
         setDecode();

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
@@ -494,8 +494,8 @@ public class VideoActivityLayoutTest {
         assertTrue(label + " playback must update artwork before the new item starts", body.contains("applyPlaybackArtwork(episode);"));
         assertTrue(label + " playback must clear lyrics and karaoke state between episodes",
                 body.contains("clearLyrics();") && body.contains("clearKaraokeState();"));
-        assertTrue(label + " playback must request content with the resolved per-episode flag",
-                body.contains("mViewModel.playerContent(getKey(), playFlag, episode.getUrl());"));
+        assertTrue(label + " playback must request content with the resolved per-episode flag and the show's kernel",
+                body.contains("mViewModel.playerContent(getKey(), playFlag, episode.getUrl(), applyHistoryPlayerKernel());"));
     }
 
     @Test
@@ -820,11 +820,52 @@ public class VideoActivityLayoutTest {
         Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "player", "PlayerManager.java"));
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
         int method = source.indexOf("public void switchPlayer(int type, Result result");
-        int methodEnd = source.indexOf("private void switchPlayer(int type, boolean persist)", method);
+        int methodEnd = source.indexOf("private void switchPlayer(int type, boolean manual)", method);
         String methodBody = method >= 0 && methodEnd > method ? source.substring(method, methodEnd) : "";
 
         assertTrue(sourcePath + " is missing refreshed-result player switching", method >= 0);
         assertTrue("a user-selected refreshed core must stop instead of auto-falling back on its first failure", methodBody.contains("manualPlayerSwitchPending = true;"));
+    }
+
+    @Test
+    public void playerKernelSwitchStaysScopedToCurrentPlayback() throws Exception {
+        String player = new String(Files.readAllBytes(findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "player", "PlayerManager.java"))), StandardCharsets.UTF_8);
+        String leanback = new String(Files.readAllBytes(findLeanbackJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"))), StandardCharsets.UTF_8);
+        String mobile = new String(Files.readAllBytes(findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"))), StandardCharsets.UTF_8);
+        String tmdb = new String(Files.readAllBytes(findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"))), StandardCharsets.UTF_8);
+        String history = new String(Files.readAllBytes(findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "bean", "History.java"))), StandardCharsets.UTF_8);
+
+        assertFalse("switching cores inside the player must not rewrite the global default kernel", player.contains("PlayerSetting.putPlayer("));
+        assertTrue("the running kernel must be published as session state instead", player.contains("PlayerSetting.putActivePlayer("));
+        assertTrue("ending playback must drop the session kernel so the global default applies again", player.contains("PlayerSetting.clearActivePlayer();"));
+
+        assertTrue("the per-show kernel must be persisted, not a transient field", history.contains("@SerializedName(\"player\")") && !history.contains("private transient int player"));
+
+        for (String source : new String[]{leanback, mobile}) {
+            assertTrue("playback must restore the show's remembered kernel before resolving the play url",
+                    source.contains("player().preparePlayer(kernel);"));
+            assertTrue("the remembered kernel must fall back to the global default", source.contains("mHistory.getPlayerOrDefault()"));
+            assertTrue("the show's history must remember the user's selection, not an engine/session state",
+                    source.contains("private void rememberPlayerKernel(int type)") && source.contains("mHistory.setPlayer(type);"));
+            // 播放页会重叠存在：上一部剧的收尾存档若也写内核，就会用别人的会话内核
+            // 覆盖本剧记住的选择，历史回归点。
+            assertFalse("routine history saves must not rewrite the show's kernel",
+                    source.contains("mHistory.setPlayer(PlayerSetting.getActivePlayer());"));
+            // 服务可能是上一次播放留活的，它建 PlayerManager 时读到的是上一部剧的内核，
+            // 所以服务就绪前定下的选择必须在连上后补落到引擎。
+            assertTrue("a kernel chosen before the service was ready must be applied once it connects",
+                    source.contains("mPendingPlayerKernel = kernel;")
+                            && source.contains("private void applyPendingPlayerKernel()")
+                            && methodBody(source, "protected void onServiceConnected()", "\n    }").contains("applyPendingPlayerKernel();"));
+        }
+        assertTrue("inline TMDB playback must resolve the play url with the show's kernel",
+                tmdb.contains("SiteApi.playerContent(key, flag, episodeUrl, playerKernel)"));
+        assertTrue("inline TMDB playback must restore the show's remembered kernel",
+                tmdb.contains("player().preparePlayer(inlineHistoryPlayerKernel());"));
+        assertTrue("inline TMDB playback must remember only the user's selection",
+                tmdb.contains("private void rememberInlinePlayerKernel(int type)") && tmdb.contains("history.setPlayer(type);"));
+        assertFalse("inline progress sync must not rewrite the show's kernel",
+                tmdb.contains("history.setPlayer(PlayerSetting.getActivePlayer());"));
     }
 
     @Test

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapterTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/helper/TmdbUIAdapterTest.java
@@ -624,7 +624,7 @@ public class TmdbUIAdapterTest {
         int firstPrepare = source.indexOf("prepareFastTmdbPlaybackHistory(item, flag, episode);", fastMethod);
         int prepare = source.indexOf("prepareFastTmdbPlaybackHistory(item, flag, episode);", startPending);
         int firstHistoryLookup = source.indexOf("History.findPlayback", fastMethod);
-        int player = source.indexOf("mViewModel.playerContent(getKey(), flag.getFlag(), episode.getUrl());", prepare);
+        int player = source.indexOf("mViewModel.playerContent(getKey(), flag.getFlag(), episode.getUrl(), applyHistoryPlayerKernel());", prepare);
         int fullBind = source.indexOf("applyFastTmdbPlaybackFullDetailNextFrame(item);", player);
         int canApply = source.indexOf("private boolean canApplyPlayerResult()");
         int fastCanApply = source.indexOf("mFastPlaybackFlag != null && mFastPlaybackEpisode != null && mHistory != null", canApply);
@@ -712,7 +712,7 @@ public class TmdbUIAdapterTest {
         String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
         int startPending = source.indexOf("private void startPendingFastTmdbPlayback()");
         int prepareItem = source.indexOf("prepareFastTmdbPlaybackItem(item);", startPending);
-        int player = source.indexOf("mViewModel.playerContent(getKey(), flag.getFlag(), episode.getUrl());", prepareItem);
+        int player = source.indexOf("mViewModel.playerContent(getKey(), flag.getFlag(), episode.getUrl(), applyHistoryPlayerKernel());", prepareItem);
         int postHydrate = source.indexOf("mBinding.getRoot().post(() -> hydrateFastTmdbPlaybackDetail(item));", player);
         int initialHydrate = source.indexOf("hydrateFastTmdbPlaybackDetail(item);", source.indexOf("private boolean tryStartFastTmdbPlayback(Vod item)"));
         int hydrate = source.indexOf("private void hydrateFastTmdbPlaybackDetail(Vod item)");


### PR DESCRIPTION
问题：在播放器内换内核会写全局默认，且历史记录记不住本剧的选择。
根因有两处：PlayerManager 的三条切内核路径都在调 PlayerSetting.putPlayer （那是设置页的全局默认值）；History.player 早前被改成 transient，Room 不再建列， 「按剧集记住」的能力一并丢失。

- 新增会话内核 PlayerSetting.getActivePlayer/putActivePlayer/clearActivePlayer（仅内存）。 运行期所有「现在用的是哪个内核」的判断改读它：取播放地址、Source.fetch、 IJK 自动调优、LUT 可用性、MPV 判定、OSD 面板；getPlayer() 只剩设置页默认值与兜底。 播放器释放时清空，下次没有会话就回到全局默认。
- History.player 恢复为真实列（默认 -1 表示无偏好），数据库 43→44 加 MIGRATION_43_44 按需加列。起播前先按本剧内核建引擎再取址（取址要按内核区分线路，顺序不能反）， 内核作为参数显式传给 SiteViewModel.playerContent。
- 内核只在用户显式选择后写回历史，且写用户选的值：例行存历史一律不碰该字段， 否则播放页重叠存在时，上一部剧的收尾存档会用别人的会话内核覆盖本剧的选择； 引擎类型也会被播放失败后的自动回退改掉，不代表用户改了选择。
- switchEngine 的 persist 参数改为 chosen，区分「用户选定的内核」与「失败回退换的引擎」， 回退只换引擎不动选择。
- 服务未就绪时先记下待应用的内核，连上后由 applyPendingPlayerKernel 落到引擎， 避免复用上一次留活的服务时引擎仍是上一部剧的内核。

测试：新增 playerKernelSwitchStaysScopedToCurrentPlayback 锁住「不写全局、退出清会话、 按剧集持久化、例行存档不改内核、服务就绪后补齐」这几条；两个 flavor 编译与单测通过
（余下 5 个失败为改动前既有：MpvPreloadControllerTest 2 项、
MultiThreadProxyPlayerUiSourceTest 1 项、FfmpegVc1SupportTest 2 项，已在干净树复现确认）。 已安装到模拟器 5558 并确认启动无崩溃、History 表 player 列迁移到位；
「切走再切回仍用本剧内核」这条端到端路径尚待人工复测。