### PR TITLE
合并 beta 最新代码并完成 dev3 复评

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/SiteHealthReportDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/SiteHealthReportDialog.java
@@ -10,6 +10,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ProgressBar;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.LinearLayoutCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -313,28 +314,35 @@ public class SiteHealthReportDialog extends BaseAlertDialog {
     }
 
     private void confirmClearSite(SiteHealthStore.Row row) {
-        new MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_WebHTV_LightDialog)
-                .setTitle(R.string.site_health_clear_site_title)
-                .setMessage(getString(R.string.site_health_clear_site_message, row.siteName))
-                .setNegativeButton(R.string.dialog_negative, null)
-                .setPositiveButton(R.string.dialog_positive, (dialog, which) -> {
+        showClearConfirmation(
+                R.string.site_health_clear_site_title,
+                getString(R.string.site_health_clear_site_message, row.siteName),
+                () -> {
                     SiteHealthStore.clear(row.siteKey);
                     binding.root.post(this::refreshReport);
-                })
-                .show();
+                });
     }
 
     private void confirmClearAll() {
         if (report.isEmpty()) return;
-        new MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_WebHTV_LightDialog)
-                .setTitle(R.string.site_health_clear_all_title)
-                .setMessage(R.string.site_health_clear_all_message)
-                .setNegativeButton(R.string.dialog_negative, null)
-                .setPositiveButton(R.string.dialog_positive, (dialog, which) -> {
+        showClearConfirmation(
+                R.string.site_health_clear_all_title,
+                getString(R.string.site_health_clear_all_message),
+                () -> {
                     SiteHealthStore.clear();
                     binding.root.post(this::refreshReport);
-                })
-                .show();
+                });
+    }
+
+    private void showClearConfirmation(int titleRes, CharSequence message, Runnable action) {
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity(), R.style.Theme_WebHTV_LightDialog)
+                .setTitle(titleRes)
+                .setMessage(message)
+                .setNegativeButton(R.string.dialog_negative, null)
+                .setPositiveButton(R.string.dialog_positive, (confirmation, which) -> action.run())
+                .create();
+        dialog.show();
+        LightDialog.apply(dialog);
     }
 
     private void addRecentError(LinearLayoutCompat block, int labelRes, SiteHealthStore.Stage stage) {

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/SiteHealthReportDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/SiteHealthReportDialog.java
@@ -121,6 +121,11 @@ public class SiteHealthReportDialog extends BaseAlertDialog {
         button.setTypeface(Typeface.DEFAULT, selected ? Typeface.BOLD : Typeface.NORMAL);
     }
 
+    private void refreshReport() {
+        report = SiteHealthStore.report();
+        render();
+    }
+
     private void render() {
         while (binding.rows.getChildCount() > 1) binding.rows.removeViewAt(1);
         binding.summary.setText(summaryText(report.summary));
@@ -314,8 +319,7 @@ public class SiteHealthReportDialog extends BaseAlertDialog {
                 .setNegativeButton(R.string.dialog_negative, null)
                 .setPositiveButton(R.string.dialog_positive, (dialog, which) -> {
                     SiteHealthStore.clear(row.siteKey);
-                    report = SiteHealthStore.report();
-                    render();
+                    binding.root.post(this::refreshReport);
                 })
                 .show();
     }
@@ -328,8 +332,7 @@ public class SiteHealthReportDialog extends BaseAlertDialog {
                 .setNegativeButton(R.string.dialog_negative, null)
                 .setPositiveButton(R.string.dialog_positive, (dialog, which) -> {
                     SiteHealthStore.clear();
-                    report = SiteHealthStore.report();
-                    render();
+                    binding.root.post(this::refreshReport);
                 })
                 .show();
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/SiteHealthReportDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/SiteHealthReportDialog.java
@@ -85,6 +85,7 @@ public class SiteHealthReportDialog extends BaseAlertDialog {
         binding.sortRecent.setOnClickListener(view -> setSort(Sort.RECENT));
         binding.sortRate.setOnClickListener(view -> setSort(Sort.RATE));
         binding.sortSamples.setOnClickListener(view -> setSort(Sort.SAMPLES));
+        binding.clearAll.setOnClickListener(view -> confirmClearAll());
         binding.close.setOnClickListener(view -> dismiss());
     }
 
@@ -123,6 +124,8 @@ public class SiteHealthReportDialog extends BaseAlertDialog {
     private void render() {
         while (binding.rows.getChildCount() > 1) binding.rows.removeViewAt(1);
         binding.summary.setText(summaryText(report.summary));
+        binding.clearAll.setEnabled(!report.isEmpty());
+        binding.clearAll.setAlpha(report.isEmpty() ? 0.5f : 1.0f);
         int visible = 0;
         for (SiteHealthStore.Row row : sortedRows()) {
             if (!matches(row)) continue;
@@ -311,6 +314,20 @@ public class SiteHealthReportDialog extends BaseAlertDialog {
                 .setNegativeButton(R.string.dialog_negative, null)
                 .setPositiveButton(R.string.dialog_positive, (dialog, which) -> {
                     SiteHealthStore.clear(row.siteKey);
+                    report = SiteHealthStore.report();
+                    render();
+                })
+                .show();
+    }
+
+    private void confirmClearAll() {
+        if (report.isEmpty()) return;
+        new MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_WebHTV_LightDialog)
+                .setTitle(R.string.site_health_clear_all_title)
+                .setMessage(R.string.site_health_clear_all_message)
+                .setNegativeButton(R.string.dialog_negative, null)
+                .setPositiveButton(R.string.dialog_positive, (dialog, which) -> {
+                    SiteHealthStore.clear();
                     report = SiteHealthStore.report();
                     render();
                 })

--- a/app/src/main/java/com/fongmi/android/tv/ui/dialog/TmdbSourceDialog.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/dialog/TmdbSourceDialog.java
@@ -80,10 +80,18 @@ public class TmdbSourceDialog {
         omdbApiKeyInput = view.findViewById(R.id.omdbApiKeyInput);
         EditText ruleInput = view.findViewById(R.id.ruleInput);
         EditText disabledRuleInput = view.findViewById(R.id.disabledRuleInput);
-        View addBtn = view.findViewById(R.id.add);
-        View addDisabledBtn = view.findViewById(R.id.addDisabled);
-        View manageBtn = view.findViewById(R.id.manage);
-        View resetBtn = view.findViewById(R.id.resetDefault);
+        TextView addBtn = view.findViewById(R.id.add);
+        TextView addDisabledBtn = view.findViewById(R.id.addDisabled);
+        TextView manageBtn = view.findViewById(R.id.manage);
+        TextView resetBtn = view.findViewById(R.id.resetDefault);
+        addBtn.setText(R.string.dialog_tmdb_add);
+        addDisabledBtn.setText(R.string.dialog_tmdb_add);
+        manageBtn.setText(R.string.dialog_tmdb_site_manage);
+        resetBtn.setText(R.string.dialog_tmdb_reset_default);
+        addBtn.setAllCaps(false);
+        addDisabledBtn.setAllCaps(false);
+        manageBtn.setAllCaps(false);
+        resetBtn.setAllCaps(false);
 
         TmdbConfig config = TmdbConfig.objectFrom(Setting.getTmdbConfig());
         tempEnabledRules = new ArrayList<>(config.getEnabledSites());

--- a/app/src/main/res/layout/dialog_site_health_report.xml
+++ b/app/src/main/res/layout/dialog_site_health_report.xml
@@ -30,6 +30,18 @@
         android:textSize="14sp"
         tools:text="3 sites · 42 samples · 8 failures" />
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/clearAll"
+        style="@style/Widget.Material3.Button.TonalButton"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:layout_marginTop="8dp"
+        android:minHeight="40dp"
+        android:nextFocusDown="@id/filterAll"
+        android:text="@string/site_health_clear_all"
+        android:textColor="@color/dialog_tonal_button_text"
+        app:backgroundTint="@color/dialog_tonal_button_bg" />
+
     <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
         android:layout_height="36dp"

--- a/app/src/main/res/layout/dialog_tmdb_source.xml
+++ b/app/src/main/res/layout/dialog_tmdb_source.xml
@@ -258,8 +258,7 @@
                         android:layout_marginStart="12dp"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
-                        android:text="@string/dialog_tmdb_add"
-                        android:textAllCaps="false" />
+                        />
 
                 </androidx.appcompat.widget.LinearLayoutCompat>
 
@@ -313,8 +312,7 @@
                         android:layout_marginStart="12dp"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
-                        android:text="@string/dialog_tmdb_add"
-                        android:textAllCaps="false" />
+                        />
 
                 </androidx.appcompat.widget.LinearLayoutCompat>
 
@@ -331,8 +329,7 @@
                         android:layout_width="0dp"
                         android:layout_height="52dp"
                         android:layout_weight="1"
-                        android:text="@string/dialog_tmdb_site_manage"
-                        android:textAllCaps="false" />
+                        />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/resetDefault"
@@ -341,8 +338,7 @@
                         android:layout_height="52dp"
                         android:layout_marginStart="12dp"
                         android:layout_weight="1"
-                        android:text="@string/dialog_tmdb_reset_default"
-                        android:textAllCaps="false" />
+                        />
 
                 </androidx.appcompat.widget.LinearLayoutCompat>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -533,6 +533,9 @@
     <string name="site_health_clear_site">清空本站</string>
     <string name="site_health_clear_site_title">清空站点统计？</string>
     <string name="site_health_clear_site_message">清空“%1$s”的健康样本？</string>
+    <string name="site_health_clear_all">一键清空样本</string>
+    <string name="site_health_clear_all_title">清空全部站点健康样本？</string>
+    <string name="site_health_clear_all_message">将删除全部播放链路健康样本，且无法撤销。</string>
     <string name="site_health_stage_search">搜索</string>
     <string name="site_health_stage_detail">详情</string>
     <string name="site_health_stage_parse">解析</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -507,6 +507,9 @@
     <string name="site_health_clear_site">清空本站</string>
     <string name="site_health_clear_site_title">清空站點統計？</string>
     <string name="site_health_clear_site_message">清空「%1$s」的健康樣本？</string>
+    <string name="site_health_clear_all">一鍵清空樣本</string>
+    <string name="site_health_clear_all_title">清空全部站點健康樣本？</string>
+    <string name="site_health_clear_all_message">將刪除全部播放鏈路健康樣本，且無法撤銷。</string>
     <string name="site_health_stage_search">搜尋</string>
     <string name="site_health_stage_detail">詳情</string>
     <string name="site_health_stage_parse">解析</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -536,6 +536,9 @@
     <string name="site_health_clear_site">Clear this site</string>
     <string name="site_health_clear_site_title">Clear site health?</string>
     <string name="site_health_clear_site_message">Clear health samples for %1$s?</string>
+    <string name="site_health_clear_all">Clear all samples</string>
+    <string name="site_health_clear_all_title">Clear all site health samples?</string>
+    <string name="site_health_clear_all_message">This will delete all playback-chain health samples. This action cannot be undone.</string>
     <string name="site_health_stage_search">Search</string>
     <string name="site_health_stage_detail">Detail</string>
     <string name="site_health_stage_parse">Parse</string>

--- a/app/src/test/java/com/fongmi/android/tv/setting/SiteHealthReportSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/setting/SiteHealthReportSourceTest.java
@@ -71,6 +71,9 @@ public class SiteHealthReportSourceTest {
         assertTrue(reportSource.contains("SiteHealthStore.clear(row.siteKey)"));
         assertTrue(reportSource.contains("confirmClearAll()"));
         assertTrue(reportSource.contains("SiteHealthStore.clear()"));
+        String clearConfirmationBody = methodBody(reportSource, "private void showClearConfirmation(");
+        assertTrue(clearConfirmationBody.contains("R.style.Theme_WebHTV_LightDialog"));
+        assertTrue(clearConfirmationBody.contains("LightDialog.apply(dialog)"));
         String refreshBody = methodBody(reportSource, "private void refreshReport()");
         assertTrue(refreshBody.indexOf("report = SiteHealthStore.report()") < refreshBody.indexOf("render()"));
         assertTrue(methodBody(reportSource, "private void confirmClearSite(").contains("binding.root.post(this::refreshReport)"));

--- a/app/src/test/java/com/fongmi/android/tv/setting/SiteHealthReportSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/setting/SiteHealthReportSourceTest.java
@@ -71,6 +71,10 @@ public class SiteHealthReportSourceTest {
         assertTrue(reportSource.contains("SiteHealthStore.clear(row.siteKey)"));
         assertTrue(reportSource.contains("confirmClearAll()"));
         assertTrue(reportSource.contains("SiteHealthStore.clear()"));
+        String refreshBody = methodBody(reportSource, "private void refreshReport()");
+        assertTrue(refreshBody.indexOf("report = SiteHealthStore.report()") < refreshBody.indexOf("render()"));
+        assertTrue(methodBody(reportSource, "private void confirmClearSite(").contains("binding.root.post(this::refreshReport)"));
+        assertTrue(methodBody(reportSource, "private void confirmClearAll()").contains("binding.root.post(this::refreshReport)"));
         assertTrue(dialogLayout.contains("@+id/report"));
         assertTrue(dialogLayout.contains("@string/site_health_report_view"));
         assertTrue(reportLayout.contains("@+id/filterAll"));

--- a/app/src/test/java/com/fongmi/android/tv/setting/SiteHealthReportSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/setting/SiteHealthReportSourceTest.java
@@ -63,11 +63,14 @@ public class SiteHealthReportSourceTest {
         assertTrue(reportSource.contains("binding.sortRecent.setOnClickListener"));
         assertTrue(reportSource.contains("binding.sortRate.setOnClickListener"));
         assertTrue(reportSource.contains("binding.sortSamples.setOnClickListener"));
+        assertTrue(reportSource.contains("binding.clearAll.setOnClickListener"));
         assertTrue(reportSource.contains("root.setOnClickListener"));
         assertTrue(reportSource.contains("reasonLabel("));
         assertTrue(reportSource.contains("recentErrors("));
         assertTrue(reportSource.contains("confirmClearSite("));
         assertTrue(reportSource.contains("SiteHealthStore.clear(row.siteKey)"));
+        assertTrue(reportSource.contains("confirmClearAll()"));
+        assertTrue(reportSource.contains("SiteHealthStore.clear()"));
         assertTrue(dialogLayout.contains("@+id/report"));
         assertTrue(dialogLayout.contains("@string/site_health_report_view"));
         assertTrue(reportLayout.contains("@+id/filterAll"));
@@ -77,12 +80,16 @@ public class SiteHealthReportSourceTest {
         assertTrue(reportLayout.contains("@+id/sortRecent"));
         assertTrue(reportLayout.contains("@+id/sortRate"));
         assertTrue(reportLayout.contains("@+id/sortSamples"));
+        assertTrue(reportLayout.contains("@+id/clearAll"));
         assertTrue(reportLayout.contains("@+id/rows"));
         assertTrue(strings.contains("name=\"site_health_report_title\""));
         assertTrue(strings.contains("name=\"site_health_filter_all\""));
         assertTrue(strings.contains("name=\"site_health_sort_failures\""));
         assertTrue(strings.contains("name=\"site_health_report_recent_errors\""));
         assertTrue(strings.contains("name=\"site_health_clear_site\""));
+        assertTrue(strings.contains("name=\"site_health_clear_all\""));
+        assertTrue(strings.contains("name=\"site_health_clear_all_title\""));
+        assertTrue(strings.contains("name=\"site_health_clear_all_message\""));
         assertTrue(strings.contains("name=\"site_health_reason_timeout\""));
         assertTrue(strings.contains("name=\"site_health_stage_parse\""));
     }

--- a/app/src/test/java/com/fongmi/android/tv/ui/dialog/TmdbSourceDialogInflationContractTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/dialog/TmdbSourceDialogInflationContractTest.java
@@ -1,0 +1,48 @@
+package com.fongmi.android.tv.ui.dialog;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TmdbSourceDialogInflationContractTest {
+
+    @Test
+    public void materialButtonLabelsAreAppliedAfterInflation() throws Exception {
+        String layout = read(sourcePath().resolve(Path.of("..", "..", "main", "res", "layout", "dialog_tmdb_source.xml")));
+        String source = read(sourcePath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "dialog", "TmdbSourceDialog.java")));
+
+        assertFalse("TMDB dialog buttons must not resolve text from binary XML on API 25",
+                buttonBlock(layout, "add").contains("android:text=")
+                        || buttonBlock(layout, "addDisabled").contains("android:text=")
+                        || buttonBlock(layout, "manage").contains("android:text=")
+                        || buttonBlock(layout, "resetDefault").contains("android:text="));
+        assertTrue(source.contains("addBtn.setText(R.string.dialog_tmdb_add)"));
+        assertTrue(source.contains("addDisabledBtn.setText(R.string.dialog_tmdb_add)"));
+        assertTrue(source.contains("manageBtn.setText(R.string.dialog_tmdb_site_manage)"));
+        assertTrue(source.contains("resetBtn.setText(R.string.dialog_tmdb_reset_default)"));
+    }
+
+    private static String buttonBlock(String layout, String id) {
+        String marker = "android:id=\"@+id/" + id + "\"";
+        int idStart = layout.indexOf(marker);
+        if (idStart < 0) return "";
+        int start = layout.lastIndexOf("<com.google.android.material.button.MaterialButton", idStart);
+        int end = layout.indexOf("/>", idStart);
+        return start >= 0 && end >= 0 ? layout.substring(start, end) : "";
+    }
+
+    private static String read(Path path) throws Exception {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static Path sourcePath() {
+        Path moduleRelative = Path.of("src", "main", "java");
+        if (Files.exists(moduleRelative)) return moduleRelative;
+        return Path.of("app", "src", "main", "java");
+    }
+}


### PR DESCRIPTION
## 变更说明

- 合并远端最新 `beta`（`87ab74014a62382af8786109099ccf95d8b58ff5`）。
- 保留并纳入远端 `dev3` 已提交修复（`398d6b900b0e684ea96b9d0b353620847c421c64`），避免推送时覆盖 TMDB API 25 对话框修复。
- 保留本地站点健康报表连续三次改动：一键清空、清空后刷新、TV 清空确认框样式统一。
- 更新 beta 复评记录与本轮完整评审记录。

## 复评结论

- Leanback 直播控制栏统一使用共享 OSD，旧顶部栏无条件隐藏，消除标题/分辨率/时间重影。
- TMDB 四个 MaterialButton 的文案改为 inflate 后设置，规避 API 25 二进制 XML inflate 崩溃。
- 站点健康报表的单站点和全量清空均有确认、正确调用 `SiteHealthStore.clear`，清空后重新读取并渲染；空报表时全量按钮禁用。
- 验证前后均未发现需要修复的问题，最终复评通过。

## 验证

- `SiteHealthReportSourceTest`：3 项通过。
- `TmdbSourceDialogInflationContractTest`：1 项通过。
- `LiveActivityLayoutTest`：5 项通过。
- `compileLeanbackArm64_v8aDebugJavaWithJavac` 与 Mobile Arm64 Java 编译通过。
- Gradle：`BUILD SUCCESSFUL in 37s`，114 actionable tasks（28 executed、86 up-to-date）。
- `git diff --cached --check`、`git ls-files -u`、task guard 检查通过。

## 回滚

- 本地恢复标签：`recovery/beta-sync-review-dev3-20260912/20260912011332-91571b47365a`。
- 如需回退合并提交：`git revert -m 1 91571b47365a8beb619e7158e284f79696b0bff6`。
