### PR TITLE
修复炫彩详情选集网格起始对齐

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapter.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapter.java
@@ -331,7 +331,9 @@ public class TmdbEpisodeAdapter extends RecyclerView.Adapter<TmdbEpisodeAdapter.
         params.height = height;
         if (params instanceof ViewGroup.MarginLayoutParams marginParams) {
             int gridSpacing = dp(holder.itemView, standardGridItem ? 8 : isNativeEnhanced() ? 12 : 8);
-            int marginStart = mode == Mode.GRID ? gridSpacing / 2 : 0;
+            int position = holder.getBindingAdapterPosition();
+            boolean firstGridColumn = mode == Mode.GRID && position >= 0 && position % gridSpanCount == 0;
+            int marginStart = mode == Mode.GRID && !firstGridColumn ? gridSpacing / 2 : 0;
             int marginEnd = mode == Mode.GRID ? gridSpacing - marginStart : dp(holder.itemView, 12);
             int bottomMargin = dp(holder.itemView, isNativeEnhanced() && mode == Mode.GRID && hasTmdbEpisodeData ? 16 : mode == Mode.GRID ? 10 : 0);
             layoutChanged |= marginParams.getMarginStart() != marginStart

--- a/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapter.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapter.java
@@ -331,10 +331,8 @@ public class TmdbEpisodeAdapter extends RecyclerView.Adapter<TmdbEpisodeAdapter.
         params.height = height;
         if (params instanceof ViewGroup.MarginLayoutParams marginParams) {
             int gridSpacing = dp(holder.itemView, standardGridItem ? 8 : isNativeEnhanced() ? 12 : 8);
-            int position = holder.getBindingAdapterPosition();
-            boolean firstGridColumn = mode == Mode.GRID && position >= 0 && position % gridSpanCount == 0;
-            int marginStart = mode == Mode.GRID && !firstGridColumn ? gridSpacing / 2 : 0;
-            int marginEnd = mode == Mode.GRID ? gridSpacing - marginStart : dp(holder.itemView, 12);
+            int marginStart = 0;
+            int marginEnd = mode == Mode.GRID ? gridSpacing : dp(holder.itemView, 12);
             int bottomMargin = dp(holder.itemView, isNativeEnhanced() && mode == Mode.GRID && hasTmdbEpisodeData ? 16 : mode == Mode.GRID ? 10 : 0);
             layoutChanged |= marginParams.getMarginStart() != marginStart
                     || marginParams.getMarginEnd() != marginEnd

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -14,13 +14,13 @@ import static org.junit.Assert.assertTrue;
 public class TmdbDetailActivityLayoutTest {
 
     @Test
-    public void cinemaEpisodeGridStartsAtTheSameLeftEdgeAsOtherDetailRails() throws Exception {
+    public void cinemaEpisodeGridStartsAtTheSameLogicalStartEdgeAsOtherDetailRails() throws Exception {
         String adapter = readJava("com", "fongmi", "android", "tv", "ui", "adapter", "TmdbEpisodeAdapter.java");
         String cardSize = javaBlockAt(adapter, "private void applyCardSize(");
 
-        assertTrue("the first episode card in every grid row must not keep the shared half-gap on its outer edge",
-                cardSize.contains("position % gridSpanCount == 0")
-                        && cardSize.contains("mode == Mode.GRID && !firstGridColumn ? gridSpacing / 2 : 0"));
+        assertTrue("the episode grid must align its logical start edge with the other detail rails while keeping a full gap after every card",
+                cardSize.contains("int marginStart = 0;")
+                        && cardSize.contains("int marginEnd = mode == Mode.GRID ? gridSpacing : dp(holder.itemView, 12);"));
     }
 
     @Test

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -14,6 +14,16 @@ import static org.junit.Assert.assertTrue;
 public class TmdbDetailActivityLayoutTest {
 
     @Test
+    public void cinemaEpisodeGridStartsAtTheSameLeftEdgeAsOtherDetailRails() throws Exception {
+        String adapter = readJava("com", "fongmi", "android", "tv", "ui", "adapter", "TmdbEpisodeAdapter.java");
+        String cardSize = javaBlockAt(adapter, "private void applyCardSize(");
+
+        assertTrue("the first episode card in every grid row must not keep the shared half-gap on its outer edge",
+                cardSize.contains("position % gridSpanCount == 0")
+                        && cardSize.contains("mode == Mode.GRID && !firstGridColumn ? gridSpacing / 2 : 0"));
+    }
+
+    @Test
     public void seasonSourceRoutesRefreshAndCarrySnapshotSelection() throws Exception {
         Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
         String source = Files.readString(sourcePath, StandardCharsets.UTF_8);

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapterTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/adapter/TmdbEpisodeAdapterTest.java
@@ -97,17 +97,19 @@ public class TmdbEpisodeAdapterTest {
     }
 
     @Test
-    public void gridEpisodeCardsUseSymmetricHorizontalMargins() throws Exception {
+    public void gridEpisodeCardsAlignToStartWithoutChangingCardWidths() throws Exception {
         String source = tmdbEpisodeAdapterSource();
         int method = source.indexOf("private void applyCardSize(ViewHolder holder, boolean compact, boolean hasTmdbEpisodeData)");
         int methodEnd = source.indexOf("private boolean nativeEnhancedMobileGrid", method);
         String body = method >= 0 && methodEnd > method ? source.substring(method, methodEnd) : "";
 
-        assertTrue("grid episode cards must split their spacing between start and end so outer margins stay balanced",
+        assertTrue("grid cards must all share zero start margin and one end spacing so their widths and inner gaps stay consistent",
                 body.contains("int gridSpacing = dp(holder.itemView, standardGridItem ? 8 : isNativeEnhanced() ? 12 : 8);")
-                        && body.contains("int marginStart = mode == Mode.GRID ? gridSpacing / 2 : 0;")
+                        && body.contains("int marginStart = 0;")
+                        && body.contains("int marginEnd = mode == Mode.GRID ? gridSpacing : dp(holder.itemView, 12);")
                         && body.contains("marginParams.setMarginStart(marginStart);")
-                        && body.contains("marginParams.getMarginStart() != marginStart"));
+                        && body.contains("marginParams.getMarginStart() != marginStart")
+                        && !body.contains("getBindingAdapterPosition()"));
     }
 
     @Test


### PR DESCRIPTION
## 变更说明

- 修复炫彩详情页选集网格与其它详情横向轨道的逻辑起始边缘不一致问题。
- 网格卡片统一使用 `start = 0`、`end = gridSpacing`：首项起始边缘对齐，卡片宽度一致，任意相邻列仍保留一个完整网格间距。
- 移除对 `ViewHolder.getBindingAdapterPosition()` 的依赖，避免刷新可见卡片时因瞬时 `NO_POSITION` 造成布局不一致。
- 更新 TMDB 详情布局与适配器测试契约，明确使用逻辑 `start/end` 语义，保持 RTL 一致性。

## 验证

- `:app:testMobileArm64_v8aDebugUnitTest --tests com.fongmi.android.tv.ui.adapter.TmdbEpisodeAdapterTest --tests com.fongmi.android.tv.ui.activity.TmdbDetailActivityLayoutTest`
  - 134 项通过，0 项失败。
- `git diff --check` 通过。

## 兼容性

- 列表模式仍使用原有的 `start = 0`、`end = 12dp` 布局规则；本次仅调整网格横向间距策略。
