### PR TITLE
fix(beta): 同步 #240，修复 WebHome fm.vod 历史续播

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/web/HomeWebBridge.java
+++ b/app/src/main/java/com/fongmi/android/tv/web/HomeWebBridge.java
@@ -10,6 +10,7 @@ import com.fongmi.android.tv.App;
 import com.fongmi.android.tv.setting.Setting;
 import com.fongmi.android.tv.api.SiteApi;
 import com.fongmi.android.tv.api.config.VodConfig;
+import com.fongmi.android.tv.db.AppDatabase;
 import com.fongmi.android.tv.bean.History;
 import com.fongmi.android.tv.bean.Result;
 import com.fongmi.android.tv.bean.Site;
@@ -279,8 +280,30 @@ public class HomeWebBridge {
         String wall = wallPic(payload);
         String content = content(payload);
         final String playSiteKey = siteKey;
-        App.post(() -> controller.prepareNativePlayback(() -> VideoActivity.start(activity, playSiteKey, vodId, title, pic, null, wall, content)));
+        App.post(() -> controller.prepareNativePlayback(() -> {
+            History resume = findResumeHistory(playSiteKey, vodId);
+            if (resume != null) {
+                VideoActivity.startDirect(activity, playSiteKey, vodId, title, pic, null, null, null, null, resume);
+            } else {
+                VideoActivity.start(activity, playSiteKey, vodId, title, pic, null, wall, content);
+            }
+        }));
         return "{}";
+    }
+
+    /**
+     * WebHome 打开有观看历史的影片时按组合键(siteKey@@@vodId@@@cid)直取 History,走与
+     * 「最近观看」相同的续播直通(EXTRA_RESUME_FROM_HISTORY 携带完整历史,跳过重匹配)。
+     * 否则详情页靠 History.findPlayback 重匹配,isSeasonEligible 的季资格检查会把多季
+     * TMDB 剧的历史拒绝掉,「继续观看」回落到第 1 集。
+     */
+    private static History findResumeHistory(String siteKey, String vodId) {
+        if (TextUtils.isEmpty(siteKey) || TextUtils.isEmpty(vodId)) return null;
+        try {
+            return History.find(siteKey + AppDatabase.SYMBOL + vodId + AppDatabase.SYMBOL + VodConfig.getCid());
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private String playVodInline(JsonObject payload) {


### PR DESCRIPTION
## 来源与范围

将已合入 `main` 的 #240 原样同步到 `beta`。

- 原始提交：`de4e1f59535b64bcb8db2dc8c7267b86d19f62fe`
- beta 基线：`14423f1a17bc05efe566097385c9b126a4f546ae`
- 仅修改 `app/src/main/java/com/fongmi/android/tv/web/HomeWebBridge.java`（24 行新增、1 行删除），不带入 `main` 的其他改动。

## 修复内容

自定义首页通过 `fm.vod(siteKey, vodId, ...)` 打开已有观看历史的剧集时，按 `siteKey@@@vodId@@@cid` 查找历史记录。命中后使用两端现有的 `VideoActivity.startDirect(..., resumeHistory)` 携带完整历史，避免多季 TMDB 剧在重新匹配历史时回落到第 1 集。

未命中历史、参数为空或查询异常时，保持原来的 `VideoActivity.start(...)` 路径及海报、背景图、简介参数传递。

## 验证

- 与 #240 的补丁等价性检查通过，stable patch-id：`b40a0a2a11d54bdba8b0e14e8629e89f6127b276`。
- 在本同步分支执行以下两个 Java 编译目标，均通过（`BUILD SUCCESSFUL in 1m 35s`）：

```bash
bash ./gradlew \
  :app:compileLeanbackArm64_v8aDebugJavaWithJavac \
  :app:compileMobileArm64_v8aDebugJavaWithJavac \
  --offline --console=plain
```

- 本次没有重复真机测试；原 PR #240 已记录自定义首页打开《吞噬星空》后从历史第 86 集续播的真机结果。

## 回退

该同步为单个独立修复提交，回退该提交即可恢复 `beta` 的原有行为。
