### PR TITLE
修复短剧竖屏手势误触：整屏上下滑切集，亮度音量改为长按后再滑

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -9286,6 +9286,9 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.playerPanel.requestFocus();
         Util.toggleFullscreen(this, true);
         setInlineFullscreenOrientation();
+        // 手动点全屏按钮不走 applyInlineShortDramaMode（那条只在 STATE_READY 触发），
+        // 这里也要按新形态重算手势，否则短剧进全屏后仍是长视频那套轴向。
+        syncInlineShortDramaGesture();
         scheduleMobileInlineSideControlMarginUpdate();
     }
 
@@ -9307,15 +9310,30 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             return;
         }
         inlineShortDramaMode = true;
+        syncInlineShortDramaGesture();
         setInlineFullscreenOrientation();
         setInlineShortDramaVideoFrame(!shouldUseShortDramaPortrait());
         setInlinePreviewScale(SHORT_DRAMA_SCALE);
         hideInlineControls();
     }
 
+    /**
+     * 手势轴向跟着呈现形态走：短剧内嵌全屏时整屏上下滑切集、长按后上下滑调亮度/音量。
+     * <p>
+     * 判据不用 {@code inlineShortDramaMode}：切集时 startInlinePlayback 会先
+     * resetInlineShortDramaMode 再等 STATE_READY 重新 apply，那段缓冲窗口里形态并没变，
+     * 手势却会退回长视频那套，连滑两集时第二次落在侧边就被当成调亮度。
+     * shouldUseInlineShortDramaMode 在尺寸未知时返回 true，正好覆盖这段窗口；
+     * 横屏短剧不走竖屏铺满形态，也就不换手势。
+     */
+    private void syncInlineShortDramaGesture() {
+        if (inlineGestureDetector != null) inlineGestureDetector.setShortDrama(inlineFullscreen && shouldUseInlineShortDramaMode());
+    }
+
     private void resetInlineShortDramaMode() {
         boolean restoreScale = inlineShortDramaMode;
         inlineShortDramaMode = false;
+        syncInlineShortDramaGesture();
         setInlineShortDramaVideoFrame(false);
         if (restoreScale && inlineStarted) setInlineScale(getInlineScale());
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerGesture.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/PlayerGesture.java
@@ -35,9 +35,13 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
     private boolean changeTime;
     private boolean multiTouch;
     private boolean animating;
+    private boolean shortDrama;
     private boolean touch;
     private boolean lock;
     private float bright;
+    private float anchorY = Float.NaN;
+    private float downX;
+    private float downY;
     private float volume;
     private float scale;
     private long time;
@@ -59,12 +63,49 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
 
     public boolean onTouchEvent(MotionEvent e) {
         int action = e.getActionMasked();
+        boolean end = action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL;
         if (action == MotionEvent.ACTION_DOWN) multiTouch = false;
+        // 起点在这里记而不是 onDown：onDown 在边缘/缩放/锁定时会提前返回，
+        // 而 changeScale 会在 onScaleEnd 之后 500ms 才解除，那段窗口里按下的手势
+        // 拿不到自己的起点，长按转调节时会拿上一次的起点算位移，一按就跳。
+        if (action == MotionEvent.ACTION_DOWN) {
+            downX = e.getX();
+            downY = e.getY();
+        }
         if (action == MotionEvent.ACTION_POINTER_DOWN) multiTouch = true;
-        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) listener.onTouchEnd();
-        if (changeSpeed && action == MotionEvent.ACTION_UP) listener.onSpeedEnd();
+        if (end) listener.onTouchEnd();
+        // 短剧的亮度/音量在长按之后才生效，此时 GestureDetector 已不再回调 onScroll，
+        // 只能在这里自行处理移动事件，详见 handleAdjust。用实时指数判断而不是 multiTouch：
+        // 后者在 ACTION_POINTER_UP 时不会复位，会把抬起一根手指后的单指调节一起挡掉。
+        if (shortDrama && action == MotionEvent.ACTION_MOVE && e.getPointerCount() == 1 && !lock && !changeScale) handleAdjust(e);
+        // 被父容器拦截或来电时只收到 CANCEL：倍速同样要交还，否则会卡在长按后的速率。
+        if (changeSpeed && end) listener.onSpeedEnd();
+        // seek 只在正常抬手时提交：CANCEL 属于手势被打断，维持原位置更符合预期。
         if (changeTime && action == MotionEvent.ACTION_UP) listener.onSeekEnd(time);
-        return e.getPointerCount() == 2 ? scaleDetector.onTouchEvent(e) : detector.onTouchEvent(e);
+        boolean handled = e.getPointerCount() == 2 ? scaleDetector.onTouchEvent(e) : detector.onTouchEvent(e);
+        // 必须等 detector 处理完再清：onFling 是 detector 在 UP 时回调的，它要读
+        // changeSpeed/changeBright/changeVolume 才能判断这次抬手是否该切集。
+        if (end) clearGesture();
+        return handled;
+    }
+
+    /**
+     * 一次手势结束就把功能标记清干净。
+     * <p>
+     * {@link #reset()} 挂在 onDown 上，而 onDown 在边缘/缩放/锁定时会提前返回，
+     * 于是上一次手势的 changeBright/anchorY 可能活到下一次手势——短剧的亮度/音量
+     * 由 onTouchEvent 直接驱动，不再有 onScroll 的兜底，残留状态会直接造成
+     * 「没长按就跳亮度」。所以收尾统一在这里做，不依赖下一次 onDown 是否被接受。
+     */
+    private void clearGesture() {
+        changeTime = false;
+        changeSpeed = false;
+        changeBright = false;
+        changeVolume = false;
+        anchorY = Float.NaN;
+        // 不动 touch：它表示「本次手势还没选定功能」，是就绪态而非残留动作。
+        // 在这里清成 false 会让缩放后 500ms 内（changeScale 还没解除时）起手的那一次
+        // 拖动选不到任何功能，白滑一次。它由 reset() 置真、checkFunc 置假，无需插手。
     }
 
     public void resetScale() {
@@ -78,6 +119,17 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
 
     public void setLock(boolean lock) {
         this.lock = lock;
+    }
+
+    /**
+     * 短剧竖屏形态下换用另一套手势轴向，参考红果短剧、抖音等主流竖屏播放器：
+     * 上下滑切上下集（全屏可用），亮度/音量改为长按后再上下滑，左半亮度右半音量。
+     * <p>
+     * 原来「中间竖滑切集 + 左右 1/4 竖滑调亮度音量」在铺满屏幕的竖屏短剧里极易误触
+     * （用户反馈）：想切集却滑到了边缘，调亮度又常常切了集。
+     */
+    public void setShortDrama(boolean shortDrama) {
+        this.shortDrama = shortDrama;
     }
 
     private boolean isMultiple(MotionEvent e) {
@@ -125,6 +177,7 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
     private void reset() {
         time = 0;
         touch = true;
+        anchorY = Float.NaN;
         changeTime = false;
         changeSpeed = false;
         changeBright = false;
@@ -159,6 +212,41 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
         return true;
     }
 
+    /**
+     * 短剧的「长按后上下滑调亮度/音量」。
+     * <p>
+     * 不能挂在 {@link #onScroll} 上：GestureDetector 触发长按后会把后续 ACTION_MOVE
+     * 全部吞掉（mInLongPress 分支直接 break），onScroll 再也不会回调，所以这条手势
+     * 必须由 onTouchEvent 自己驱动。
+     */
+    private void handleAdjust(MotionEvent e) {
+        // 只认「本次手势自己长按出来」的调节，避免上一次手势的残留标记把亮度带跑。
+        if (!changeSpeed && Float.isNaN(anchorY)) return;
+        if (changeSpeed) {
+            float dx = e.getX() - downX;
+            float dy = e.getY() - downY;
+            if (Math.abs(dy) <= Math.abs(dx) || Math.abs(dy) < ResUtil.dp2px(20)) return;
+            startAdjust(e);
+        }
+        // 以「长按转调节」的那一刻为基准，避免把长按期间的位移一次性算进亮度/音量。
+        float deltaY = anchorY - e.getY();
+        if (changeBright) setBright(deltaY);
+        if (changeVolume) setVolume(deltaY);
+    }
+
+    /**
+     * 长按倍速中途转为亮度/音量调节：先把倍速交还，再以当前触点为新基准。
+     */
+    private void startAdjust(MotionEvent e) {
+        listener.onSpeedEnd();
+        changeSpeed = false;
+        touch = false;
+        anchorY = e.getY();
+        bright = Util.getBrightness(activity);
+        volume = manager.getStreamVolume(AudioManager.STREAM_MUSIC);
+        checkSide(e);
+    }
+
     @Override
     public boolean onDoubleTap(@NonNull MotionEvent e) {
         if (isMultiple(e) || isEdge(e) || changeScale) return true;
@@ -175,15 +263,21 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
 
     @Override
     public boolean onFling(MotionEvent e1, @NonNull MotionEvent e2, float velocityX, float velocityY) {
-        if (isMultiple(e1) || isEdge(e1) || isSide(e1) || changeScale || lock || animating) return true;
+        // 短剧上下滑切集不再受左右 1/4 的亮度/音量分区限制（那两块已改为长按触发），
+        // 但 isEdge 的 24dp 边框仍然保留：那里要让给系统的返回/通知栏手势。
+        if (isMultiple(e1) || isEdge(e1) || (!shortDrama && isSide(e1)) || changeScale || lock || animating) return true;
+        // 这次手势已经用于调亮度/音量或倍速，抬手不应再被当成切集。
+        if (changeSpeed || changeBright || changeVolume) return true;
         checkFunc(e1, e2);
         return true;
     }
 
     private void checkFunc(float distanceX, float distanceY, MotionEvent e2) {
         if ((float) Math.sqrt(distanceX * distanceX + distanceY * distanceY) < ResUtil.dp2px(20)) return;
+        // 短剧的上下滑整屏留给切集（onFling），亮度/音量改由 startAdjust（长按后再滑）接管，
+        // 所以这里只保留横滑拖进度，不再按左右 1/4 分派亮度/音量。
         if (distanceX >= distanceY) changeTime = true;
-        else if (isSide(e2)) checkSide(e2);
+        else if (!shortDrama && isSide(e2)) checkSide(e2);
         touch = false;
     }
 
@@ -191,10 +285,13 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
         float dx = e2.getX() - e1.getX();
         float dy = e2.getY() - e1.getY();
         double angle = Math.toDegrees(Math.atan2(Math.abs(dy), Math.abs(dx)));
+        // 短剧的切集动画沿用同一套竖向回弹，但不跟随直播的「反转」开关：
+        // 竖屏短剧里上滑=下一集是抖音/红果的既定语义，反转会让用户完全迷失。
+        boolean invert = !shortDrama && LiveSetting.isInvert();
         if (angle > 70 && e1.getY() - e2.getY() > DISTANCE) {
-            videoView.animate().translationYBy(ResUtil.dp2px(LiveSetting.isInvert() ? 24 : -24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingUp).withEndAction(() -> animating = false).start()).start();
+            videoView.animate().translationYBy(ResUtil.dp2px(invert ? 24 : -24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingUp).withEndAction(() -> animating = false).start()).start();
         } else if (angle > 70 && e2.getY() - e1.getY() > DISTANCE) {
-            videoView.animate().translationYBy(ResUtil.dp2px(LiveSetting.isInvert() ? -24 : 24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingDown).withEndAction(() -> animating = false).start()).start();
+            videoView.animate().translationYBy(ResUtil.dp2px(invert ? -24 : 24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingDown).withEndAction(() -> animating = false).start()).start();
         }
     }
 
@@ -217,6 +314,7 @@ public class PlayerGesture extends GestureDetector.SimpleOnGestureListener imple
     private void setVolume(float deltaY) {
         int height = Math.max(videoView.getMeasuredHeight(), 1);
         int maxVolume = manager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+        if (maxVolume <= 0) return;
         float deltaV = deltaY * 2.0f / height * maxVolume;
         float index = volume + deltaV;
         if (index > maxVolume) index = maxVolume;

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -1343,6 +1343,9 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         // 否则长视频会卡在竖屏全屏且无法旋转。仍是短剧则保持形态，避免无谓的进出全屏抖动。
         if (shortDramaSession && !isShortDramaSource()) exitFullscreen();
         shortDramaSession = false;
+        // 形态可能仍是短剧全屏（新条目也是短剧时上面不退出），所以按当前形态重算而不是一律清掉，
+        // 否则新条目在到达 STATE_READY 之前会用长视频那套手势，侧边竖滑又变成调亮度。
+        syncShortDramaGesture();
         setOrient();
         checkId();
     }
@@ -4482,6 +4485,9 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         setSizeText();
         setRotate(current.isPortrait());
         mKeyDown.resetScale();
+        // 短剧会话退出全屏后再双击/点全屏按钮进来不走 enterShortDramaFullscreen，
+        // 这里也要按新形态重算，否则回到全屏时手势还是长视频那套轴向。
+        syncShortDramaGesture();
         App.post(mR3, 2000);
         hideControl();
         logVideoFrame("enterFullscreen after");
@@ -4516,6 +4522,8 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
         mBinding.video.setLayoutParams(mFrameParams);
         restoreEmbeddedVideoLayoutAfterFullscreen();
         mKeyDown.resetScale();
+        // 退出全屏就交还短剧手势：内嵌小窗上竖滑要留给详情页滚动，不能再切集。
+        syncShortDramaGesture();
         App.post(mR3, 2000);
         setRotate(false);
         hideControl();
@@ -8154,9 +8162,21 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
             setRequestedOrientation(isPort() ? ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT : ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
             mKeyDown.resetScale();
         }
+        syncShortDramaGesture();
         setShortDramaScale();
         hideControl();
         ViewCompat.requestApplyInsets(mBinding.getRoot());
+    }
+
+    /**
+     * 手势轴向跟着呈现形态走：短剧竖屏全屏时整屏上下滑切集、长按后上下滑调亮度/音量。
+     * <p>
+     * 必须由「当前是否处于短剧全屏」推导，不能在进入时置一次了事：横屏短剧允许自由旋转，
+     * 转回竖屏会走 exitFullscreen 退回内嵌小窗，此时若手势仍是短剧那套，在详情页上
+     * 竖滑就会误切集。同理换到另一部短剧时形态保持不变，标记也不该被清掉。
+     */
+    private void syncShortDramaGesture() {
+        if (mKeyDown != null) mKeyDown.setShortDrama(isFullscreen() && isShortDramaSession());
     }
 
     private void setShortDramaScale() {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/custom/CustomKeyDown.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/custom/CustomKeyDown.java
@@ -36,10 +36,14 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
     private boolean changeTime;
     private boolean multiTouch;
     private boolean animating;
+    private boolean shortDrama;
     private boolean touch;
     private boolean lock;
     private float bright;
     private float currentBright;
+    private float anchorY = Float.NaN;
+    private float downX;
+    private float downY;
     private float brightLimit = BrightnessPolicy.NO_LIMIT;
     private float volume;
     private float scale;
@@ -65,13 +69,51 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
         int action = e.getActionMasked();
         boolean end = action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL;
         if (action == MotionEvent.ACTION_DOWN) multiTouch = false;
+        // 起点在这里记而不是 onDown：onDown 在边缘/缩放/锁定时会提前返回，
+        // 而 changeScale 会在 onScaleEnd 之后 500ms 才解除，那段窗口里按下的手势
+        // 拿不到自己的起点，长按转调节时会拿上一次的起点算位移，一按就跳。
+        if (action == MotionEvent.ACTION_DOWN) {
+            downX = e.getX();
+            downY = e.getY();
+        }
         if (action == MotionEvent.ACTION_POINTER_DOWN) multiTouch = true;
-        if (action == MotionEvent.ACTION_UP) listener.onTouchEnd();
+        // 被父容器拦截或来电时只收到 CANCEL：HUD 与倍速同样要收尾，
+        // 否则 widget 会一直盖在画面上、倍速卡在长按后的速率。
+        if (end) listener.onTouchEnd();
+        // 短剧的亮度/音量在长按之后才生效，此时 GestureDetector 已不再回调 onScroll，
+        // 只能在这里自行处理移动事件，详见 handleAdjust。用实时指数判断而不是 multiTouch：
+        // 后者在 ACTION_POINTER_UP 时不会复位，会把抬起一根手指后的单指调节一起挡掉。
+        if (shortDrama && action == MotionEvent.ACTION_MOVE && e.getPointerCount() == 1 && !lock && !changeScale) handleAdjust(e);
         // 手势被父容器拦截或来电时只收到 CANCEL，同样要落盘，否则窗口已改而记忆值未更新
         if (changeBright && end) PlayerSetting.putBrightness(currentBright);
-        if (changeSpeed && action == MotionEvent.ACTION_UP) listener.onSpeedEnd();
+        if (changeSpeed && end) listener.onSpeedEnd();
+        // seek 只在正常抬手时提交：CANCEL 属于手势被打断，维持原位置更符合预期。
         if (changeTime && action == MotionEvent.ACTION_UP) listener.onSeekEnd(time);
-        return e.getPointerCount() == 2 ? scaleDetector.onTouchEvent(e) : detector.onTouchEvent(e);
+        boolean handled = e.getPointerCount() == 2 ? scaleDetector.onTouchEvent(e) : detector.onTouchEvent(e);
+        // 必须等 detector 处理完再清：onFling 是 detector 在 UP 时回调的，它要读
+        // changeSpeed/changeBright/changeVolume 才能判断这次抬手是否该切集。
+        // 提前清掉会让「调完亮度松手」被当成切集手势。
+        if (end) clearGesture();
+        return handled;
+    }
+
+    /**
+     * 一次手势结束就把功能标记清干净。
+     * <p>
+     * {@link #reset()} 挂在 onDown 上，而 onDown 在边缘/缩放/锁定时会提前返回，
+     * 于是上一次手势的 changeBright/anchorY 可能活到下一次手势——短剧的亮度/音量
+     * 由 onTouchEvent 直接驱动，不再有 onScroll 的兜底，残留状态会直接造成
+     * 「没长按就跳亮度」。所以收尾统一在这里做，不依赖下一次 onDown 是否被接受。
+     */
+    private void clearGesture() {
+        changeTime = false;
+        changeSpeed = false;
+        changeBright = false;
+        changeVolume = false;
+        anchorY = Float.NaN;
+        // 不动 touch：它表示「本次手势还没选定功能」，是就绪态而非残留动作。
+        // 在这里清成 false 会让缩放后 500ms 内（changeScale 还没解除时）起手的那一次
+        // 拖动选不到任何功能，白滑一次。它由 reset() 置真、checkFunc 置假，无需插手。
     }
 
     private void applyBrightness() {
@@ -119,6 +161,17 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
 
     public void setLock(boolean lock) {
         this.lock = lock;
+    }
+
+    /**
+     * 短剧竖屏形态下换用另一套手势轴向，参考红果短剧、抖音等主流竖屏播放器：
+     * 上下滑切上下集（全屏可用），亮度/音量改为长按后再上下滑，左半亮度右半音量。
+     * <p>
+     * 原来「中间竖滑切集 + 左右 1/4 竖滑调亮度音量」在铺满屏幕的竖屏短剧里极易误触
+     * （用户反馈）：想切集却滑到了边缘，调亮度又常常切了集。
+     */
+    public void setShortDrama(boolean shortDrama) {
+        this.shortDrama = shortDrama;
     }
 
     public float getScale() {
@@ -170,6 +223,7 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
     private void reset() {
         time = 0;
         touch = true;
+        anchorY = Float.NaN;
         changeTime = false;
         changeSpeed = false;
         changeBright = false;
@@ -208,6 +262,43 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
         return true;
     }
 
+    /**
+     * 短剧的「长按后上下滑调亮度/音量」。
+     * <p>
+     * 不能挂在 {@link #onScroll} 上：GestureDetector 触发长按后会把后续 ACTION_MOVE
+     * 全部吞掉（mInLongPress 分支直接 break），onScroll 再也不会回调，所以这条手势
+     * 必须由 onTouchEvent 自己驱动。
+     */
+    private void handleAdjust(MotionEvent e) {
+        // 只认「本次手势自己长按出来」的调节，避免上一次手势的残留标记把亮度带跑。
+        if (!changeSpeed && Float.isNaN(anchorY)) return;
+        if (changeSpeed) {
+            float dx = e.getX() - downX;
+            float dy = e.getY() - downY;
+            if (Math.abs(dy) <= Math.abs(dx) || Math.abs(dy) < ResUtil.dp2px(20)) return;
+            startAdjust(e);
+        }
+        // 以「长按转调节」的那一刻为基准，避免把长按期间的位移一次性算进亮度/音量。
+        float deltaY = anchorY - e.getY();
+        if (changeBright) setBright(deltaY);
+        if (changeVolume) setVolume(deltaY);
+    }
+
+    /**
+     * 长按倍速中途转为亮度/音量调节：先把倍速交还，再以当前触点为新基准。
+     */
+    private void startAdjust(MotionEvent e) {
+        listener.onSpeedEnd();
+        changeSpeed = false;
+        touch = false;
+        anchorY = e.getY();
+        float saved = PlayerSetting.getBrightness();
+        bright = saved >= 0 ? saved : Util.getBrightness(activity);
+        currentBright = bright;
+        volume = manager.getStreamVolume(AudioManager.STREAM_MUSIC);
+        checkSide(e);
+    }
+
     @Override
     public boolean onDoubleTap(@NonNull MotionEvent e) {
         if (isMultiple(e) || isEdge(e) || changeScale) return true;
@@ -224,15 +315,21 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
 
     @Override
     public boolean onFling(MotionEvent e1, @NonNull MotionEvent e2, float velocityX, float velocityY) {
-        if (isMultiple(e1) || isEdge(e1) || isSide(e1) || changeScale || lock || animating) return true;
+        // 短剧上下滑切集不再受左右 1/4 的亮度/音量分区限制（那两块已改为长按触发），
+        // 但 isEdge 的 24dp 边框仍然保留：那里要让给系统的返回/通知栏手势。
+        if (isMultiple(e1) || isEdge(e1) || (!shortDrama && isSide(e1)) || changeScale || lock || animating) return true;
+        // 这次手势已经用于调亮度/音量或倍速，抬手不应再被当成切集。
+        if (changeSpeed || changeBright || changeVolume) return true;
         checkFunc(e1, e2);
         return true;
     }
 
     private void checkFunc(float distanceX, float distanceY, MotionEvent e2) {
         if ((float) Math.sqrt(distanceX * distanceX + distanceY * distanceY) < ResUtil.dp2px(20)) return;
+        // 短剧的上下滑整屏留给切集（onFling），亮度/音量改由 startAdjust（长按后再滑）接管，
+        // 所以这里只保留横滑拖进度，不再按左右 1/4 分派亮度/音量。
         if (distanceX >= distanceY) changeTime = true;
-        else if (isSide(e2)) checkSide(e2);
+        else if (!shortDrama && isSide(e2)) checkSide(e2);
         touch = false;
     }
 
@@ -240,10 +337,13 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
         float dx = e2.getX() - e1.getX();
         float dy = e2.getY() - e1.getY();
         double angle = Math.toDegrees(Math.atan2(Math.abs(dy), Math.abs(dx)));
+        // 短剧的切集动画沿用同一套竖向回弹，但不跟随直播的「反转」开关：
+        // 竖屏短剧里上滑=下一集是抖音/红果的既定语义，反转会让用户完全迷失。
+        boolean invert = !shortDrama && LiveSetting.isInvert();
         if (angle > 70 && e1.getY() - e2.getY() > DISTANCE) {
-            videoView.animate().translationYBy(ResUtil.dp2px(LiveSetting.isInvert() ? 24 : -24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingUp).withEndAction(() -> animating = false).start()).start();
+            videoView.animate().translationYBy(ResUtil.dp2px(invert ? 24 : -24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingUp).withEndAction(() -> animating = false).start()).start();
         } else if (angle > 70 && e2.getY() - e1.getY() > DISTANCE) {
-            videoView.animate().translationYBy(ResUtil.dp2px(LiveSetting.isInvert() ? -24 : 24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingDown).withEndAction(() -> animating = false).start()).start();
+            videoView.animate().translationYBy(ResUtil.dp2px(invert ? -24 : 24)).setDuration(150).withStartAction(() -> animating = true).withEndAction(() -> videoView.animate().translationY(0).setDuration(100).withStartAction(listener::onFlingDown).withEndAction(() -> animating = false).start()).start();
         }
     }
 
@@ -265,8 +365,9 @@ public class CustomKeyDown extends GestureDetector.SimpleOnGestureListener imple
     }
 
     private void setVolume(float deltaY) {
-        int height = videoView.getMeasuredHeight();
+        int height = Math.max(videoView.getMeasuredHeight(), 1);
         int maxVolume = manager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+        if (maxVolume <= 0) return;
         float deltaV = deltaY * 2.0f / height * maxVolume;
         float index = volume + deltaV;
         if (index > maxVolume) index = maxVolume;

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/VideoActivityLayoutTest.java
@@ -951,6 +951,97 @@ public class VideoActivityLayoutTest {
     }
 
     @Test
+    public void mobileShortDramaGesturesSwapAxesToAvoidMisfires() throws Exception {
+        // 用户反馈：竖屏短剧铺满屏幕，左右 1/4 竖滑调亮度/音量与中间竖滑切集互相误触。
+        // 短剧形态改为「整屏上下滑切集 + 长按后上下滑调亮度/音量」，两个手势类同步。
+        List<Path> gestureFiles = Arrays.asList(
+                findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "custom", "CustomKeyDown.java")),
+                findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "custom", "PlayerGesture.java"))
+        );
+
+        for (Path gestureFile : gestureFiles) {
+            String source = new String(Files.readAllBytes(gestureFile), StandardCharsets.UTF_8);
+            assertTrue(gestureFile + " must expose the short drama gesture mode", source.contains("public void setShortDrama(boolean shortDrama)"));
+            // 上下滑切集不再受左右 1/4 亮度/音量分区限制。
+            assertTrue(gestureFile + " must let short drama flings cover the side quarters",
+                    source.contains("(!shortDrama && isSide(e1))"));
+            // 亮度/音量不再由滑动起点的左右 1/4 触发。
+            assertTrue(gestureFile + " must stop routing short drama scrolls to brightness/volume",
+                    source.contains("else if (!shortDrama && isSide(e2)) checkSide(e2);"));
+            // 长按后 GestureDetector 不再回调 onScroll，调节必须由 onTouchEvent 自己驱动。
+            assertTrue(gestureFile + " must drive the long-press adjust from onTouchEvent",
+                    source.contains("action == MotionEvent.ACTION_MOVE") && source.contains("handleAdjust(e);"));
+            assertTrue(gestureFile + " must hand back the speed-up before adjusting", source.contains("private void startAdjust(MotionEvent e)"));
+            // 起点必须在 ACTION_DOWN 时记：onDown 会在边缘/缩放/锁定时提前返回，
+            // 拿上一次手势的起点算位移会让长按转调节一按就跳。
+            assertTrue(gestureFile + " must capture the down point from the raw stream",
+                    source.contains("if (action == MotionEvent.ACTION_DOWN) {") && source.contains("downY = e.getY();"));
+            assertFalse(gestureFile + " must not rely on onDown for the down point",
+                    methodBody(source, "public boolean onDown(@NonNull MotionEvent e)", "\n    }").contains("downY = e.getY();"));
+            // 切集方向在短剧下固定，不跟随直播的「反转」开关。
+            assertTrue(gestureFile + " must pin the short drama fling direction",
+                    source.contains("boolean invert = !shortDrama && LiveSetting.isInvert();"));
+
+            // onDown 在边缘/缩放/锁定时提前返回不走 reset()，所以每次抬手都要主动清标记，
+            // 否则上一次的 changeBright + anchorY 会让下一次手势没长按就跳亮度。
+            assertTrue(gestureFile + " must clear gesture flags when the stream ends",
+                    source.contains("private void clearGesture()") && source.contains("if (end) clearGesture();"));
+            assertTrue(gestureFile + " must reset the adjust anchor on cleanup",
+                    methodBody(source, "private void clearGesture()", "\n    }").contains("anchorY = Float.NaN;"));
+            // 没有本次手势自己建立的基准就不许调节，避免 NaN 基准算出静音/跟随系统亮度。
+            assertTrue(gestureFile + " must require an anchor established by this gesture",
+                    source.contains("if (!changeSpeed && Float.isNaN(anchorY)) return;"));
+            // CANCEL（被父容器拦截/来电）同样要交还倍速，否则播放卡在长按后的速率。
+            assertTrue(gestureFile + " must hand back the speed boost on cancel too", source.contains("if (changeSpeed && end) listener.onSpeedEnd();"));
+            // ACTION_POINTER_UP 不会复位 multiTouch，用实时指数判断才不会永久挡掉单指调节。
+            assertTrue(gestureFile + " must gate the adjust on the live pointer count",
+                    source.contains("action == MotionEvent.ACTION_MOVE && e.getPointerCount() == 1"));
+            // 未测量的播放视图会让 deltaY/height 变成 Infinity/NaN，音量瞬间拉满或静音。
+            assertTrue(gestureFile + " must floor the view height before dividing",
+                    methodBody(source, "private void setVolume(float deltaY)", "\n    }").contains("Math.max(videoView.getMeasuredHeight(), 1)"));
+            assertTrue(gestureFile + " must skip volume when the stream has no range",
+                    source.contains("if (maxVolume <= 0) return;"));
+        }
+
+        // 手势轴向必须由「当前是否处于短剧全屏」推导：退出全屏回到内嵌小窗后若仍是短剧那套，
+        // 详情页上竖滑就会误切集；换到另一部短剧时形态不变，标记也不该被清掉。
+        String video = new String(Files.readAllBytes(findMobileJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "VideoActivity.java"))), StandardCharsets.UTF_8);
+        assertTrue("the gesture mode must be derived from the current presentation",
+                video.contains("mKeyDown.setShortDrama(isFullscreen() && isShortDramaSession());"));
+        assertFalse("no call site may pin the gesture mode to a literal",
+                video.contains("mKeyDown.setShortDrama(true)") || video.contains("mKeyDown.setShortDrama(false)"));
+        for (String host : Arrays.asList("private void enterShortDramaFullscreen()", "private void enterFullscreen()", "private void exitFullscreen()", "protected void onNewIntent(Intent intent)")) {
+            int start = video.indexOf(host);
+            assertTrue(host + " must exist in VideoActivity", start >= 0);
+            int end = video.indexOf("\n    }", start);
+            assertTrue("presentation change must resync the gesture axes: " + host,
+                    end > start && video.substring(start, end).contains("syncShortDramaGesture();"));
+        }
+
+        String tmdb = new String(Files.readAllBytes(findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"))), StandardCharsets.UTF_8);
+        assertTrue("the inline gesture mode must be derived from the current presentation",
+                tmdb.contains("inlineGestureDetector.setShortDrama(inlineFullscreen && shouldUseInlineShortDramaMode());"));
+        assertFalse("no inline call site may pin the gesture mode to a literal",
+                tmdb.contains("inlineGestureDetector.setShortDrama(true)") || tmdb.contains("inlineGestureDetector.setShortDrama(false)"));
+        // enterInlineFullscreen 要直接重算：手动点全屏不走 applyInlineShortDramaMode。
+        // exitInlineFullscreen 经 resetInlineShortDramaMode 间接重算（它先置 inlineFullscreen=false）。
+        for (String host : Arrays.asList("private void applyInlineShortDramaMode()", "private void resetInlineShortDramaMode()", "private void enterInlineFullscreen()")) {
+            int start = tmdb.indexOf(host);
+            assertTrue(host + " must exist in TmdbDetailActivity", start >= 0);
+            int end = tmdb.indexOf("\n    }", start);
+            assertTrue("presentation change must resync the inline gesture axes: " + host,
+                    end > start && tmdb.substring(start, end).contains("syncInlineShortDramaGesture();"));
+        }
+        int exitInline = tmdb.indexOf("private void exitInlineFullscreen()");
+        assertTrue("exitInlineFullscreen must exist", exitInline >= 0);
+        String exitBody = tmdb.substring(exitInline, tmdb.indexOf("\n    }", exitInline));
+        int cleared = exitBody.indexOf("inlineFullscreen = false;");
+        int resync = exitBody.indexOf("resetInlineShortDramaMode();");
+        assertTrue("leaving inline fullscreen must resync the gesture axes after clearing the flag",
+                cleared >= 0 && resync > cleared);
+    }
+
+    @Test
     public void mobileShortDramaQualityIconHasSingleSourceOfTruth() throws Exception {
         // setQualityVisible 有 6 个调用点，其中多处显式传 false（未选中集数、切线路重置），
         // 与 Result.isMulti() 的结论并不一致。dock 图标若自行推导 Result，就会与 action 栏


### PR DESCRIPTION
用户反馈短剧模式下亮度/音量容易误触。原来的轴向是「中间竖滑切集 +
左右 1/4 竖滑调亮度音量」，在铺满屏幕的竖屏短剧里两者互相干扰：想切集
却滑到了边缘，想调亮度又常常切了集。

参考红果短剧、抖音等主流竖屏播放器改为：
- 上下滑切上下集，不再受左右 1/4 分区限制（24dp 边框仍让给系统手势）
- 亮度/音量改为长按后再上下滑，左半亮度右半音量
- 切集方向固定为上滑=下一集，不跟随直播的「反转」开关
- 横滑拖进度保持不变

长按后的调节不能挂在 onScroll 上：GestureDetector 触发长按后会把后续
ACTION_MOVE 全部吞掉，onScroll 不再回调，所以这条手势由 onTouchEvent 自己驱动（handleAdjust）。

由此带出的几处状态管理问题一并修掉：

- reset() 挂在 onDown 上，而 onDown 在边缘/缩放/锁定时会提前返回。旧代码 有 onScroll 兜底所以没暴露，改由 onTouchEvent 直接驱动后，上一次手势的 changeBright/anchorY 会活到下一次，在边缘起手时第一个 MOVE 就改亮度并 落盘。新增 clearGesture() 挂在每次 UP/CANCEL 上，不依赖下一次 onDown 是否被接受；必须等 detector 处理完再清，因为 onFling 要读这些标记。
- anchorY 停在 NaN 时 deltaY 为 NaN，setVolume 两个 clamp 对 NaN 均为 false， (int) NaN == 0 导致静音；亮度侧 merge(NaN, ...) 返回 -1 被当成用户设定 持久化。handleAdjust 增加「没有本次手势建立的基准就不调节」前置判断。
- downX/downY 同样不能记在 onDown 里：changeScale 在缩放结束后 500ms 才 解除，那段窗口按下的手势拿不到自己的起点，会用上一次的起点算位移，一按 就跳。改到 ACTION_DOWN 分支无条件记录。
- 手势轴向改为由「当前是否处于短剧全屏」推导，在 enterFullscreen / exitFullscreen / enterShortDramaFullscreen / onNewIntent 四处重算。 此前只在进入时置一次：横屏短剧允许旋转，转回竖屏走 exitFullscreen 退到 内嵌小窗后仍是短剧轴向，在详情页上竖滑会误切集；换到第二部短剧时形态 故意保留但标记被清掉，整个解析缓冲窗口用的是长视频轴向。
- CANCEL（被父容器拦截/来电）此前不收尾，倍速卡在长按速率、HUD 常驻画面。 长按现在是亮度/音量主入口，这个路径变常见了。
- setVolume 除以未测量的 getMeasuredHeight() 会得到 Infinity/NaN，音量一帧 拉满或静音，补 Math.max(..., 1) 与 maxVolume <= 0 判断。
- 用实时 getPointerCount() 而非 multiTouch 判断多指：后者在 ACTION_POINTER_UP 时不复位，会把抬起一根手指后的单指调节一起挡掉。

沉浸融合模式的内联播放器（PlayerGesture）同步同一套改动，并在
enterInlineFullscreen 补上重算——手动点全屏不走 applyInlineShortDramaMode。

TV/leanback 端没有滑动手势，无需改动。

新增 mobileShortDramaGesturesSwapAxesToAvoidMisfires 覆盖上述每一条，并把 两处 setShortDrama 调用点约束为不许传字面量，防止退回硬编码。