### PR TITLE
修复详情页 MPV 自定义按钮焦点导航

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -1297,11 +1297,13 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
             addInlineCustomButton(playerActions, button);
             if (mobileActions != null) addInlineCustomButton(mobileActions, button);
         }
+        setupInlineCustomButtonFocus();
         updateInlineCustomButtonVisibility();
     }
 
     private void addInlineCustomButton(ViewGroup container, MpvConfigStore.CustomButton button) {
         TextView view = new TextView(this);
+        view.setId(View.generateViewId());
         view.setTextSize(13);
         view.setTextColor(Color.WHITE);
         view.setGravity(Gravity.CENTER);
@@ -1338,6 +1340,28 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         boolean visible = service() != null && player() != null
                 && !player().isEmpty() && player().isMpv();
         for (View view : inlineCustomActionViews) view.setVisibility(visible ? View.VISIBLE : View.GONE);
+    }
+
+    /**
+     * 自定义按钮不属于 PlayerButtonSetting 的固定按钮集合，不能依赖固定按钮的焦点链。
+     * 否则 TV 端最后一个内置按钮的右焦点仍然是 NO_ID，动态追加的按钮无法用方向键到达。
+     */
+    private void setupInlineCustomButtonFocus() {
+        if (Util.isMobile()) return;
+        ViewGroup container = (ViewGroup) binding.playerActionRow.getChildAt(0);
+        List<View> focusable = new ArrayList<>();
+        for (int i = 0; i < container.getChildCount(); i++) {
+            View view = container.getChildAt(i);
+            if (view.getVisibility() == View.VISIBLE && view.isEnabled() && view.isFocusable()) focusable.add(view);
+        }
+        for (int i = 0; i < focusable.size(); i++) {
+            View current = focusable.get(i);
+            View previous = focusable.get(i == 0 ? focusable.size() - 1 : i - 1);
+            View next = focusable.get(i == focusable.size() - 1 ? 0 : i + 1);
+            current.setNextFocusLeftId(previous.getId());
+            current.setNextFocusRightId(next.getId());
+            current.setNextFocusUpId(current.getId());
+        }
     }
 
     private void inflateMobileInlineControl() {
@@ -7401,6 +7425,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         setInlineFullscreenIcon();
         updateMobileInlineButtons(playing, hasPlayer, episodeCount, hasTitle);
         applyInlinePlayerButtonSettings();
+        setupInlineCustomButtonFocus();
         updateInlineDisplayPanel();
         // 更新按钮颜色
         updateInlineButtonColors();

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -112,6 +112,7 @@ import com.fongmi.android.tv.player.IntroSkipPlayback;
 import com.fongmi.android.tv.player.PlayerManager;
 import com.fongmi.android.tv.player.PlayerHelper;
 import com.fongmi.android.tv.player.exo.MediaSourceFactory;
+import com.fongmi.android.tv.player.mpv.MpvConfigStore;
 import com.fongmi.android.tv.service.AiAdDetectionService;
 import com.fongmi.android.tv.service.AiEpisodeSeasonService;
 import com.fongmi.android.tv.service.AiRecommendationService;
@@ -415,6 +416,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private int mAdFeedbackGeneration;
     private int tmdbDialogGeneration;
     private AiEpisodeSeasonService aiSeasonService;
+    private final List<View> inlineCustomActionViews = new ArrayList<>();
+    private boolean inlineCustomButtonsInitialized;
     private AlertDialog aiSeasonLoadingDialog;
     private int tmdbApplyGeneration;
     private int tmdbEpisodeDetailGeneration;
@@ -1206,6 +1209,7 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.playerSearch.setOnLongClickListener(view -> openGlobalSourceSearch());
         inlinePlayerUi.bindInlineActions();
         setupMobileInlineControl();
+        setupInlineCustomButtons();
         hideInlineControls();
         updateInlineButtons(false);
         focusInlinePlayerPanel();
@@ -1272,6 +1276,68 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         parse.setHasFixedSize(true);
         parse.setItemAnimator(null);
         parse.setAdapter(inlineParseAdapter = new InlineParseAdapter());
+    }
+
+    /**
+     * 影视原生模式和详情页使用不同的控制条。原生模式会在 VideoActivity
+     * 中创建 scripts 按钮，详情页此前只绑定了内置按钮，因此沉浸融合模式
+     * 虽然 MPV 已加载脚本桥接文件，却没有任何入口发送 script-message。
+     */
+    private void setupInlineCustomButtons() {
+        if (inlineCustomButtonsInitialized) return;
+        inlineCustomButtonsInitialized = true;
+        List<MpvConfigStore.CustomButton> buttons = MpvConfigStore.customButtons();
+        if (buttons.isEmpty()) return;
+
+        ViewGroup playerActions = (ViewGroup) binding.playerActionRow.getChildAt(0);
+        ViewGroup mobileActions = Util.isMobile() && detailActionRoot != null
+                ? detailActionRoot.findViewById(R.id.container) : null;
+        for (MpvConfigStore.CustomButton button : buttons) {
+            if (button == null || !button.enabled) continue;
+            addInlineCustomButton(playerActions, button);
+            if (mobileActions != null) addInlineCustomButton(mobileActions, button);
+        }
+        updateInlineCustomButtonVisibility();
+    }
+
+    private void addInlineCustomButton(ViewGroup container, MpvConfigStore.CustomButton button) {
+        TextView view = new TextView(this);
+        view.setTextSize(13);
+        view.setTextColor(Color.WHITE);
+        view.setGravity(Gravity.CENTER);
+        view.setMinHeight(ResUtil.dp2px(40));
+        view.setMinWidth(ResUtil.dp2px(56));
+        view.setPadding(ResUtil.dp2px(8), ResUtil.dp2px(4), ResUtil.dp2px(8), ResUtil.dp2px(4));
+        view.setBackgroundResource(R.drawable.selector_control_sheet_button);
+        view.setText(button.title);
+        view.setSingleLine(true);
+        view.setMaxWidth(ResUtil.dp2px(144));
+        view.setEllipsize(TextUtils.TruncateAt.END);
+        view.setContentDescription(button.title);
+        view.setOnClickListener(item -> dispatchInlineCustomButton(item, button.id, false));
+        view.setOnLongClickListener(item -> {
+            dispatchInlineCustomButton(item, button.id, true);
+            return true;
+        });
+        view.setFocusable(true);
+        if (Util.isLeanback()) view.setFocusableInTouchMode(true);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ResUtil.dp2px(40));
+        params.setMargins(ResUtil.dp2px(4), ResUtil.dp2px(2), ResUtil.dp2px(4), ResUtil.dp2px(2));
+        container.addView(view, params);
+        inlineCustomActionViews.add(view);
+    }
+
+    private void dispatchInlineCustomButton(View view, String id, boolean longPress) {
+        if (service() == null || player() == null || !player().isMpv()) return;
+        if (player().sendMpvCustomButton(id, longPress)) view.setSelected(!view.isSelected());
+        setInlineHideCallback();
+    }
+
+    private void updateInlineCustomButtonVisibility() {
+        boolean visible = service() != null && player() != null
+                && !player().isEmpty() && player().isMpv();
+        for (View view : inlineCustomActionViews) view.setVisibility(visible ? View.VISIBLE : View.GONE);
     }
 
     private void inflateMobileInlineControl() {
@@ -7272,9 +7338,11 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
     private void updateInlineButtons(boolean playing) {
         if (!isInlinePlayerMode() || inlineControlController == null) {
             setInlineDecodeText(getString(R.string.play_decode_idle));
+            updateInlineCustomButtonVisibility();
             return;
         }
         boolean hasPlayer = service() != null && !player().isEmpty();
+        updateInlineCustomButtonVisibility();
         setInlineSpeedText(service() == null || player().isEmpty() ? getString(R.string.play_speed) : player().getSpeedText());
         setInlineDecodeText(inlineDecodeText(hasPlayer));
         binding.playerExternal.setText(service() == null ? getString(R.string.play_exo) : player().getPlayerText());

--- a/docs/beta-sync-review-dev2-20260907-round2.md
+++ b/docs/beta-sync-review-dev2-20260907-round2.md
@@ -1,5 +1,16 @@
 # dev2 第二轮 beta 同步与电视端详情闪烁复评（2026-09-07）
 
+## Recovery anchor（本次最新收口）
+
+- 目标：合并远端最新 beta，评审当前全部改动（含已提交未推送），修复、验证、复评通过后提交、推送并创建中文 PR 到 beta，最后确认远端最新状态。
+- 本次远端基线：`origin/beta@9fc936fd88cb5b58d645c49b97209b0f246ed078`；已无冲突合并为本地 `ff6f6562d42ad3e1efdf1941c564899b86e455cd`。
+- 本次相对 beta 的独有代码：`804d83f6e88a07974ef1b48d302558fbc78e7329` 在 `TmdbDetailActivity.java` 增加融合播放器 MPV 自定义按钮入口；首轮复审发现 TV 动态按钮未接入方向键焦点链，已在同文件补充稳定 View ID 与动态焦点链重建。
+- 当前保护路径：5 个 `*.bak20260906*` 备份文件，均保持未修改、不纳入提交；任务守卫为 `M202609071946-beta-review-fusion-mpv-scripts`，范围为 `TmdbDetailActivity.java` 与本文档。
+- 已完成证据：Mobile Arm64 `TmdbDetailActivityLayoutTest` 与 Leanback Arm64 Java 编译均 `BUILD SUCCESSFUL`（日志 `/tmp/beta-review-fusion-mpv-scripts-final.log`）；此前双 flavor 编译日志为 `/tmp/beta-review-fusion-mpv-scripts-gradle.log`；`git diff --check` 与任务守卫 check 通过。
+- 最新复评结论：自定义按钮只读取启用配置，短按/长按分别透传 MPV script-message；非 MPV、无服务或空播放器时隐藏；Mobile 双动作栏不重复挂载；TV 动态按钮已分配稳定 ID 并接入可见焦点链。未发现剩余 P1/P2 阻断问题。
+- 未决风险：真实设备逐帧视觉与遥控器验证不在本地证据内；该边界不影响源码编译、源契约测试和焦点链静态复评结论。
+- 回滚锚点：`ff6f6562d42ad3e1efdf1941c564899b86e455cd`；下一动作：任务守卫原子提交并创建恢复标签，然后推送 dev2、创建中文 PR 到 beta，最后拉取远端最新状态。
+
 ## Recovery anchor
 
 - 目标：合并远端最新 beta，评审全部当前改动（含已提交未推送），修复、定向验证、复评通过后提交与恢复标签，推送 dev2 并创建中文 PR 到 beta，最后拉取远端最新状态。


### PR DESCRIPTION
## 变更说明
- 合入远端 beta 最新代码 `9fc936fd88cb5b58d645c49b97209b0f246ed078`，无冲突。
- 为融合详情播放器增加已启用 MPV 自定义按钮入口，支持短按/长按 script-message。
- 修复 TV 端动态按钮无法通过方向键访问的问题，补充稳定 View ID 和动态焦点链。
- Mobile 端同步详情动作栏，非 MPV、无服务或空播放器时自动隐藏。

## 验证
- `:app:testMobileArm64_v8aDebugUnitTest --tests com.fongmi.android.tv.ui.activity.TmdbDetailActivityLayoutTest`
- `:app:compileLeanbackArm64_v8aDebugJavaWithJavac`
- 两项均 `BUILD SUCCESSFUL`。
- 已完成修复后复评，未发现剩余 P1/P2 问题。

## 备注
- 未覆盖真实设备逐帧视觉与遥控器验证。