### PR TITLE
修复 WebHome fm.vod 打开有历史的影片不续播(多季 TMDB 剧回落第 1 集)

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/web/HomeWebBridge.java
+++ b/app/src/main/java/com/fongmi/android/tv/web/HomeWebBridge.java
@@ -10,6 +10,7 @@ import com.fongmi.android.tv.App;
 import com.fongmi.android.tv.setting.Setting;
 import com.fongmi.android.tv.api.SiteApi;
 import com.fongmi.android.tv.api.config.VodConfig;
+import com.fongmi.android.tv.db.AppDatabase;
 import com.fongmi.android.tv.bean.History;
 import com.fongmi.android.tv.bean.Result;
 import com.fongmi.android.tv.bean.Site;
@@ -279,8 +280,30 @@ public class HomeWebBridge {
         String wall = wallPic(payload);
         String content = content(payload);
         final String playSiteKey = siteKey;
-        App.post(() -> controller.prepareNativePlayback(() -> VideoActivity.start(activity, playSiteKey, vodId, title, pic, null, wall, content)));
+        App.post(() -> controller.prepareNativePlayback(() -> {
+            History resume = findResumeHistory(playSiteKey, vodId);
+            if (resume != null) {
+                VideoActivity.startDirect(activity, playSiteKey, vodId, title, pic, null, null, null, null, resume);
+            } else {
+                VideoActivity.start(activity, playSiteKey, vodId, title, pic, null, wall, content);
+            }
+        }));
         return "{}";
+    }
+
+    /**
+     * WebHome 打开有观看历史的影片时按组合键(siteKey@@@vodId@@@cid)直取 History,走与
+     * 「最近观看」相同的续播直通(EXTRA_RESUME_FROM_HISTORY 携带完整历史,跳过重匹配)。
+     * 否则详情页靠 History.findPlayback 重匹配,isSeasonEligible 的季资格检查会把多季
+     * TMDB 剧的历史拒绝掉,「继续观看」回落到第 1 集。
+     */
+    private static History findResumeHistory(String siteKey, String vodId) {
+        if (TextUtils.isEmpty(siteKey) || TextUtils.isEmpty(vodId)) return null;
+        try {
+            return History.find(siteKey + AppDatabase.SYMBOL + vodId + AppDatabase.SYMBOL + VodConfig.getCid());
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private String playVodInline(JsonObject payload) {


### PR DESCRIPTION
## 现象

在 WebHome 自定义首页用 `fm.vod(siteKey, vodId, ...)` 打开有观看历史的剧集(例:吞噬星空已看到 86 集),实际从第 1 集开始;原生「最近观看」点击同一部剧则正常续播。

## 根因

1. 原生「最近观看」走直通通道:`startDirectFromHistory(..., resumeHistory)` 携带完整 History 对象,写入 `EXTRA_RESUME_FROM_HISTORY` + 编码历史载荷(`TmdbDetailActivity.java:570-572`),消费侧 `mHistory = resumeHistory == null ? History.findPlayback(...) : resumeHistory.forPlaybackKey(...)`(`VideoActivity.java:4553`),**跳过重匹配**直取上次集数。
2. WebHome 的 `fm.vod` 走 `HomeWebBridge.playVod`(`HomeWebBridge.java:271`),只传 `siteKey/vodId/title/pic/wallPic/content`,没有 History 通道。
3. 详情页靠 `History.findPlayback(...)` 重新匹配,其中 `isSeasonEligible`(`History.java:464`)的季资格检查:多季 TMDB 条目(如吞噬星空)重新拉起的 TMDB 身份与历史记录的季口径不一致时历史被拒绝 → 回落第 1 集。

## 修复

`playVod` 按组合键 `siteKey@@@vodId@@@cid` 直取 History,命中则走 `VideoActivity.startDirect(..., resumeHistory)`(leanback/mobile 两端均有该 public 重载),与「最近观看」同链路续播直通;未命中保持原有 `VideoActivity.start(...)` 路径不变。

```java
History resume = findResumeHistory(playSiteKey, vodId);
if (resume != null) {
    VideoActivity.startDirect(activity, playSiteKey, vodId, title, pic, null, null, null, null, resume);
} else {
    VideoActivity.start(activity, playSiteKey, vodId, title, pic, null, wall, content);
}
```

## 验证

- leanback/mobile 两 flavor `compileArm64_v8aDebugJavaWithJavac` 编译通过
- 真机(alist-tvbox 后端 + WebHome 首页,吞噬星空 sub51 历史第 86 集):`fm.vod('csp_Media','msub:51',...)` 命中 History 直通,从第 86 集续播