### PR TITLE
合并 dev4：统一分集客串演员卡片并稳定移动端滚动

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
@@ -393,6 +393,7 @@ public class EpisodeDetailDialog {
 
                             TmdbPersonAdapter guestAdapter = new TmdbPersonAdapter(person -> TmdbPersonDialog.show(activity, person, site));
                             guestAdapter.setLight(light);
+                            guestAdapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());
                             guestAdapter.setItems(guests);
                             guestsGrid.setAdapter(guestAdapter);
                         }
@@ -449,6 +450,7 @@ public class EpisodeDetailDialog {
 
             TmdbPersonAdapter guestAdapter = new TmdbPersonAdapter(person -> TmdbPersonDialog.show(activity, person, null));
             guestAdapter.setLight(light);
+            guestAdapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());
             guestAdapter.setItems(guests);
             guestsGrid.setAdapter(guestAdapter);
         } else {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
@@ -389,11 +389,13 @@ public class EpisodeDetailDialog {
                             guestsLabel.setVisibility(View.VISIBLE);
                             guestsGrid.setVisibility(View.VISIBLE);
                             guestsGrid.setHorizontalSpacing(ResUtil.dp2px(12));
-                            guestsGrid.setRowHeight(ResUtil.dp2px(154));
+                            boolean cinema = Setting.isTmdbCinemaStyle();
+                            guestsGrid.setRowHeight(ResUtil.dp2px(cinema ? 90 : 154));
+                            if (cinema) resizeGuestGrid(guestsGrid);
 
                             TmdbPersonAdapter guestAdapter = new TmdbPersonAdapter(person -> TmdbPersonDialog.show(activity, person, site));
                             guestAdapter.setLight(light);
-                            guestAdapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());
+                            guestAdapter.setCinema(cinema);
                             guestAdapter.setItems(guests);
                             guestsGrid.setAdapter(guestAdapter);
                         }
@@ -446,17 +448,25 @@ public class EpisodeDetailDialog {
             guestsLabel.setVisibility(View.VISIBLE);
             guestsGrid.setVisibility(View.VISIBLE);
             guestsGrid.setHorizontalSpacing(ResUtil.dp2px(12));
-            guestsGrid.setRowHeight(ResUtil.dp2px(154));
+            boolean cinema = Setting.isTmdbCinemaStyle();
+            guestsGrid.setRowHeight(ResUtil.dp2px(cinema ? 90 : 154));
+            if (cinema) resizeGuestGrid(guestsGrid);
 
             TmdbPersonAdapter guestAdapter = new TmdbPersonAdapter(person -> TmdbPersonDialog.show(activity, person, null));
             guestAdapter.setLight(light);
-            guestAdapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());
+            guestAdapter.setCinema(cinema);
             guestAdapter.setItems(guests);
             guestsGrid.setAdapter(guestAdapter);
         } else {
             guestsLabel.setVisibility(View.GONE);
             guestsGrid.setVisibility(View.GONE);
         }
