### PR TITLE
修复电视直播屏显重影并完成最终复评

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java
@@ -670,10 +670,8 @@ public class LiveActivity extends PlaybackActivity implements GroupAdapter.OnCli
 
     private void showControl(View view) {
         mBinding.control.getRoot().setVisibility(View.VISIBLE);
-        // OSD 启用时，不显示 widget.top（避免与 OSD 的 topLeft/topRight 重影）
-        if (!PlayerSetting.isOsdEnabled()) {
-            mBinding.widget.top.setVisibility(View.VISIBLE);
-        }
+        // 控制栏显示时统一由 PlayerOsdController 显示标题、分辨率和时间，避免旧栏重影
+        mBinding.widget.top.setVisibility(View.GONE);
         if (mOsd != null) mOsd.setControlsVisible(true);
         App.post(view::requestFocus, 25);
         setR1Callback();

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/LiveActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/LiveActivityLayoutTest.java
@@ -12,6 +12,21 @@ import static org.junit.Assert.assertTrue;
 public class LiveActivityLayoutTest {
 
     @Test
+    public void leanbackLiveControlsUseSharedOsdWithoutLegacyTopBar() throws Exception {
+        Path sourcePath = findLeanbackJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "activity", "LiveActivity.java"));
+        String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+        String showControlBody = section(source, "private void showControl(View view)", "private void hideControl()");
+
+        assertFalse(sourcePath + " is missing showControl", showControlBody.isEmpty());
+        assertTrue("leanback live controls must hide the retired top bar before showing shared OSD",
+                showControlBody.contains("mBinding.widget.top.setVisibility(View.GONE);")
+                        && showControlBody.contains("mOsd.setControlsVisible(true);"));
+        assertFalse("leanback live controls must not show the retired top bar when all OSD options are off",
+                showControlBody.contains("mBinding.widget.top.setVisibility(View.VISIBLE);"));
+    }
+
+    @Test
     public void explicitLivePiPPreparesVideoBeforeEnteringSystemPiP() throws Exception {
         Path sourcePath = findMobileJavaPath().resolve(Path.of(
                 "com", "fongmi", "android", "tv", "ui", "activity", "LiveActivity.java"));

--- a/docs/beta-sync-review-dev2-20260911.md
+++ b/docs/beta-sync-review-dev2-20260911.md
@@ -62,3 +62,16 @@
 2. 推送 `dev2` 和新恢复标签。
 3. 创建目标为 `beta` 的中文 PR。
 4. 再次拉取远端最新代码并核对分支、PR 和工��作树状态。
+
+## 后续拉取与最终复评（2026-09-11）
+
+- 2026-09-11 21:43 CST 已执行 `git fetch --prune origin beta`；当前 `origin/beta` 为完整提交 `be1b02e06b22a4fa2f08c791555536e3e6154c95`，没有发现新的远端 beta 提交。
+- 当前 `HEAD` 为完整提交 `3a2b9d39e8bd3314027e5ce8e709c17e75a21236`，其父提交正是 `origin/beta`；`git merge --ff-only origin/beta` 返回 `Already up to date`，无新增合�并、无冲突。
+- 复用本文件此前对 beta 增量的评审与验证记录：此前合并提交及其相关 beta 改动均已成为 `origin/beta` 的祖先。本次相对最新 beta 的唯一未合入提交是 `3a2b9d39e8bd3314027e5ce8e709c17e75a21236`（`修复电视直播屏显重影`），实际差异仅为：
+  - `app/src/leanback/java/com/fongmi/android/tv/ui/activity/LiveActivity.java`
+  - `app/src/testMobile/java/com/fongmi/android/tv/ui/activity/LiveActivityLayoutTest.java`
+- 最终复评�检查 `showControl`/`hideControl` 生命周期：控制栏显示前始终隐藏旧 `mBinding.widget.top`，再由共享 `PlayerOsdController` 显示标题、分辨率和时间；控制栏隐藏时同时隐藏旧栏并关闭共享 OSD；源码中没有其他路径重新显示该旧栏。未发现空指针、状态遗漏或与 beta 最终树的合并问题。
+- 定向验证已通过：
+  - `bash ./gradlew :app:testMobileArm64_v8aDebugUnitTest --tests com.fongmi.android.tv.ui.activity.LiveActivityLayoutTest :app:compileLeanbackArm64_v8aDebugJavaWithJavac --no-daemon --console=plain`：`BUILD SUCCESSFUL`，98 actionable tasks（7 executed、91 up-to-date）。
+  - `git diff --check origin/beta...HEAD`：通过。
+- 结论：本轮复评通过，无需新增修复；当前任务改动可提交并推送。


### PR DESCRIPTION
## 变更说明

- 修复电视直播控制栏显示时旧 `widget.top` 与共享 `PlayerOsdController` 重复显示造成的屏显重影。
- 增加 `LiveActivityLayoutTest` 回归覆盖，确保控制栏使用共享 OSD 且不会重新显示旧顶部栏。
- 补充 dev2 同步 beta 后的最终复评记录。

## 复评结论

- 已拉取并核对最新�� `origin/beta`，dev2 基于该版本，无新增合并冲突。
- 已检查 `showControl`/`hideControl` 生命周期及 OSD 状态切换，未发现剩余阻断问题。

## 验证

- `:app:testMobileArm64_v8aDebugUnitTest --tests com.fongmi.android.tv.ui.activity.LiveActivityLayoutTest` 通过。
- `:app:compileLeanbackArm64_v8aDebugJavaWithJavac` 通过。
- Gradle 构建结果为 `BUILD SUCCESSFUL`，98 actionable tasks。
- `git diff --check origin/beta...HEAD` 通过。

## 回滚�

- 恢复标签：`recovery/beta-sync-review-dev2-followup-20260911/20260911220922-c36a29038360`。