### PR TITLE
合并 beta 最新代码并完成 dev1 全量复评（2026-09-12）

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -2930,7 +2930,7 @@ private long mInitialPlaybackPosition = C.TIME_UNSET;
     }
 
     private boolean isShortDramaQueueEligible(Result result) {
-        if (!PlaybackExperimentSetting.isDomainEnabled(PlaybackExperimentPolicy.Domain.EXO)) return false;
+        if (!PlaybackExperimentSetting.isAllowed(PlaybackExperimentPolicy.Action.EXO_SHORT_DRAMA_QUEUE)) return false;
         if (!isShortDramaSource() || service() == null || player() == null || !player().isExo()
                 || !player().supportsPlaylistQueue() || !PreloadSetting.isPreload(PlayerSetting.EXO)) return false;
         if (MultiThreadProxySetting.get().enabled() || player().isRepeatOne() || mHistory == null

--- a/app/src/main/java/com/fongmi/android/tv/player/PlaybackExperimentPolicy.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlaybackExperimentPolicy.java
@@ -122,6 +122,8 @@ public final class PlaybackExperimentPolicy {
                 Risk.STABLE_BASELINE, 1),
         EXO_AUTO_PRELOAD("exo.auto-preload", Domain.EXO,
                 Risk.AUTOMATIC_OPTIMIZATION, 1),
+        EXO_SHORT_DRAMA_QUEUE("exo.short-drama-queue", Domain.EXO,
+                Risk.AUTOMATIC_OPTIMIZATION, 2),
         EXO_NETWORK_SPEED("exo.network-speed", Domain.EXO,
                 Risk.AUTOMATIC_OPTIMIZATION, 1),
         EXO_RTSP_RECOVERY("exo.rtsp-recovery", Domain.EXO,

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -2032,8 +2032,10 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.overview.setTextSize(compact ? 14.5f : 16f);
         binding.overview.setLineSpacing(ResUtil.dp2px(compact ? 4 : 3), 1f);
         TmdbDetailLayoutUtils.setHeightDp(binding.episodePhotoList, compact ? 128 : 160);
-        // 光影剧幕的大屏海报沿用卡片圆角，避免主题模板把海报显示成直角。
-        if (!compact) binding.posterList.setClipToOutline(true);
+        // 海报卡片本体为 148x222dp，列表额外保留焦点放大空间，确保完整显示四角圆角。
+        TmdbDetailLayoutUtils.setHeightDp(binding.posterList, 238);
+        binding.posterList.setClipToOutline(false);
+        binding.posterList.setClipChildren(false);
         TmdbDetailLayoutUtils.setHeightDp(binding.castList, compact ? 90 : 90);
         TmdbDetailLayoutUtils.setHeightDp(binding.creatorList, compact ? 90 : 90);
         TmdbDetailLayoutUtils.setHeightDp(binding.relatedList, compact ? 160 : 160);

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivity.java
@@ -2032,6 +2032,8 @@ public class TmdbDetailActivity extends PlaybackActivity implements TrackDialog.
         binding.overview.setTextSize(compact ? 14.5f : 16f);
         binding.overview.setLineSpacing(ResUtil.dp2px(compact ? 4 : 3), 1f);
         TmdbDetailLayoutUtils.setHeightDp(binding.episodePhotoList, compact ? 128 : 160);
+        // 光影剧幕的大屏海报沿用卡片圆角，避免主题模板把海报显示成直角。
+        if (!compact) binding.posterList.setClipToOutline(true);
         TmdbDetailLayoutUtils.setHeightDp(binding.castList, compact ? 90 : 90);
         TmdbDetailLayoutUtils.setHeightDp(binding.creatorList, compact ? 90 : 90);
         TmdbDetailLayoutUtils.setHeightDp(binding.relatedList, compact ? 160 : 160);

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/VideoActivity.java
@@ -2591,7 +2591,7 @@ private final Task.Scope mPersonalRecommendationTasks = new Task.Scope(Task.reco
     }
 
     private boolean isShortDramaQueueEligible(Result result) {
-        if (!PlaybackExperimentSetting.isDomainEnabled(PlaybackExperimentPolicy.Domain.EXO)) return false;
+        if (!PlaybackExperimentSetting.isAllowed(PlaybackExperimentPolicy.Action.EXO_SHORT_DRAMA_QUEUE)) return false;
         if (!isShortDramaSource() || service() == null || player() == null || !player().isExo()
                 || !player().supportsPlaylistQueue() || !PreloadSetting.isPreload(PlayerSetting.EXO)) return false;
         if (MultiThreadProxySetting.get().enabled() || player().isRepeatOne() || mHistory == null

--- a/app/src/test/java/com/fongmi/android/tv/player/PlaybackExperimentPolicyTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/player/PlaybackExperimentPolicyTest.java
@@ -60,6 +60,8 @@ public class PlaybackExperimentPolicyTest {
         assertTrue(state.allows(
                 PlaybackExperimentPolicy.Action.EXO_AUTO_PRELOAD));
         assertTrue(state.allows(
+                PlaybackExperimentPolicy.Action.EXO_SHORT_DRAMA_QUEUE));
+        assertTrue(state.allows(
                 PlaybackExperimentPolicy.Action.MPV_HLS_RUNTIME_RELOAD));
         assertTrue(state.allows(
                 PlaybackExperimentPolicy.Action.IJK_DECODE_REBUILD));

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -14,12 +14,14 @@ import static org.junit.Assert.assertTrue;
 public class TmdbDetailActivityLayoutTest {
 
     @Test
-    public void cinemaPosterRailKeepsRoundedOutlineOnLargeScreens() throws Exception {
+    public void cinemaPosterRailLeavesRoomForTheFullRoundedPosterCard() throws Exception {
         String source = readJava("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java");
         String cinemaTemplate = javaBlockAt(source, "private void applyCinemaDetailTemplate()");
 
-        assertTrue("large-screen cinema posters must keep their rounded card outline",
-                cinemaTemplate.contains("if (!compact) binding.posterList.setClipToOutline(true);"));
+        assertTrue("the poster rail must leave room for the full 222dp rounded card and focus scaling",
+                cinemaTemplate.contains("TmdbDetailLayoutUtils.setHeightDp(binding.posterList, 238);")
+                        && cinemaTemplate.contains("binding.posterList.setClipToOutline(false);")
+                        && cinemaTemplate.contains("binding.posterList.setClipChildren(false);"));
     }
 
     @Test

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/activity/TmdbDetailActivityLayoutTest.java
@@ -14,6 +14,15 @@ import static org.junit.Assert.assertTrue;
 public class TmdbDetailActivityLayoutTest {
 
     @Test
+    public void cinemaPosterRailKeepsRoundedOutlineOnLargeScreens() throws Exception {
+        String source = readJava("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java");
+        String cinemaTemplate = javaBlockAt(source, "private void applyCinemaDetailTemplate()");
+
+        assertTrue("large-screen cinema posters must keep their rounded card outline",
+                cinemaTemplate.contains("if (!compact) binding.posterList.setClipToOutline(true);"));
+    }
+
+    @Test
     public void seasonSourceRoutesRefreshAndCarrySnapshotSelection() throws Exception {
         Path sourcePath = findMainJavaPath().resolve(Path.of("com", "fongmi", "android", "tv", "ui", "activity", "TmdbDetailActivity.java"));
         String source = Files.readString(sourcePath, StandardCharsets.UTF_8);

--- a/docs/E-SP8-exo-short-drama-queue.md
+++ b/docs/E-SP8-exo-short-drama-queue.md
@@ -415,3 +415,11 @@ startup／seek、重缓冲和稳定播放质量不得发生可重复的实质退
 - 当前状态：**E-SP8 代码实现和合并后源码复评通过；实验默认策略及正式放量前的连续切集、网络争用、字幕/弹幕和 Leanback 实机验收仍保持未完成。**
 - 回滚：代码层面可使用已有 E-SP8 recovery tag；当前 beta 合并提交完成后另以本 task 的 recovery tag 回滚整合层。
 - **唯一下一步：完成 `beta-sync-review-dev1-20260911` 的 merge commit/tag，推送 `dev1` 并创建目标为 `beta` 的中文 PR。**
+
+## Recovery anchor（2026-09-12 01:00 Asia/Shanghai）
+
+- 现场根因：短剧队列资格错误使用 `isDomainEnabled(EXO)`，这会在稳定策略默认关闭内部实验时直接拒绝队列，因此用户无法看到下一集预解析、播放列表追加和受控预载。
+- 修复：新增生产自动优化动作 `EXO_SHORT_DRAMA_QUEUE`，Mobile 与 Leanback 改为通过 `isAllowed(EXO_SHORT_DRAMA_QUEUE)` 准入；安全条件、短剧源识别、Exo、预载设置、协议及恢复位置等既有门槛保持不变。
+- 非目标保持不变：不会把多个剧集文件合并成一个文件；增强路径仍使用两个独立 MediaItem 的有界播放列表。
+- 验证结果：`testMobileArm64_v8aDebugUnitTest` 中的 `PlaybackExperimentPolicyTest` 与 `ShortDramaQueueCoordinatorTest` 通过，Mobile 与 Leanback Arm64_v8a Debug Java 编译通过；Gradle 报告 `BUILD SUCCESSFUL in 20s`，仅有既有 CXX5202 与弃用 API 警告。
+- 唯一下一步：执行 task guard 检查并提交本次准入修复；真实设备连续切集、网络争用、字幕与弹幕时序仍须后续验收。

--- a/scripts/build_arm64_debug_install.sh
+++ b/scripts/build_arm64_debug_install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# 打包 Mobile Arm64_v8a Debug APK 并推送到 Android 模拟器/设备。
+# 用法:
+#   bash scripts/build_arm64_debug_install.sh [--serial 192.168.50.3:5555] [--adb /path/to/adb] [--skip-check]
+# 示例:
+#   bash scripts/build_arm64_debug_install.sh
+#   bash scripts/build_arm64_debug_install.sh --serial 192.168.50.3:5559
+#
+# 流程: 检查 Gradle 守护进程是否空闲 -> 打包 :app:assembleMobileArm64_v8aDebug
+#       -> adb 连接/安装 -> 校验模拟器上包存在。
+
+set -euo pipefail
+
+SERIAL="192.168.50.3:5555"
+ADB=""
+SKIP_IDLE_CHECK=0
+
+usage() {
+  sed -n '2,9p' "$0" | sed 's/^# //; s/^#$//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s|--serial) SERIAL="${2:?missing serial}"; shift 2 ;;
+    -a|--adb) ADB="${2:?missing adb path}"; shift 2 ;;
+    --skip-check) SKIP_IDLE_CHECK=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "未知参数: $1" >&2; usage ;;
+  esac
+done
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$ROOT_DIR"
+
+if [[ -z "$ADB" ]]; then
+  for candidate in \
+    "$HOME/android-sdk/platform-tools/adb" \
+    "$HOME/Android/Sdk/platform-tools/adb" \
+    "/usr/local/android-sdk/platform-tools/adb" \
+    "adb"; do
+    if command -v "$candidate" >/dev/null 2>&1 || [[ -x "$candidate" ]]; then
+      ADB="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$ADB" ]]; then
+  echo "❌ 未找到 adb，请用 --adb 指定路径" >&2
+  exit 1
+fi
+
+echo "==> adb: $ADB"
+echo "==> 设备: $SERIAL"
+
+if [[ "$SKIP_IDLE_CHECK" -eq 0 ]]; then
+  echo "==> 检查 Gradle 守护进程是否空闲（避免与其他打包任务冲突）..."
+  STATUS_OUTPUT="$(./gradlew --status 2>&1 || true)"
+  BUSY_PIDS="$(echo "$STATUS_OUTPUT" | awk '$2 == "BUSY" {print $1}')"
+  if [[ -n "$BUSY_PIDS" ]]; then
+    echo "❌ 检测到 Gradle 守护进程正在忙（PID: $BUSY_PIDS），可能有其他打包任务在进行。" >&2
+    echo "   请等待其结束后再运行，或用 --skip-check 跳过此检查。" >&2
+    exit 1
+  fi
+  echo "==> Gradle 守护进程空闲，可以开始打包"
+fi
+
+echo "==> 开始打包 :app:assembleMobileArm64_v8aDebug ..."
+./gradlew :app:assembleMobileArm64_v8aDebug
+
+APK="app/build/outputs/apk/mobileArm64_v8a/debug/app-mobile-arm64_v8a-debug.apk"
+if [[ ! -f "$APK" ]]; then
+  echo "❌ 打包结束但未找到 APK: $APK" >&2
+  exit 1
+fi
+echo "==> APK: $APK ($(du -h "$APK" | cut -f1))"
+
+echo "==> 连接设备 $SERIAL ..."
+"$ADB" connect "$SERIAL" >/dev/null 2>&1 || true
+
+echo "==> 安装 APK 到 $SERIAL ..."
+"$ADB" -s "$SERIAL" install -r "$APK"
+
+echo "==> 校验安装 ..."
+PKG="com.silent.android.webhtv"
+if "$ADB" -s "$SERIAL" shell "pm list packages | grep -q '$PKG'"; then
+  echo "✅ 安装成功: $PKG 已存在于 $SERIAL"
+else
+  echo "❌ 安装后未在设备上找到 $PKG" >&2
+  exit 1
+fi
+
+echo "✅ 全部完成: 打包并安装到 $SERIAL"

--- a/scripts/build_arm64_debug_install.sh
+++ b/scripts/build_arm64_debug_install.sh
@@ -1,34 +1,68 @@
 #!/usr/bin/env bash
-# 打包 Mobile Arm64_v8a Debug APK 并推送到 Android 模拟器/设备。
-# 用法:
-#   bash scripts/build_arm64_debug_install.sh [--serial 192.168.50.3:5555] [--adb /path/to/adb] [--skip-check]
-# 示例:
-#   bash scripts/build_arm64_debug_install.sh
-#   bash scripts/build_arm64_debug_install.sh --serial 192.168.50.3:5559
+# 打包指定 flavor (mobile/leanback) 的 Debug APK 并推送到 Android 模拟器/设备。
 #
-# 流程: 检查 Gradle 守护进程是否空闲 -> 打包 :app:assembleMobileArm64_v8aDebug
+# 用法:
+#   bash scripts/build_arm64_debug_install.sh [--flavor mobile|leanback]
+#                                            [--abi arm64-v8a|armeabi-v7a]
+#                                            [--serial 192.168.50.3:5555]
+#                                            [--adb /path/to/adb]
+#                                            [--skip-check]
+# 示例:
+#   bash scripts/build_arm64_debug_install.sh                      # 手机版 arm64
+#   bash scripts/build_arm64_debug_install.sh --flavor leanback    # TV/电脑版 arm64
+#   bash scripts/build_arm64_debug_install.sh --flavor leanback --serial 192.168.50.3:5559
+#
+# 流程: 检查 Gradle 守护进程是否空闲 -> gradlew assemble<Flavor><Abi>Debug
 #       -> adb 连接/安装 -> 校验模拟器上包存在。
+# 手机版 package 为 com.silent.android.webhtv，TV/电脑版(leanback) 同用该包名。
 
 set -euo pipefail
 
+FLAVOR="mobile"
+ABI="arm64-v8a"
 SERIAL="192.168.50.3:5555"
 ADB=""
 SKIP_IDLE_CHECK=0
 
 usage() {
-  sed -n '2,9p' "$0" | sed 's/^# //; s/^#$//'
+  sed -n '3,14p' "$0" | sed 's/^# //; s/^#$//'
   exit 0
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    -f|--flavor) FLAVOR="${2:?missing flavor}"; shift 2 ;;
+    -a|--abi) ABI="${2:?missing abi}"; shift 2 ;;
     -s|--serial) SERIAL="${2:?missing serial}"; shift 2 ;;
-    -a|--adb) ADB="${2:?missing adb path}"; shift 2 ;;
+    --adb) ADB="${2:?missing adb path}"; shift 2 ;;
     --skip-check) SKIP_IDLE_CHECK=1; shift ;;
     -h|--help) usage ;;
     *) echo "未知参数: $1" >&2; usage ;;
   esac
 done