+    }
+
+    private static void resizeGuestGrid(androidx.leanback.widget.HorizontalGridView guestsGrid) {
+        ViewGroup.LayoutParams params = guestsGrid.getLayoutParams();
+        params.height = ResUtil.dp2px(104);
+        guestsGrid.setLayoutParams(params);
     }
 
     /**

--- a/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbPersonAdapter.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbPersonAdapter.java
@@ -1,8 +1,10 @@
 package com.fongmi.android.tv.ui.adapter;
 
 import android.view.LayoutInflater;
+import android.graphics.Outline;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewOutlineProvider;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
@@ -18,6 +20,15 @@ import java.util.List;
 
 public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.ViewHolder> {
 
+    private static final int PHOTO_CORNER_RADIUS_DP = 14;
+    private static final ViewOutlineProvider ROUNDED_PHOTO_OUTLINE = new ViewOutlineProvider() {
+        @Override
+        public void getOutline(View view, Outline outline) {
+            float cornerRadius = PHOTO_CORNER_RADIUS_DP * view.getResources().getDisplayMetrics().density;
+            outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), cornerRadius);
+        }
+    };
+
     public interface Listener {
         void onItemClick(TmdbPerson item);
     }
@@ -26,6 +37,7 @@ public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.Vi
     private final List<TmdbPerson> items = new ArrayList<>();
     private boolean cinema;
     private boolean light;
+    private boolean roundedPhoto;
 
     public TmdbPersonAdapter(Listener listener) {
         this.listener = listener;
@@ -59,6 +71,13 @@ public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.Vi
 
     public void setLight(boolean light) {
         this.light = light;
+        notifyDataSetChanged();
+    }
+
+    /** Keeps the episode-detail portrait separate from its label with four matching rounded corners. */
+    public void setRoundedPhoto(boolean roundedPhoto) {
+        if (this.roundedPhoto == roundedPhoto) return;
+        this.roundedPhoto = roundedPhoto;
         notifyDataSetChanged();
     }
 
@@ -108,6 +127,7 @@ public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.Vi
         holder.binding.name.setTextSize(cinema ? 17f : 12f);
         holder.binding.subtitle.setTextSize(cinema ? 13f : 10f);
         holder.binding.subtitle.setMaxLines(cinema ? 1 : 2);
+        holder.binding.photo.setOutlineProvider(roundedPhoto ? ROUNDED_PHOTO_OUTLINE : ViewOutlineProvider.BACKGROUND);
         holder.binding.photo.setClipToOutline(true);
         if (cinema) holder.binding.photo.setBackgroundColor(TmdbCinemaTheme.palette(light).imagePlaceholder());
     }

--- a/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbPersonAdapter.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/adapter/TmdbPersonAdapter.java
@@ -1,10 +1,8 @@
 package com.fongmi.android.tv.ui.adapter;
 
 import android.view.LayoutInflater;
-import android.graphics.Outline;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewOutlineProvider;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
@@ -20,15 +18,6 @@ import java.util.List;
 
 public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.ViewHolder> {
 
-    private static final int PHOTO_CORNER_RADIUS_DP = 14;
-    private static final ViewOutlineProvider ROUNDED_PHOTO_OUTLINE = new ViewOutlineProvider() {
-        @Override
-        public void getOutline(View view, Outline outline) {
-            float cornerRadius = PHOTO_CORNER_RADIUS_DP * view.getResources().getDisplayMetrics().density;
-            outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), cornerRadius);
-        }
-    };
-
     public interface Listener {
         void onItemClick(TmdbPerson item);
     }
@@ -37,7 +26,6 @@ public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.Vi
     private final List<TmdbPerson> items = new ArrayList<>();
     private boolean cinema;
     private boolean light;
-    private boolean roundedPhoto;
 
     public TmdbPersonAdapter(Listener listener) {
         this.listener = listener;
@@ -71,13 +59,6 @@ public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.Vi
 
     public void setLight(boolean light) {
         this.light = light;
-        notifyDataSetChanged();
-    }
-
-    /** Keeps the episode-detail portrait separate from its label with four matching rounded corners. */
-    public void setRoundedPhoto(boolean roundedPhoto) {
-        if (this.roundedPhoto == roundedPhoto) return;
-        this.roundedPhoto = roundedPhoto;
         notifyDataSetChanged();
     }
 
@@ -127,7 +108,6 @@ public class TmdbPersonAdapter extends RecyclerView.Adapter<TmdbPersonAdapter.Vi
         holder.binding.name.setTextSize(cinema ? 17f : 12f);
         holder.binding.subtitle.setTextSize(cinema ? 13f : 10f);
         holder.binding.subtitle.setMaxLines(cinema ? 1 : 2);
-        holder.binding.photo.setOutlineProvider(roundedPhoto ? ROUNDED_PHOTO_OUTLINE : ViewOutlineProvider.BACKGROUND);
         holder.binding.photo.setClipToOutline(true);
         if (cinema) holder.binding.photo.setBackgroundColor(TmdbCinemaTheme.palette(light).imagePlaceholder());
     }

