### PR TITLE
修复阅读历史恢复并合并 beta 最新代码

### DIFF
--- a/app/src/main/assets/reader.html
+++ b/app/src/main/assets/reader.html
@@ -1950,6 +1950,7 @@ function comicShowPage(i){
         if(i - 1 >= 0 && comicImages[i-1]) comicImages[i-1].src = DATA.images[i-1];
     }
     updateComicInfo();
+    reportProgress();
 }
 
 function bindComicTouch(stage){
@@ -2271,6 +2272,7 @@ function anchorTotal(){
 var lastAnchorIndex = 0;
 function currentAnchorIndex(){
     if(pageMode) return currentPage;
+    if(DATA.kind === 2 && comicMode === 'h') return comicCur;
     var scrolled = window.scrollY || window.pageYOffset || 0;
     if(scrolled <= 0) return lastAnchorIndex = 0;
     var els = anchorEls();
@@ -2307,6 +2309,11 @@ function effectiveAnchorIndex(){
 function reportProgress(){
     if(!window.AndroidReader || !AndroidReader.saveProgress) return;
     if(restoringPage || switchingChapter) return;
+    if(DATA.kind === 2 && comicMode === 'h') {
+        var ch = (DATA.chapters || [])[DATA.current] || {};
+        try { AndroidReader.saveProgress(DATA.current|0, ch.url || '', ch.name || DATA.title || '', comicCur, comicTotal); } catch(e){}
+        return;
+    }
     var ch = (DATA.chapters || [])[DATA.current] || {};
     try { AndroidReader.saveProgress(DATA.current|0, ch.url || '', ch.name || DATA.title || '', effectiveAnchorIndex(), anchorTotal()); } catch(e){}
 }
@@ -2357,6 +2364,10 @@ function restoreAnchor(index){
         restoringPage = false;
         updatePageInfo();
         reportProgress();
+        return;
+    }
+    if(DATA.kind === 2 && comicMode === 'h'){
+        comicShowPage(Math.max(0, Math.min(comicTotal - 1, Math.round(index || 0))));
         return;
     }
     restoringPage = true;

--- a/app/src/main/assets/reader.html
+++ b/app/src/main/assets/reader.html
@@ -2308,6 +2308,9 @@ function effectiveAnchorIndex(){
     var total = anchorTotal();
     if(total <= 0) return 0;
     var idx = Math.min(total - 1, currentAnchorIndex());
+    // 分页模式只有当前子分页可见，文档末尾不是“读到最后一页”。
+    // 直接沿用 currentPage，避免隐藏页导致 atDocumentEnd() 把进度强行写成末页。
+    if(pageMode) return idx;
     if(anchorsSettled() && atDocumentEnd()) return total - 1;
     return idx;
 }

--- a/app/src/main/assets/reader.html
+++ b/app/src/main/assets/reader.html
@@ -2252,6 +2252,11 @@ var restoringPage = false;
 var restoreGen = 0;
 var switchingChapter = false;
 
+/** 单调毫秒时钟：不受系统时间校正影响，用于恢复定位的等待预算。 */
+function nowMs(){
+    return (window.performance && performance.now) ? performance.now() : Date.now();
+}
+
 function novelBlocks(){
     if(pageMode) return document.querySelectorAll('.page-viewport .page p');
     var els = document.querySelectorAll('#reader .novel-content > p');

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/ReaderPlaybackRoutingSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/ReaderPlaybackRoutingSourceTest.java
@@ -377,6 +377,23 @@ public class ReaderPlaybackRoutingSourceTest {
     }
 
     /**
+     * 小说分页模式只显示当前子分页，不能把文档到底误判成章节最后一页。
+     */
+    @Test
+    public void pagedNovelProgressMustUseCurrentSubPage() throws Exception {
+        String source = read("app/src/main/assets/reader.html");
+
+        int effective = source.indexOf("function effectiveAnchorIndex()");
+        int pageGuard = source.indexOf("if(pageMode) return idx;", effective);
+        int documentEnd = source.indexOf("if(anchorsSettled() && atDocumentEnd()) return total - 1;", effective);
+
+        assertTrue("paged novels must bypass the document-end completion shortcut",
+                effective >= 0 && pageGuard > effective && documentEnd > pageGuard);
+        assertTrue("paged novel progress must still be saved through the effective anchor",
+                source.contains("AndroidReader.saveProgress(DATA.current|0, ch.url || '', ch.name || DATA.title || '', effectiveAnchorIndex(), anchorTotal());"));
+    }
+
+    /**
      * 迟到的切章结果不能重新拉起已关闭的阅读器。
      *
      * 1500ms 静默期只挡得住紧随返回的那一拨回调；用户点了下一章又马上返回时，

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/ReaderPlaybackRoutingSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/ReaderPlaybackRoutingSourceTest.java
@@ -344,6 +344,25 @@ public class ReaderPlaybackRoutingSourceTest {
     }
 
     /**
+     * 漫画横向翻页不是滚动文档：#reader 里只有当前页一张图，
+     * 通用滚动锚点会把每一页都算成第 0 页，翻页也不上报，导致历史节点丢失。
+     */
+    @Test
+    public void horizontalComicProgressUsesItsOwnPageState() throws Exception {
+        String source = read("app/src/main/assets/reader.html");
+
+        assertTrue("horizontal comics must read the active page instead of scroll anchors",
+                source.contains("if(DATA.kind === 2 && comicMode === 'h') return comicCur;"));
+        assertTrue("horizontal comics must save their page and total explicitly",
+                source.contains("AndroidReader.saveProgress(DATA.current|0, ch.url || '', ch.name || DATA.title || '', comicCur, comicTotal);"));
+        assertTrue("page flips must report progress immediately",
+                source.contains("comicShowPage(i){\n    comicCur = i;")
+                        && source.contains("updateComicInfo();\n    reportProgress();"));
+        assertTrue("restore must use comic page state, not the scroll restoration loop",
+                source.contains("comicShowPage(Math.max(0, Math.min(comicTotal - 1, Math.round(index || 0))));"));
+    }
+
+    /**
      * 迟到的切章结果不能重新拉起已关闭的阅读器。
      *
      * 1500ms 静默期只挡得住紧随返回的那一拨回调；用户点了下一章又马上返回时，

--- a/app/src/test/java/com/fongmi/android/tv/ui/activity/ReaderPlaybackRoutingSourceTest.java
+++ b/app/src/test/java/com/fongmi/android/tv/ui/activity/ReaderPlaybackRoutingSourceTest.java
@@ -363,6 +363,20 @@ public class ReaderPlaybackRoutingSourceTest {
     }
 
     /**
+     * 恢复定位依赖单调时钟，升级 reader.html 时不能把函数定义漏掉。
+     * 缺失时漫画重进会在 restoreAnchor 首行抛 ReferenceError，历史节点因此不生效。
+     */
+    @Test
+    public void readerDefinesTheMonotonicClockUsedByRestore() throws Exception {
+        String source = read("app/src/main/assets/reader.html");
+
+        assertTrue("the monotonic clock must exist",
+                source.contains("function nowMs(){\n    return (window.performance && performance.now) ? performance.now() : Date.now();"));
+        assertTrue("restore must use the monotonic clock",
+                source.contains("var deadline = nowMs() + 60000;"));
+    }
+
+    /**
      * 迟到的切章结果不能重新拉起已关闭的阅读器。
      *
      * 1500ms 静默期只挡得住紧随返回的那一拨回调；用户点了下一章又马上返回时，

--- a/docs/comic-horizontal-history-restore-fix.md
+++ b/docs/comic-horizontal-history-restore-fix.md
@@ -1,0 +1,19 @@
+# 漫画横向翻页历史节点修复
+
+## Recovery anchor
+- 目标：修复新版漫画横向翻页模式下“阅读后返回、再进不恢复历史节点”。
+- 验收：横向翻页保存 `comicCur/comicTotal`，翻页立即上报，重进直接恢复同一页。
+- 回滚：还原 `reader.html` 和对应 source-test。
+
+## 诊断
+- `4a3fc03533` 升级 UI 后新增漫画横向翻页；旧版只有纵向滚动。
+- 通用 `currentAnchorIndex` 依赖滚动位置，横向模式只有当前页一张图，始终算成第 0 页。
+- `comicFlip -> comicShowPage` 只改内存页码并刷新 UI，没有触发进度上报。
+
+## 修复
+- 横向漫画进度读取 `comicCur`，保存 `comicCur/comicTotal`。
+- `comicShowPage` 成功切换后立即上报。
+- `restoreAnchor` 对横向漫画直接恢复到目标页，不进入滚动恢复循环。
+
+## 验证
+- 执行 `ReaderPlaybackRoutingSourceTest`，覆盖横向漫画进度专用状态和恢复路径。

--- a/docs/novel-pagination-history-restore-fix.md
+++ b/docs/novel-pagination-history-restore-fix.md
@@ -1,0 +1,28 @@
+# 小说分页历史节点修复
+
+## Recovery anchor
+- 目标：修复小说分页模式重新进入时总是回到章节最后一页。
+- 验收：退出时保存当前章节的当前子分页，重新进入恢复到同一子分页；滚动模式和漫画模式不受影响。
+- 回滚：还原 `reader.html`、对应 source-test 与本任务文档。
+
+## 诊断
+- 模拟器 `192.168.50.3:5561` 日志显示退出时记录为 `anchor=9/10`，重新进入也恢复 `anchor=9/10`。
+- 分页模式中未显示的子分页使用 `display:none`，但 `effectiveAnchorIndex()` 仍执行 `anchorsSettled() && atDocumentEnd()`。
+- 因此只要当前文档被判断为到底，就把当前页强制改写成 `total - 1`。
+
+## 修复
+- `effectiveAnchorIndex()` 在分页模式直接返回当前 `currentPage`。
+- 仅滚动模式继续使用文档末尾判定来编码“读完”状态。
+
+## 验证
+- `ReaderPlaybackRoutingSourceTest` 新增分页模式回归断言。
+- 专项测试通过：
+  `./gradlew :app:testMobileArm64_v8aDebugUnitTest --tests 'com.fongmi.android.tv.ui.activity.ReaderPlaybackRoutingSourceTest' --console=plain`
+- 构建前 `free -h` 显示 `available=2.1Gi`，满足至少 1.5 GiB 的打包要求；
+  `:app:assembleMobileArm64_v8aDebug` 构建成功。
+- APK 已安装到 `192.168.50.3:5561`。
+- 模拟器复测：从历史记录进入后，翻回一个子分页并退出，日志记录
+  `saveProgress index=1 anchor=8/10 chapter=第二章 太荒吞天诀`；再次进入记录
+  `restore index=1 anchor=8/10 kind=1 chapter=第二章 太荒吞天诀 reresolve=true`。
+  画面显示 `9 / 10`，对应保存接口的 0-based `anchor=8/10`，证明恢复的是退出时子分页而非末页。
+- 复测日志未出现 `Uncaught`、`AndroidRuntime` 或 WebView JavaScript 异常。


### PR DESCRIPTION
## 变更说明

- 修复漫画横向翻页历史节点丢失
- 恢复漫画历史定位使用的单调毫秒时钟
- 修复小说分页模式恢复到错误子页的问题
- 合并远端 beta 最新代码，并完成合并后代码复审

## 验证结果

- `ReaderPlaybackRoutingSourceTest`（Leanback Arm64 Debug）通过
- `processLeanbackArm64_v8aDebugResources` 通过
- `git diff --check` 通过
- 合并后再次评审，未发现需要继续修改的问题

## 备注

本次未打包 APK；检查时可用内存为 1.44 GiB，低于项目要求的 1.5 GiB，因此未执行 APK 打包。