### PR TITLE
fix(home): restore missing paddingEnd in part view for proper focus layout

### DIFF
--- a/app/src/leanback/res/layout/activity_video.xml
+++ b/app/src/leanback/res/layout/activity_video.xml
@@ -887,7 +887,7 @@
                 android:clipToPadding="false"
                 android:paddingStart="24dp"
                 android:paddingEnd="24dp"
-                android:nestedScrollingEnabled="false"
+                android:nestedScrollingEnabled="false" android:nextFocusDown="@id/part"
                 android:visibility="gone"
                 tools:visibility="visible" />
 
@@ -1347,7 +1347,6 @@
             android:clipChildren="false"
             android:clipToPadding="false"
             android:paddingStart="24dp"
-            android:paddingEnd="24dp"
             android:visibility="gone" />
 
         <androidx.leanback.widget.HorizontalGridView

--- a/app/src/leanback/res/layout/activity_video.xml
+++ b/app/src/leanback/res/layout/activity_video.xml
@@ -1346,7 +1346,7 @@
             android:layout_marginBottom="12dp"
             android:clipChildren="false"
             android:clipToPadding="false"
-            android:paddingStart="24dp"
+            android:paddingStart="24dp" android:paddingEnd="24dp"
             android:visibility="gone" />
 
         <androidx.leanback.widget.HorizontalGridView


### PR DESCRIPTION
修复焦点布局：在 activity_video.xml 中为 part 行恢复缺失的 24dp 右侧留白，确保焦点在质量选择和分集之间的双向导航正常工作。此更改来源于对 beta 分支最新代码的评审与验证。