+
+case "$FLAVOR" in
+  mobile|leanback) ;;
+  *) echo "❌ --flavor 只能是 mobile 或 leanback" >&2; usage ;;
+esac
+
+case "$ABI" in
+  arm64-v8a|armeabi-v7a) ;;
+  *) echo "❌ --abi 只能是 arm64-v8a 或 armeabi-v7a" >&2; usage ;;
+esac
+
+# 组装 Gradle flavor/ABI 名
+case "$FLAVOR" in
+  mobile)   FLAVOR_GRADLE="Mobile" ;;
+  leanback) FLAVOR_GRADLE="Leanback" ;;
+esac
+case "$ABI" in
+  arm64-v8a)   ABI_GRADLE="Arm64_v8a";   ABISUFFIX="arm64_v8a" ;;
+  armeabi-v7a) ABI_GRADLE="Armeabi_v7a"; ABISUFFIX="armeabi_v7a" ;;
+esac
+TASK=":app:assemble${FLAVOR_GRADLE}${ABI_GRADLE}Debug"
+APK="app/build/outputs/apk/${FLAVOR}${ABI_GRADLE}/debug/app-${FLAVOR}-${ABISUFFIX}-debug.apk"
+
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "$ROOT_DIR"
@@ -50,6 +84,7 @@ if [[ -z "$ADB" ]]; then
   exit 1
 fi
 
