### PR TITLE
修复 TV 关于页面焦点导航与高亮

### DIFF
--- a/app/src/main/res/color/about_primary_action_bg.xml
+++ b/app/src/main/res/color/about_primary_action_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="#0B57D0" android:state_focused="true" />
+    <item android:color="#0B57D0" android:state_pressed="true" />
+    <item android:alpha="0.38" android:color="#E8F0FE" android:state_enabled="false" />
+    <item android:color="#E8F0FE" />
+</selector>

--- a/app/src/main/res/color/about_primary_action_text.xml
+++ b/app/src/main/res/color/about_primary_action_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.42" android:color="#174EA6" android:state_enabled="false" />
+    <item android:color="#FFFFFF" android:state_focused="true" />
+    <item android:color="#FFFFFF" android:state_pressed="true" />
+    <item android:color="#174EA6" />
+</selector>

--- a/app/src/main/res/color/about_primary_icon_tint.xml
+++ b/app/src/main/res/color/about_primary_icon_tint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="#FFFFFF" android:state_focused="true" />
+    <item android:color="#FFFFFF" android:state_pressed="true" />
+    <item android:color="#5F6368" />
+</selector>

--- a/app/src/main/res/drawable/about_primary_icon_button.xml
+++ b/app/src/main/res/drawable/about_primary_icon_button.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#0B57D0" />
+            <corners android:radius="18dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#0B57D0" />
+            <corners android:radius="18dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/transparent" />
+            <corners android:radius="18dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -103,9 +103,9 @@
                 android:layout_weight="1"
                 android:minHeight="44dp"
                 android:text="@string/about_check_update"
-                android:textColor="@color/dialog_tonal_button_text"
+                android:textColor="@color/about_primary_action_text"
                 android:textSize="14sp"
-                app:backgroundTint="@color/dialog_tonal_button_bg"
+                app:backgroundTint="@color/about_primary_action_bg"
                 app:cornerRadius="8dp" />
 
             <com.google.android.material.button.MaterialButton
@@ -117,9 +117,9 @@
                 android:minHeight="44dp"
                 android:nextFocusUp="@id/checkUpdate"
                 android:text="@string/setting_github_proxy_short"
-                android:textColor="@color/dialog_tonal_button_text"
+                android:textColor="@color/about_primary_action_text"
                 android:textSize="14sp"
-                app:backgroundTint="@color/dialog_tonal_button_bg"
+                app:backgroundTint="@color/about_primary_action_bg"
                 app:cornerRadius="8dp" />
 
         </androidx.appcompat.widget.LinearLayoutCompat>
@@ -144,11 +144,11 @@
             android:layout_height="44dp"
             android:layout_gravity="end"
             android:layout_marginTop="10dp"
-            android:background="@drawable/selector_dialog_step_button"
+            android:background="@drawable/about_primary_icon_button"
             android:contentDescription="@string/update_settings"
             android:padding="10dp"
             android:src="@drawable/ic_remote_settings"
-            app:tint="#5F6368" />
+            app:tint="@color/about_primary_icon_tint" />
 
     </androidx.appcompat.widget.LinearLayoutCompat>
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -115,6 +115,7 @@
                 android:layout_height="44dp"
                 android:layout_weight="1"
                 android:minHeight="44dp"
+                android:nextFocusUp="@id/checkUpdate"
                 android:text="@string/setting_github_proxy_short"
                 android:textColor="@color/dialog_tonal_button_text"
                 android:textSize="14sp"

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -131,6 +131,7 @@
             android:layout_height="44dp"
             android:layout_marginTop="10dp"
             android:minHeight="44dp"
+            android:nextFocusUp="@id/checkUpdate"
             android:text="@string/about_acknowledge"
             android:textColor="@color/dialog_primary_button_text"
             android:textSize="14sp"


### PR DESCRIPTION
## 变更说明

- 修复关于页面“检查更新”的上键焦点导航
- 修复“我已知悉”按钮的上键焦点导航
- 增强关于页面主要按钮和设置图标的 TV 焦点高亮反馈

## 评审结果

- 已复核远端 beta 最新提交，当前 beta 提交已包含在 dev3 历史中，无合并冲突
- 已复评 beta 之后的全部 3 个提交及其最终差异，未发现新的任务范围内问题
- Android Leanback arm64 资源处理成功
- 任务涉及的 5 个资源文件无 Lint 告警或错误
- 项目全量 Lint 仍被既有的非本任务问题阻断，首个问题位于 KaraokeMicRecorder.java:114，未纳入本次修复范围

## 验证

- `:app:processLeanbackArm64_v8aDebugResources` 通过
- `:app:lintLeanbackArm64_v8aDebug` 执行完成分析，任务范围内无发现；全局因既有 153 个错误失败