--- a/app/src/main/res/layout/dialog_episode_detail.xml
+++ b/app/src/main/res/layout/dialog_episode_detail.xml
@@ -132,17 +132,6 @@
                 </LinearLayout>
             </androidx.core.widget.NestedScrollView>
 
-            <!-- 关闭按钮 -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/close"
-                style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:minHeight="48dp"
-                android:text="@string/dialog_negative"
-                android:textColor="#FFFFFF"
-                app:strokeColor="#4A4A4A" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 </FrameLayout>

--- a/app/src/main/res/layout/dialog_episode_detail.xml
+++ b/app/src/main/res/layout/dialog_episode_detail.xml
@@ -29,11 +29,12 @@
                 android:layout_height="0dp"
                 android:layout_weight="1"
                 android:fillViewport="false"
-                android:overScrollMode="ifContentScrolls">
+                android:overScrollMode="never">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingBottom="12dp"
                     android:orientation="vertical">
 
                     <!-- 剧照 -->

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
@@ -352,6 +352,7 @@ public class EpisodeDetailDialog {
             guestsList.setVisibility(View.VISIBLE);
             TmdbPersonAdapter adapter = new TmdbPersonAdapter(person -> TmdbPersonDialog.show(activity, person, null));
             adapter.setLight(light);
+            adapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());
             adapter.setItems(guests);
             guestsList.setAdapter(adapter);
         }

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
@@ -302,6 +302,8 @@ public class EpisodeDetailDialog {
 
     private static void bindHorizontalList(RecyclerView view, int spacingDp) {
         view.setLayoutManager(new LinearLayoutManager(view.getContext(), LinearLayoutManager.HORIZONTAL, false));
+        view.setNestedScrollingEnabled(false);
+        view.setOverScrollMode(View.OVER_SCROLL_NEVER);
         view.addItemDecoration(new RecyclerView.ItemDecoration() {
             @Override
             public void getItemOffsets(@NonNull android.graphics.Rect outRect, @NonNull View child, RecyclerView parent, @NonNull RecyclerView.State state) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java
@@ -2,7 +2,6 @@ package com.fongmi.android.tv.ui.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -31,7 +30,6 @@ import com.fongmi.android.tv.ui.adapter.EpisodeStillAdapter;
 import com.fongmi.android.tv.ui.adapter.TmdbPersonAdapter;
 import com.fongmi.android.tv.utils.ResUtil;
 import com.fongmi.android.tv.utils.Task;
-import com.google.android.material.button.MaterialButton;
 import com.google.android.material.card.MaterialCardView;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.gson.JsonObject;
@@ -93,7 +91,6 @@ public class EpisodeDetailDialog {
 
         Dialog dialog = new Dialog(activity, android.R.style.Theme_Black_NoTitleBar_Fullscreen);
         dialog.setContentView(view);
-        view.findViewById(R.id.close).setOnClickListener(v -> dialog.dismiss());
         if (dismissListener != null) dialog.setOnDismissListener(dismissListener);
         dialog.show();
         applyWindowSize(dialog);
@@ -171,7 +168,6 @@ public class EpisodeDetailDialog {
 
         Dialog dialog = new Dialog(activity, android.R.style.Theme_Black_NoTitleBar_Fullscreen);
         dialog.setContentView(view);
-        view.findViewById(R.id.close).setOnClickListener(v -> dialog.dismiss());
         if (dismissListener != null) dialog.setOnDismissListener(dismissListener);
         dialog.show();
         applyWindowSize(dialog);
@@ -281,7 +277,6 @@ public class EpisodeDetailDialog {
         TextView overview = view.findViewById(R.id.overview);
         TextView photoTitle = view.findViewById(R.id.photoTitle);
         TextView guestsTitle = view.findViewById(R.id.guestsTitle);
-        MaterialButton close = view.findViewById(R.id.close);
 
         int overlay = light ? 0x99F4F7FA : 0xB3000000;
         int panelColor = light ? 0xFFF4F7FA : 0xFF2A2A2A;
@@ -290,7 +285,6 @@ public class EpisodeDetailDialog {
         int secondary = light ? 0x9912202D : 0xFFAAAAAA;
         int body = light ? 0xCC12202D : 0xFFDDDDDD;
         int stroke = light ? 0x33424B57 : 0xFF4A4A4A;
-        int control = light ? 0xFFE7EDF3 : 0xFF2A2A2A;
 
         if (root != null) root.setBackgroundColor(overlay);
         if (panel != null) {
@@ -304,10 +298,6 @@ public class EpisodeDetailDialog {
         overview.setTextColor(body);
         photoTitle.setTextColor(primary);
         guestsTitle.setTextColor(primary);
-        close.setTextColor(primary);
-        close.setStrokeColor(ColorStateList.valueOf(stroke));
-        close.setBackgroundTintList(ColorStateList.valueOf(control));
-        close.setRippleColor(ColorStateList.valueOf(light ? 0x1F12202D : 0x33FFFFFF));
     }
 
     private static void bindHorizontalList(RecyclerView view, int spacingDp) {
@@ -352,7 +342,13 @@ public class EpisodeDetailDialog {
             guestsList.setVisibility(View.VISIBLE);
             TmdbPersonAdapter adapter = new TmdbPersonAdapter(person -> TmdbPersonDialog.show(activity, person, null));
             adapter.setLight(light);
-            adapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());
+            boolean cinema = Setting.isTmdbCinemaStyle();
+            adapter.setCinema(cinema);
+            if (cinema) {
+                ViewGroup.LayoutParams params = guestsList.getLayoutParams();
+                params.height = ResUtil.dp2px(104);
+                guestsList.setLayoutParams(params);
+            }
             adapter.setItems(guests);
             guestsList.setAdapter(adapter);
         }

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialogThemeTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialogThemeTest.java
@@ -64,6 +64,27 @@ public class EpisodeDetailDialogThemeTest {
     }
 
     @Test
+    public void cinemaEpisodeGuestCardsRoundPortraitsWithoutChangingTheirRailLayout() throws Exception {
+        String adapter = read(findMainJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "adapter", "TmdbPersonAdapter.java")));
+        String mobileDialog = read(findMobileJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "dialog", "EpisodeDetailDialog.java")));
+        String leanbackDialog = read(findLeanbackJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "dialog", "EpisodeDetailDialog.java")));
+
+        assertTrue("guest portraits need the same 14dp radius as their parent cards",
+                adapter.contains("private static final int PHOTO_CORNER_RADIUS_DP = 14;")
+                        && adapter.contains("outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), cornerRadius);"));
+        assertTrue("the portrait must use its own outline so the lower edge is clipped too",
+                adapter.contains("holder.binding.photo.setOutlineProvider(roundedPhoto ? ROUNDED_PHOTO_OUTLINE : ViewOutlineProvider.BACKGROUND);")
+                        && adapter.contains("holder.binding.photo.setClipToOutline(true);"));
+        assertTrue("mobile episode details must request rounded portraits only for the cinema-stage theme",
+                mobileDialog.contains("adapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());"));
+        assertTrue("both TV episode-media paths must request the cinema-stage rounded portrait treatment",
+                countOccurrences(leanbackDialog, "guestAdapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());") >= 2);
+    }
+
+    @Test
     public void tvEpisodePhotosUseUnifiedYellowFocusStrokeWithoutGrayOverlay() throws Exception {
         String adapter = read(findLeanbackJavaPath().resolve(Path.of(
                 "com", "fongmi", "android", "tv", "ui", "adapter", "EpisodePhotoAdapter.java")));
@@ -152,6 +173,18 @@ public class EpisodeDetailDialogThemeTest {
 
     private static String read(Path path) throws Exception {
         return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static Path findMainJavaPath() {
+        Path moduleRelative = Path.of("src", "main", "java");
+        if (Files.exists(moduleRelative)) return moduleRelative;
+        return Path.of("app", "src", "main", "java");
+    }
+
+    private static Path findMobileJavaPath() {
+        Path moduleRelative = Path.of("src", "mobile", "java");
+        if (Files.exists(moduleRelative)) return moduleRelative;
+        return Path.of("app", "src", "mobile", "java");
     }
 
     private static Path findLeanbackJavaPath() {

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialogThemeTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialogThemeTest.java
@@ -64,24 +64,35 @@ public class EpisodeDetailDialogThemeTest {
     }
 
     @Test
-    public void cinemaEpisodeGuestCardsRoundPortraitsWithoutChangingTheirRailLayout() throws Exception {
+    public void cinemaEpisodeGuestCardsReuseOuterHorizontalLayoutWithoutPhotoRounding() throws Exception {
         String adapter = read(findMainJavaPath().resolve(Path.of(
                 "com", "fongmi", "android", "tv", "ui", "adapter", "TmdbPersonAdapter.java")));
         String mobileDialog = read(findMobileJavaPath().resolve(Path.of(
                 "com", "fongmi", "android", "tv", "ui", "dialog", "EpisodeDetailDialog.java")));
         String leanbackDialog = read(findLeanbackJavaPath().resolve(Path.of(
                 "com", "fongmi", "android", "tv", "ui", "dialog", "EpisodeDetailDialog.java")));
+        String mobileLayout = read(findMainResPath().resolve(Path.of(
+                "layout", "dialog_episode_detail.xml")));
 
-        assertTrue("guest portraits need the same 14dp radius as their parent cards",
-                adapter.contains("private static final int PHOTO_CORNER_RADIUS_DP = 14;")
-                        && adapter.contains("outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), cornerRadius);"));
-        assertTrue("the portrait must use its own outline so the lower edge is clipped too",
-                adapter.contains("holder.binding.photo.setOutlineProvider(roundedPhoto ? ROUNDED_PHOTO_OUTLINE : ViewOutlineProvider.BACKGROUND);")
-                        && adapter.contains("holder.binding.photo.setClipToOutline(true);"));
-        assertTrue("mobile episode details must request rounded portraits only for the cinema-stage theme",
-                mobileDialog.contains("adapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());"));
-        assertTrue("both TV episode-media paths must request the cinema-stage rounded portrait treatment",
-                countOccurrences(leanbackDialog, "guestAdapter.setRoundedPhoto(Setting.isTmdbCinemaStyle());") >= 2);
+        assertTrue("cinema guest cards must reuse the outer actor rail's horizontal card geometry",
+                adapter.contains("params.width = dp(holder.itemView, cinema ? 250 : 90);")
+                        && adapter.contains("holder.binding.content.setOrientation(cinema ? LinearLayout.HORIZONTAL : LinearLayout.VERTICAL);")
+                        && adapter.contains("photoParams.width = dp(holder.itemView, cinema ? 86 : 90);")
+                        && adapter.contains("photoParams.height = dp(holder.itemView, cinema ? 86 : 118);"));
+        assertFalse("guest photos must not receive an independent rounded outline",
+                adapter.contains("setRoundedPhoto") || adapter.contains("ROUNDED_PHOTO_OUTLINE")
+                        || adapter.contains("setOutlineProvider"));
+        assertTrue("mobile episode guest cards must switch to the outer actor rail layout only in cinema style",
+                mobileDialog.contains("adapter.setCinema(cinema);")
+                        && mobileDialog.contains("boolean cinema = Setting.isTmdbCinemaStyle();")
+                        && mobileDialog.contains("params.height = ResUtil.dp2px(104);"));
+        assertTrue("both TV episode-media paths must switch guest cards to the cinema layout",
+                countOccurrences(leanbackDialog, "guestAdapter.setCinema(cinema);") >= 2
+                        && leanbackDialog.contains("guestsGrid.setRowHeight(ResUtil.dp2px(cinema ? 90 : 154));")
+                        && leanbackDialog.contains("params.height = ResUtil.dp2px(104);"));
+        assertFalse("the mobile episode detail must not render a cancel button",
+                mobileLayout.contains("android:id=\"@+id/close\"")
+                        || mobileDialog.contains("R.id.close"));
     }
 
     @Test
@@ -185,6 +196,12 @@ public class EpisodeDetailDialogThemeTest {
         Path moduleRelative = Path.of("src", "mobile", "java");
         if (Files.exists(moduleRelative)) return moduleRelative;
         return Path.of("app", "src", "mobile", "java");
+    }
+
+    private static Path findMainResPath() {
+        Path moduleRelative = Path.of("src", "main", "res");
+        if (Files.exists(moduleRelative)) return moduleRelative;
+        return Path.of("app", "src", "main", "res");
     }
 
     private static Path findLeanbackJavaPath() {

--- a/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialogThemeTest.java
+++ b/app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialogThemeTest.java
@@ -96,6 +96,21 @@ public class EpisodeDetailDialogThemeTest {
     }
 
     @Test
+    public void mobileEpisodeDetailKeepsBottomGuestCardsInsideStableScrollBounds() throws Exception {
+        String dialog = read(findMobileJavaPath().resolve(Path.of(
+                "com", "fongmi", "android", "tv", "ui", "dialog", "EpisodeDetailDialog.java")));
+        String layout = read(findMainResPath().resolve(Path.of(
+                "layout", "dialog_episode_detail.xml")));
+
+        assertTrue("mobile detail must disable nested scrolling for its horizontal rails",
+                dialog.contains("view.setNestedScrollingEnabled(false);")
+                        && dialog.contains("view.setOverScrollMode(View.OVER_SCROLL_NEVER);"));
+        assertTrue("mobile detail must disable parent overscroll and leave a bottom safety inset",
+                layout.contains("android:overScrollMode=\"never\"")
+                        && layout.contains("android:paddingBottom=\"12dp\""));
+    }
+
+    @Test
     public void tvEpisodePhotosUseUnifiedYellowFocusStrokeWithoutGrayOverlay() throws Exception {
         String adapter = read(findLeanbackJavaPath().resolve(Path.of(
                 "com", "fongmi", "android", "tv", "ui", "adapter", "EpisodePhotoAdapter.java")));

--- a/docs/beta-sync-review-dev4-20260912.md
+++ b/docs/beta-sync-review-dev4-20260912.md
@@ -1,0 +1,62 @@
+# dev4 合并 beta 与代码复评记录（2026-09-12）
+
+## 目标
+
+将远端 `origin/beta` 最新代码合并到 `dev4`，覆盖评审当前分支相对 beta 的全部修改及此前已提交但未推送的提交；完成针对性验证和验证后复评，随后提交、推送并创建合入 beta 的中文 PR，最后再次拉取远端最新状态。
+
+## 合并基线
+
+- 合并前 HEAD：`b6b18ac1dd2f248c3001b1802ac285622620b6fa`
+- 合并时远端 beta：`ccd608c503`
+- 合并结果：使用 Git `ort` 策略成功完成，无冲突。
+- 合并后当前分支相对 beta 的有效功能提交：
+  - `667992b22e`：统一光影剧幕分集客串演员图片圆角行为。
+  - `6a002d29f7`：统一光影剧幕分集客串演员横向卡片布局。
+  - `b6b18ac1dd`：稳定移动端分集详情底部滚动边界。
+
+## 评审范围
+
+- `app/src/leanback/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java`
+- `app/src/main/res/layout/dialog_episode_detail.xml`
+- `app/src/mobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialog.java`
+- `app/src/testMobile/java/com/fongmi/android/tv/ui/dialog/EpisodeDetailDialogThemeTest.java`
+
+同时逐提交检查了上述三个功能提交，并检查合并后相对 `origin/beta` 的完整差异。
+
+## 第一轮评审结论
+
+- 影院风格下，移动端与 TV 端分集客串演员列表均复用外层演员栏的横向卡片布局，非影院风格保持原有纵向卡片行为。
+- TV 端两个客串演员数据入口均同步设置影院样式、行高及容器高度，没有发现只覆盖单一路径的问题。
+- 移动端移除冗余关闭按钮后仍保留系统返回和点击外部关闭方式，避免固定底部按钮挤压滚动区域。
+- 横向图片列表关闭嵌套滚动与过度滚动，父滚动容器关闭过度滚动并增加底部安全间距，处理底部客串演员卡片滚动边界。
+- 新增测试覆盖影院风格卡片几何、移动��端与 TV 端接线、关闭按钮移除以及底部滚动边界。
+- `git diff --check origin/beta...HEAD` 未发现空白符错误。
+- 未发现需要修改的正确性、兼容性或回归问题。
+
+## 验证
+
+执行构建前已检查实际 Gradle、Kotlin、AAPT2、Ninja 和 CMake 构建进程；排除仅驻留的 Gradle Daemon 后，未发现其他实际打包任务。
+
+针对性验证命令：
+
+```bash
+bash ./gradlew :app:testMobileArm64_v8aDebugUnitTest \
+  --tests 'com.fongmi.android.tv.ui.dialog.EpisodeDetailDialogThemeTest'
+```
+
+结果：`BUILD SUCCESSFUL`，共 87 个任务，其中 6 个执行、81 个为最新状态。
+
+构建输出中仅有项目既存的 32 位原生库、弃用 API 和未检查操作警告，本次改动未新增相关问题。
+
+## 验证后第二轮复评
+
+验证通过后再次检查 `origin/beta...HEAD` 的完整四文件差异及 `git diff --check`：
+
+- 差异仍严格限定于分集详情影院风格客串演员卡片和移动端滚动边界。
+- 合并 beta 后没有产生冲突残留、重复实现或行为覆盖。
+- 测试断言与实际源集路径、变体及运行时代码一致。
+- 未发现新的阻断问题，复评通过，无需追加代码修复。
+
+## 回滚
+
+若合入后发现问题，可按功能提交分别回滚 `b6b18ac1dd`、`6a002d29f7`、`667992b22e`；本次合并和交付提交另有任务恢复标签用于整体回退。


### PR DESCRIPTION
## 变更摘要

- 合并 `origin/beta` 最新代码到 `dev4`，合��并过程无冲突。
- 统一光影剧幕样式下移动端与 TV 端分集客串演员的横向卡片布局。
- 稳定移动端分集详情底部滚动边界，移除冗余关闭按钮。
- 新增并完善相关回归测试。
- 补充 dev4 合并 beta 后的两轮代码复评与验证记录。

## 代码复评

- 已覆盖当前分支相对 beta 的完整差异及此前未推送提交。
- 第一轮评审与验证后第二轮复评均未发现阻断问题。
- `git diff --check origin/beta...HEAD` 通过。

## 验证

构建前已检查其他实际打包任务，确认无占用后执行：

```bash
bash ./gradlew :app:testMobileArm64_v8aDebugUnitTest \
  --tests 'com.fongmi.android.tv.ui.dialog.EpisodeDetailDialogThemeTest'
```

结果：`BUILD SUCCESSFUL`，87 个任务中 6 个执行、81 个为最新状态。
