### PR TITLE
fix(tv): 修复分类切换后的内容滚动位置

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/HomeActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/HomeActivity.java
@@ -209,6 +209,9 @@ public class HomeActivity extends BaseActivity implements ExitConfirmDialog.List
             syncNativeContentInset();
             syncWebOverlayLayout();
         });
+        mBinding.typeRecycler.setOnFocusChangeListener((view, hasFocus) -> {
+            if (hasFocus && isCategoryVisible() && mFolder != null) mFolder.scrollContentToTop();
+        });
         mBinding.recycler.addOnChildViewHolderSelectedListener(new OnChildViewHolderSelectedListener() {
             @Override
             public void onChildViewHolderSelected(@NonNull RecyclerView parent, @Nullable RecyclerView.ViewHolder child, int position, int subposition) {
@@ -227,10 +230,7 @@ public class HomeActivity extends BaseActivity implements ExitConfirmDialog.List
                 if (child == null) return;
                 mSelectedTypeView = child.itemView;
                 mSelectedTypeView.setSelected(true);
-                if (parent.hasFocus()) {
-                    updateToolbarVisibility(true);
-                    if (isCategoryVisible() && mFolder != null) mFolder.requestContentFocus(0);
-                }
+                if (parent.hasFocus()) updateToolbarVisibility(true);
                 if (Setting.isHomeVodAutoLoad()) scheduleTypeSwitch(position);
             }
         });
@@ -342,7 +342,7 @@ public class HomeActivity extends BaseActivity implements ExitConfirmDialog.List
         else transaction.add(R.id.categoryContainer, target, tag);
         target.setUserVisibleHint(true);
         transaction.runOnCommit(() -> {
-            target.requestContentFocus(0);
+            target.scrollContentToTop();
             restoreTypeFocus(keepTypeFocus, item);
             if (toggleFilter && target == mFolder && isCurrentCategory(item)) updateFilter(item);
         });

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/HomeActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/HomeActivity.java
@@ -227,7 +227,10 @@ public class HomeActivity extends BaseActivity implements ExitConfirmDialog.List
                 if (child == null) return;
                 mSelectedTypeView = child.itemView;
                 mSelectedTypeView.setSelected(true);
-                if (parent.hasFocus()) updateToolbarVisibility(true);
+                if (parent.hasFocus()) {
+                    updateToolbarVisibility(true);
+                    if (isCategoryVisible() && mFolder != null) mFolder.requestContentFocus(0);
+                }
                 if (Setting.isHomeVodAutoLoad()) scheduleTypeSwitch(position);
             }
         });
@@ -339,6 +342,7 @@ public class HomeActivity extends BaseActivity implements ExitConfirmDialog.List
         else transaction.add(R.id.categoryContainer, target, tag);
         target.setUserVisibleHint(true);
         transaction.runOnCommit(() -> {
+            target.requestContentFocus(0);
             restoreTypeFocus(keepTypeFocus, item);
             if (toggleFilter && target == mFolder && isCurrentCategory(item)) updateFilter(item);
         });

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/FolderFragment.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/FolderFragment.java
@@ -41,6 +41,7 @@ public class FolderFragment extends BaseFragment {
     private FragmentFolderBinding mBinding;
     private Boolean pendingFilterVisible;
     private Integer pendingContentRow;
+    private boolean pendingScrollToTop;
     private Class mType;
 
     public static FolderFragment newInstance(String key, Class type) {
@@ -98,6 +99,7 @@ public class FolderFragment extends BaseFragment {
         FragmentTransaction transaction = getChildFragmentManager().beginTransaction().replace(R.id.container, TypeFragment.newInstance(getKey(), mType.getTypeId(), mType.getStyle(), getExtend(), mType.isFolder(), getHistoryResumeCid(), getHistoryResumeKey(), getHistoryResumeTargetCid()));
         transaction.runOnCommit(this::applyPendingFilter);
         transaction.runOnCommit(this::applyPendingContentFocus);
+        transaction.runOnCommit(this::applyPendingScrollToTop);
         transaction.commit();
     }
 
@@ -161,8 +163,22 @@ public class FolderFragment extends BaseFragment {
         pendingContentRow = null;
     }
 
+    public void scrollContentToTop() {
+        pendingScrollToTop = true;
+        applyPendingScrollToTop();
+    }
+
+    private void applyPendingScrollToTop() {
+        if (!pendingScrollToTop) return;
+        TypeFragment child = getChild();
+        if (child == null) return;
+        child.scrollContentToTop();
+        pendingScrollToTop = false;
+    }
+
     public void clearContentFocusRequest() {
         pendingContentRow = null;
+        pendingScrollToTop = false;
         TypeFragment child = getChild();
         if (child != null) child.clearContentFocusRequest();
     }

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/TypeFragment.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/TypeFragment.java
@@ -344,6 +344,16 @@ public class TypeFragment extends BaseFragment implements CustomScroller.Callbac
         return mBinding.recycler.requestFocus();
     }
 
+    public void scrollContentToTop() {
+        if (mBinding == null || mAdapter == null) return;
+        int target = filterVisible ? mFilters.size() : 0;
+        mBinding.recycler.post(() -> {
+            if (mBinding == null || mAdapter == null || mAdapter.size() <= target) return;
+            mBinding.recycler.showHeader();
+            mBinding.recycler.scrollToPosition(target);
+        });
+    }
+
     public void requestContentFocus(int contentRow) {
         pendingContentRow = Math.max(0, contentRow);
         contentFocusGeneration++;


### PR DESCRIPTION
## 中文说明

- 合并远端 beta 最新代码。
- 修复 TV 端分类焦点切换后内容列表未回到顶部的问题。
- 保留筛选行偏移，并在分类获得焦点及分类内容切换提交后统一滚动到顶部。

## 验证

- `git diff origin/beta..HEAD --check`
- `./gradlew :app:compileLeanbackArmeabi_v7aReleaseJavaWithJavac --no-daemon`（通过）