### PR TITLE
合并 beta 最新代码并完成 dev2 复评（2026-09-12）

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -2031,7 +2031,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.subtitle.setTextSize(compact ? 13f : 14f);
         binding.overview.setTextSize(compact ? 14.5f : 16f);
         binding.overview.setLineSpacing(ResUtil.dp2px(compact ? 4 : 3), 1f);
-        TmdbDetailLayoutUtils.setHeightDp(binding.episodePhotoList, compact ? 128 : 160);
+        // 剧照卡片固定为 124dp 高；容器保持同高，避免大屏剧幕主题在剧照与下一栏之间留下额外空白。
+        TmdbDetailLayoutUtils.setHeightDp(binding.episodePhotoList, 124);
         TmdbDetailLayoutUtils.setHeightDp(binding.castList, compact ? 90 : 90);
         TmdbDetailLayoutUtils.setHeightDp(binding.creatorList, compact ? 90 : 90);
         TmdbDetailLayoutUtils.setHeightDp(binding.relatedList, compact ? 160 : 160);

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -24,6 +24,15 @@ public class TmdbDetailActivityLayoutTest {
     }
 
     @Test
+    public void cinemaPhotoRailMatchesItsCardHeightSoFollowingRailsKeepTheSharedSectionGap() throws Exception {
+        String source = readJava("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java");
+        String cinemaTemplate = javaBlockAt(source, "private void applyCinemaDetailTemplate()");
+
+        assertTrue("cinema still cards are 124dp high, so their rail must not reserve a larger empty bottom area before posters",
+                cinemaTemplate.contains("TmdbDetailLayoutUtils.setHeightDp(binding.episodePhotoList, 124);"));
+    }
+
+    @Test
     public void seasonSourceRoutesRefreshAndCarrySnapshotSelection() throws Exception {
         Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
         String source = Files.readString(sourcePath, StandardCharsets.UTF_8);

--- a/docs/beta-sync-review-dev2-20260912.md
+++ b/docs/beta-sync-review-dev2-20260912.md
@@ -95,12 +95,20 @@
 
 回滚方式：提交前执行 `git merge --abort`；提交后使用本任务创建的 annotated recovery tag，或对合并提交执行 `git revert -m 1 <merge-commit>`。
 
+## 关闭记录（2026-09-12 13:50 CST）
+
+- 原子合并提交：`4353f020eb541ee74a2be98f1b5ce20eef3f4021`（`merge: 合并 beta 最新代码并完成 dev2 复评 (2026-09-12)`）。
+- 原始任务恢复标签：`recovery/beta-sync-review-dev2-20260912/20260912134415-4353f020eb54`，已推送。
+- `dev2` 已推送至 `origin`；在首次 PR 创建失败后，使用显式 head `Silent1566:dev2` 成功创建中文 PR [#258](https://github.com/Silent1566/webhtv/pull/258)，目标分支为 `beta`。
+- 最终 `git fetch --prune origin && git pull --ff-only origin dev2` 返回 `Already up to date`；当时 `HEAD == origin/dev2 == 4353f020eb541ee74a2be98f1b5ce20eef3f4021`，`origin/beta == 7c325e4a04891fc1df224d359039998500ec4235`。
+- GitHub 最终核对：PR #258 为 `OPEN`、非草稿、`mergeStateStatus=CLEAN`，head 为 `dev2@4353f020eb541ee74a2be98f1b5ce20eef3f4021`，base 为 `beta@7c325e4a04891fc1df224d359039998500ec4235`；PR 包含本地 TMDB 修复和本次合并复评提交。
+
 ## 状态
 
 - [x] 拉取 `origin/beta` 最新代码并确认当前目标提交。
 - [x] 无冲突合并 beta。
 - [x] 评审 beta 增量和已提交未推送的本地 TMDB 改动。
 - [x] 完成移动端定向测试、Leanback 资源处理和验证后复评。
-- [ ] `task_guard.sh finish` 原子提交并创建恢复标签。
-- [ ] 推送 `dev2`/恢复标签并创建中文 PR 到 `beta`。
-- [ ] 最后拉取远端最新代码并核对交付状态。
+- [x] `task_guard.sh finish` 原子提交并创建恢复标签。
+- [x] 推送 `dev2`/恢复标签并创建中文 PR 到 `beta`。
+- [x] 最后拉取远端最新代码并核对交付状态。


### PR DESCRIPTION
## 变更说明
- 合并 `origin/beta` 最新代码，修复 TV 关于页焦点导航与聚焦高亮。
- 保留并复评 dev2 已提交未推送的 TMDB 剧幕剧照栏 124dp 间距修复。
- 补充合并范围、提交台账、评审结论、验证边界与回滚方式。

## 评审结论
- 合并无冲突，最终复评通过，无需额外代码修复。
- beta 新增的 `dialog_about.xml` 及 4 个 selector 资源已检查焦点目标、点击监听、资源引用和 XML 语法。
- 既有 beta 评审覆盖的历史提交均已确认进入最终树，唯一本地差异为 TMDB 剧照栏修复。

## 验证
- `:app:processMobileArm64_v8aDebugResources`：通过。
- `AboutDialogLayoutTest`：10 项通过。
- `TmdbDetailActivityLayoutTest`：121 项通过。
- `:app:processLeanbackArm64_v8aDebugResources`：通过。
- 5 个受影响 XML：Python XML 解析通过。
- 真实设备遥控器焦点与视觉验收未执行，详见任务文档验证边界。

任务提交：`4353f020eb541ee74a2be98f1b5ce20eef3f4021`
恢复标签：`recovery/beta-sync-review-dev2-20260912/20260912134415-4353f020eb54`