+echo "==> 构建类型: ${FLAVOR}/${ABI} Debug"
 echo "==> adb: $ADB"
 echo "==> 设备: $SERIAL"
 
@@ -65,10 +100,9 @@ if [[ "$SKIP_IDLE_CHECK" -eq 0 ]]; then
   echo "==> Gradle 守护进程空闲，可以开始打包"
 fi
 
-echo "==> 开始打包 :app:assembleMobileArm64_v8aDebug ..."
-./gradlew :app:assembleMobileArm64_v8aDebug
+echo "==> 开始打包 $TASK ..."
+./gradlew "$TASK"
 
-APK="app/build/outputs/apk/mobileArm64_v8a/debug/app-mobile-arm64_v8a-debug.apk"
 if [[ ! -f "$APK" ]]; then
   echo "❌ 打包结束但未找到 APK: $APK" >&2
   exit 1
@@ -90,4 +124,4 @@ else
   exit 1
 fi
 
-echo "✅ 全部完成: 打包并安装到 $SERIAL"
+echo "✅ 全部完成: ${FLAVOR}/${ABI} Debug 打包并安装到 $SERIAL"


### PR DESCRIPTION
## 概要

- 合并 `origin/beta@81435e97eafabd64727412169ead107687f7325c` 到 `dev1`。
- 解决 `TmdbDetailActivity.java` 与 `TmdbDetailActivityLayoutTest.java` 两处冲突，同时保留 beta 的剧照栏 124dp 修复和 dev1 的海报完整圆角显示修复。
- 复评 beta 增量及 dev1 已提交未推送改动，未发现需要追加修复的问题。

## 验证

- Mobile 定向测试共 159 项通过，0 failures、0 errors、0 skipped。
- Mobile/Leanback Arm64 Debug Java 编译通过。
- XML 语法解析、`git diff --cached --check`、冲突标记检查及 task guard 检查通过。
- Leanback 单测任务仅因过滤器指定了不存在于该 source set 的 `LiveActivityLayoutTest` 而报告 `No tests found`，已确认该测试位于 Mobile source set 且已通过，不属于代码回归。

## 风险边界

尚未执行真实电视遥控器逐键焦点验收，以及短剧连续切集、网络争用、字幕和弹幕时序的实机验收。

## 回滚

恢复标签：`recovery/beta-sync-review-dev1-20260912/20260912143201-f1c15ef02560`。